### PR TITLE
refactor(badge): migration to signals

### DIFF
--- a/libs/cli/src/generators/ui/libs/ui-badge-helm/files/lib/hlm-badge.directive.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-badge-helm/files/lib/hlm-badge.directive.ts.template
@@ -1,4 +1,5 @@
-import { Directive, Input, booleanAttribute, computed, input, signal } from '@angular/core';
+import type { BooleanInput } from '@angular/cdk/coercion';
+import { Directive, booleanAttribute, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { type VariantProps, cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
@@ -43,7 +44,7 @@ export const badgeVariants = cva(
 		},
 	},
 );
-type badgeVariants = VariantProps<typeof badgeVariants>;
+export type BadgeVariants = VariantProps<typeof badgeVariants>;
 
 @Directive({
 	selector: '[hlmBadge]',
@@ -53,26 +54,12 @@ type badgeVariants = VariantProps<typeof badgeVariants>;
 	},
 })
 export class HlmBadgeDirective {
-	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected _computedClass = computed(() =>
-		hlm(badgeVariants({ variant: this._variant(), size: this._size(), static: this._static() }), this.userClass()),
+	protected readonly _computedClass = computed(() =>
+		hlm(badgeVariants({ variant: this.variant(), size: this.size(), static: this.static() }), this.userClass()),
 	);
 
-	private readonly _variant = signal<badgeVariants['variant']>('default');
-	@Input()
-	set variant(variant: badgeVariants['variant']) {
-		this._variant.set(variant);
-	}
-
-	private readonly _static = signal<badgeVariants['static']>(false);
-	@Input({ transform: booleanAttribute })
-	set static(value: badgeVariants['static']) {
-		this._static.set(value);
-	}
-
-	private readonly _size = signal<badgeVariants['size']>('default');
-	@Input()
-	set size(size: badgeVariants['size']) {
-		this._size.set(size);
-	}
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	public readonly variant = input<BadgeVariants['variant']>('default');
+	public readonly static = input<BadgeVariants['static'], BooleanInput>(false, { transform: booleanAttribute });
+	public readonly size = input<BadgeVariants['size']>('default');
 }

--- a/libs/ui/badge/badge.stories.ts
+++ b/libs/ui/badge/badge.stories.ts
@@ -11,15 +11,24 @@ const meta: Meta<HlmBadgeDirective> = {
 			control: {
 				type: 'select',
 			},
+			table: {
+				defaultValue: { summary: 'default' },
+			},
 		},
 		size: {
 			options: ['default', 'lg'],
 			control: {
 				type: 'select',
 			},
+			table: {
+				defaultValue: { summary: 'default' },
+			},
 		},
 		static: {
 			control: { type: 'boolean' },
+			table: {
+				defaultValue: { summary: 'false' },
+			},
 		},
 	},
 	args: {

--- a/libs/ui/badge/helm/src/lib/hlm-badge.directive.ts
+++ b/libs/ui/badge/helm/src/lib/hlm-badge.directive.ts
@@ -1,4 +1,5 @@
-import { Directive, Input, booleanAttribute, computed, input, signal } from '@angular/core';
+import type { BooleanInput } from '@angular/cdk/coercion';
+import { Directive, booleanAttribute, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
 import { type VariantProps, cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
@@ -43,7 +44,7 @@ export const badgeVariants = cva(
 		},
 	},
 );
-type badgeVariants = VariantProps<typeof badgeVariants>;
+export type BadgeVariants = VariantProps<typeof badgeVariants>;
 
 @Directive({
 	selector: '[hlmBadge]',
@@ -53,26 +54,12 @@ type badgeVariants = VariantProps<typeof badgeVariants>;
 	},
 })
 export class HlmBadgeDirective {
-	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected _computedClass = computed(() =>
-		hlm(badgeVariants({ variant: this._variant(), size: this._size(), static: this._static() }), this.userClass()),
+	protected readonly _computedClass = computed(() =>
+		hlm(badgeVariants({ variant: this.variant(), size: this.size(), static: this.static() }), this.userClass()),
 	);
 
-	private readonly _variant = signal<badgeVariants['variant']>('default');
-	@Input()
-	set variant(variant: badgeVariants['variant']) {
-		this._variant.set(variant);
-	}
-
-	private readonly _static = signal<badgeVariants['static']>(false);
-	@Input({ transform: booleanAttribute })
-	set static(value: badgeVariants['static']) {
-		this._static.set(value);
-	}
-
-	private readonly _size = signal<badgeVariants['size']>('default');
-	@Input()
-	set size(size: badgeVariants['size']) {
-		this._size.set(size);
-	}
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	public readonly variant = input<BadgeVariants['variant']>('default');
+	public readonly static = input<BadgeVariants['static'], BooleanInput>(false, { transform: booleanAttribute });
+	public readonly size = input<BadgeVariants['size']>('default');
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [x] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #419

## What is the new behavior?

Migrated to input signals and added default values to the Storybook docs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
