### PR TITLE
refactor(avatar)!: migration to signals

### DIFF
--- a/libs/cli/src/generators/ui/libs/ui-avatar-helm/files/lib/fallback/hlm-avatar-fallback.directive.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-avatar-helm/files/lib/fallback/hlm-avatar-fallback.directive.ts.template
@@ -20,7 +20,7 @@ import { hlm } from '@spartan-ng/ui-core';
 export class HlmAvatarFallbackDirective {
 	private readonly _brn = inject(BrnAvatarFallbackDirective);
 	private readonly _hex = computed(() => {
-		if (!this._brn.useAutoColor() || !this._brn.getTextContent()) return;
+		if (!this._brn.autoColor() || !this._brn.getTextContent()) return;
 		return hexColorFor(this._brn.getTextContent());
 	});
 
@@ -34,7 +34,7 @@ export class HlmAvatarFallbackDirective {
 		return hlm(
 			'flex h-full w-full items-center justify-center rounded-full',
 			this._autoColorTextCls() ?? 'bg-muted',
-			this._brn?.userCls(),
+			this._brn?.userClass(),
 		);
 	});
 }

--- a/libs/cli/src/generators/ui/libs/ui-avatar-helm/files/lib/hlm-avatar.component.spec.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-avatar-helm/files/lib/hlm-avatar.component.spec.ts.template
@@ -44,13 +44,13 @@ describe('HlmAvatarComponent', () => {
 	});
 
 	it('should change the size when the variant is changed', () => {
-		component.variant = 'small';
+		fixture.componentRef.setInput('variant', 'small');
 		fixture.detectChanges();
 		expect(fixture.nativeElement.className).toContain('h-6');
 		expect(fixture.nativeElement.className).toContain('w-6');
 		expect(fixture.nativeElement.className).toContain('text-xs');
 
-		component.variant = 'large';
+		fixture.componentRef.setInput('variant', 'large');
 		fixture.detectChanges();
 		expect(fixture.nativeElement.className).toContain('h-14');
 		expect(fixture.nativeElement.className).toContain('w-14');

--- a/libs/cli/src/generators/ui/libs/ui-avatar-helm/files/lib/hlm-avatar.component.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-avatar-helm/files/lib/hlm-avatar.component.ts.template
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation, computed, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation, computed, input } from '@angular/core';
 import { BrnAvatarComponent } from '@spartan-ng/ui-avatar-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { type VariantProps, cva } from 'class-variance-authority';
@@ -28,7 +28,7 @@ export type AvatarVariants = VariantProps<typeof avatarVariants>;
 		'[class]': '_computedClass()',
 	},
 	template: `
-		@if (image?.canShow()) {
+		@if (image()?.canShow()) {
 			<ng-content select="[hlmAvatarImage],[brnAvatarImage]" />
 		} @else {
 			<ng-content select="[hlmAvatarFallback],[brnAvatarFallback]" />
@@ -37,13 +37,9 @@ export type AvatarVariants = VariantProps<typeof avatarVariants>;
 })
 export class HlmAvatarComponent extends BrnAvatarComponent {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() =>
-		hlm(avatarVariants({ variant: this._variant() }), this.userClass()),
-	);
+	public readonly variant = input<AvatarVariants['variant']>('medium');
 
-	private readonly _variant = signal<AvatarVariants['variant']>('medium');
-	@Input()
-	set variant(variant: AvatarVariants['variant']) {
-		this._variant.set(variant);
-	}
+	protected readonly _computedClass = computed(() =>
+		hlm(avatarVariants({ variant: this.variant() }), this.userClass()),
+	);
 }

--- a/libs/ui/avatar/brain/src/lib/brn-avatar.component.ts
+++ b/libs/ui/avatar/brain/src/lib/brn-avatar.component.ts
@@ -9,12 +9,11 @@ import { BrnAvatarImageDirective } from './image';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,
 	template: `
-		<ng-container *ngIf="image()?.canShow(); else fallback">
+		@if (image()?.canShow()) {
 			<ng-content select="[brnAvatarImage]" />
-		</ng-container>
-		<ng-template #fallback>
+		} @else {
 			<ng-content select="[brnAvatarFallback]" />
-		</ng-template>
+		}
 	`,
 })
 export class BrnAvatarComponent {

--- a/libs/ui/avatar/brain/src/lib/brn-avatar.component.ts
+++ b/libs/ui/avatar/brain/src/lib/brn-avatar.component.ts
@@ -1,5 +1,5 @@
 import { NgIf } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ContentChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation, contentChild } from '@angular/core';
 import { BrnAvatarImageDirective } from './image';
 
 @Component({
@@ -9,7 +9,7 @@ import { BrnAvatarImageDirective } from './image';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,
 	template: `
-		<ng-container *ngIf="image?.canShow(); else fallback">
+		<ng-container *ngIf="image()?.canShow(); else fallback">
 			<ng-content select="[brnAvatarImage]" />
 		</ng-container>
 		<ng-template #fallback>
@@ -18,6 +18,5 @@ import { BrnAvatarImageDirective } from './image';
 	`,
 })
 export class BrnAvatarComponent {
-	@ContentChild(BrnAvatarImageDirective, { static: true })
-	protected readonly image: BrnAvatarImageDirective | null = null;
+	protected readonly image = contentChild(BrnAvatarImageDirective);
 }

--- a/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.ts
+++ b/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.ts
@@ -1,3 +1,4 @@
+import { BooleanInput } from '@angular/cdk/coercion';
 import { Directive, ElementRef, booleanAttribute, inject, input } from '@angular/core';
 import type { ClassValue } from 'clsx';
 
@@ -9,8 +10,8 @@ import type { ClassValue } from 'clsx';
 export class BrnAvatarFallbackDirective {
 	private readonly element = inject(ElementRef).nativeElement;
 
-	public readonly userCls = input<ClassValue>('', { alias: 'class' });
-	public readonly useAutoColor = input(false, { alias: 'autoColor', transform: booleanAttribute });
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	public readonly autoColor = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 
 	getTextContent(): string {
 		return this.element.textContent;

--- a/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.ts
+++ b/libs/ui/avatar/brain/src/lib/fallback/brn-avatar-fallback.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Input, booleanAttribute, inject, signal } from '@angular/core';
+import { Directive, ElementRef, booleanAttribute, inject, input } from '@angular/core';
 import type { ClassValue } from 'clsx';
 
 @Directive({
@@ -8,20 +8,11 @@ import type { ClassValue } from 'clsx';
 })
 export class BrnAvatarFallbackDirective {
 	private readonly element = inject(ElementRef).nativeElement;
-	readonly userCls = signal<ClassValue>('');
-	readonly useAutoColor = signal(false);
-	readonly textContent = inject(ElementRef).nativeElement.textContent;
+
+	public readonly userCls = input<ClassValue>('', { alias: 'class' });
+	public readonly useAutoColor = input(false, { alias: 'autoColor', transform: booleanAttribute });
 
 	getTextContent(): string {
 		return this.element.textContent;
-	}
-
-	@Input() set class(cls: ClassValue | string) {
-		this.userCls.set(cls);
-	}
-
-	@Input({ transform: booleanAttribute })
-	set autoColor(value: boolean) {
-		this.useAutoColor.set(value);
 	}
 }

--- a/libs/ui/avatar/helm/src/lib/fallback/hlm-avatar-fallback.directive.ts
+++ b/libs/ui/avatar/helm/src/lib/fallback/hlm-avatar-fallback.directive.ts
@@ -20,7 +20,7 @@ import { hlm } from '@spartan-ng/ui-core';
 export class HlmAvatarFallbackDirective {
 	private readonly _brn = inject(BrnAvatarFallbackDirective);
 	private readonly _hex = computed(() => {
-		if (!this._brn.useAutoColor() || !this._brn.getTextContent()) return;
+		if (!this._brn.autoColor() || !this._brn.getTextContent()) return;
 		return hexColorFor(this._brn.getTextContent());
 	});
 
@@ -34,7 +34,7 @@ export class HlmAvatarFallbackDirective {
 		return hlm(
 			'flex h-full w-full items-center justify-center rounded-full',
 			this._autoColorTextCls() ?? 'bg-muted',
-			this._brn?.userCls(),
+			this._brn?.userClass(),
 		);
 	});
 }

--- a/libs/ui/avatar/helm/src/lib/hlm-avatar.component.spec.ts
+++ b/libs/ui/avatar/helm/src/lib/hlm-avatar.component.spec.ts
@@ -44,13 +44,13 @@ describe('HlmAvatarComponent', () => {
 	});
 
 	it('should change the size when the variant is changed', () => {
-		component.variant = 'small';
+		fixture.componentRef.setInput('variant', 'small');
 		fixture.detectChanges();
 		expect(fixture.nativeElement.className).toContain('h-6');
 		expect(fixture.nativeElement.className).toContain('w-6');
 		expect(fixture.nativeElement.className).toContain('text-xs');
 
-		component.variant = 'large';
+		fixture.componentRef.setInput('variant', 'large');
 		fixture.detectChanges();
 		expect(fixture.nativeElement.className).toContain('h-14');
 		expect(fixture.nativeElement.className).toContain('w-14');

--- a/libs/ui/avatar/helm/src/lib/hlm-avatar.component.ts
+++ b/libs/ui/avatar/helm/src/lib/hlm-avatar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation, computed, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation, computed, input } from '@angular/core';
 import { BrnAvatarComponent } from '@spartan-ng/ui-avatar-brain';
 import { hlm } from '@spartan-ng/ui-core';
 import { type VariantProps, cva } from 'class-variance-authority';
@@ -28,7 +28,7 @@ export type AvatarVariants = VariantProps<typeof avatarVariants>;
 		'[class]': '_computedClass()',
 	},
 	template: `
-		@if (image?.canShow()) {
+		@if (image()?.canShow()) {
 			<ng-content select="[hlmAvatarImage],[brnAvatarImage]" />
 		} @else {
 			<ng-content select="[hlmAvatarFallback],[brnAvatarFallback]" />
@@ -37,13 +37,9 @@ export type AvatarVariants = VariantProps<typeof avatarVariants>;
 })
 export class HlmAvatarComponent extends BrnAvatarComponent {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() =>
-		hlm(avatarVariants({ variant: this._variant() }), this.userClass()),
-	);
+	public readonly variant = input<AvatarVariants['variant']>('medium');
 
-	private readonly _variant = signal<AvatarVariants['variant']>('medium');
-	@Input()
-	set variant(variant: AvatarVariants['variant']) {
-		this._variant.set(variant);
-	}
+	protected readonly _computedClass = computed(() =>
+		hlm(avatarVariants({ variant: this.variant() }), this.userClass()),
+	);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [x] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Components and directives related to Avatar do not use signals.

Closes #415

## What is the new behavior?

Components and directives related to Avatar use signals.

Covered areas:
- HlmAvatarComponent (with updated tests)
- BrnAvatarComponent
- BrnAvatarFallbackDirective

Already using signals:
- HlmAvatarImageDirective
- HlmAvatarFallbackDirective
- BrnAvatarImageDirective

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

In BrnAvatarComponent, `image` is now a signal, and the type has changed from `BrnAvatarImageDirective | null` to `BrnAvatarImageDirective | undefined`.

## Other information
