### PR TITLE
feat(command): allow items to be dynamically selected

### DIFF
--- a/libs/cli/src/generators/ui/libs/ui-command-helm/files/lib/hlm-command-item.directive.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-command-helm/files/lib/hlm-command-item.directive.ts.template
@@ -1,4 +1,4 @@
-import { Directive, computed, input } from '@angular/core';
+import { Directive, ElementRef, Renderer2, computed, inject, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import type { ClassValue } from 'clsx';
 
@@ -7,6 +7,7 @@ import type { ClassValue } from 'clsx';
 	standalone: true,
 	host: {
 		'[class]': '_computedClass()',
+		'[attr.aria-selected]': 'selected()',
 		// This is needed after changes to the underlying CMDK library used for the BrnCommand primitive
 		// Ideally we would remove the dependency on this outside module. If you are open to that please
 		// reach out and if you are feeling super ambitious you can implement it yourself and open a PR!
@@ -14,7 +15,11 @@ import type { ClassValue } from 'clsx';
 	},
 })
 export class HlmCommandItemDirective {
+	private readonly el = inject(ElementRef);
+	private readonly renderer = inject(Renderer2);
+
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	public readonly selected = input<boolean>(false);
 
 	protected _computedClass = computed(() =>
 		hlm(
@@ -25,4 +30,11 @@ export class HlmCommandItemDirective {
 			this.userClass(),
 		),
 	);
+
+	ngAfterViewChecked() {
+		const ariaSelected = this.el.nativeElement.hasAttribute('aria-selected');
+		if (ariaSelected && !this.selected()) {
+			this.renderer.removeAttribute(this.el.nativeElement, 'aria-selected');
+		}
+	}
 }

--- a/libs/cli/src/generators/ui/libs/ui-command-helm/files/lib/hlm-command-item.directive.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-command-helm/files/lib/hlm-command-item.directive.ts.template
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Renderer2, computed, inject, input } from '@angular/core';
+import { Directive, computed, inject, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import type { ClassValue } from 'clsx';
 
@@ -15,9 +15,6 @@ import type { ClassValue } from 'clsx';
 	},
 })
 export class HlmCommandItemDirective {
-	private readonly el = inject(ElementRef);
-	private readonly renderer = inject(Renderer2);
-
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	public readonly selected = input<boolean>(false);
 
@@ -30,11 +27,4 @@ export class HlmCommandItemDirective {
 			this.userClass(),
 		),
 	);
-
-	ngAfterViewChecked() {
-		const ariaSelected = this.el.nativeElement.hasAttribute('aria-selected');
-		if (ariaSelected && !this.selected()) {
-			this.renderer.removeAttribute(this.el.nativeElement, 'aria-selected');
-		}
-	}
 }

--- a/libs/ui/command/helm/src/lib/hlm-command-item.directive.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-item.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, computed, input } from '@angular/core';
+import { Directive, ElementRef, Renderer2, computed, inject, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import type { ClassValue } from 'clsx';
 
@@ -7,6 +7,7 @@ import type { ClassValue } from 'clsx';
 	standalone: true,
 	host: {
 		'[class]': '_computedClass()',
+		'[attr.aria-selected]': 'selected()',
 		// This is needed after changes to the underlying CMDK library used for the BrnCommand primitive
 		// Ideally we would remove the dependency on this outside module. If you are open to that please
 		// reach out and if you are feeling super ambitious you can implement it yourself and open a PR!
@@ -14,7 +15,11 @@ import type { ClassValue } from 'clsx';
 	},
 })
 export class HlmCommandItemDirective {
+	private readonly el = inject(ElementRef);
+	private readonly renderer = inject(Renderer2);
+
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	public readonly selected = input<boolean>(false);
 
 	protected _computedClass = computed(() =>
 		hlm(
@@ -25,4 +30,11 @@ export class HlmCommandItemDirective {
 			this.userClass(),
 		),
 	);
+
+	ngAfterViewChecked() {
+		const ariaSelected = this.el.nativeElement.hasAttribute('aria-selected');
+		if (ariaSelected && !this.selected()) {
+			this.renderer.removeAttribute(this.el.nativeElement, 'aria-selected');
+		}
+	}
 }

--- a/libs/ui/command/helm/src/lib/hlm-command-item.directive.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-item.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Renderer2, computed, inject, input } from '@angular/core';
+import { Directive, computed, inject, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import type { ClassValue } from 'clsx';
 
@@ -15,9 +15,6 @@ import type { ClassValue } from 'clsx';
 	},
 })
 export class HlmCommandItemDirective {
-	private readonly el = inject(ElementRef);
-	private readonly renderer = inject(Renderer2);
-
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	public readonly selected = input<boolean>(false);
 
@@ -30,11 +27,4 @@ export class HlmCommandItemDirective {
 			this.userClass(),
 		),
 	);
-
-	ngAfterViewChecked() {
-		const ariaSelected = this.el.nativeElement.hasAttribute('aria-selected');
-		if (ariaSelected && !this.selected()) {
-			this.renderer.removeAttribute(this.el.nativeElement, 'aria-selected');
-		}
-	}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [x] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?
currently, there's no way to tell if a command item is aria-selected. so the problem is that the first item will always look like this:

 
![Screenshot 2024-10-16 at 19 27 53](https://github.com/user-attachments/assets/811feb65-fbdf-43c2-8f83-c76a96056164)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

after this PR it would look like this:

![Screenshot 2024-10-16 at 19 28 58](https://github.com/user-attachments/assets/33bbbc41-5a35-494a-8304-4699174960b0)

```html
  <brn-cmd-list hlm>
    <brn-cmd-group hlm>
       @for (item of items(); track $index) {
         <button
              hlm
              brnCmdItem
              [selected]="currentItem() === item"
            >
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
