### PR TITLE
refactor(progress): migration to signals

### DIFF
--- a/libs/ui/progress/brain/src/index.ts
+++ b/libs/ui/progress/brain/src/index.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 
 import { BrnProgressIndicatorComponent } from './lib/brn-progress-indicator.component';
 import { BrnProgressComponent } from './lib/brn-progress.component';
+export { injectBrnProgress } from './lib/brn-progress.token';
 
 export * from './lib/brn-progress-indicator.component';
 export * from './lib/brn-progress.component';

--- a/libs/ui/progress/brain/src/lib/brn-progress-indicator.component.ts
+++ b/libs/ui/progress/brain/src/lib/brn-progress-indicator.component.ts
@@ -1,19 +1,16 @@
-import { Component, inject } from '@angular/core';
-import { BrnProgressComponent } from './brn-progress.component';
+import { Component } from '@angular/core';
+import { injectBrnProgress } from './brn-progress.token';
 
 @Component({
 	selector: 'brn-progress-indicator',
 	standalone: true,
 	template: '',
 	host: {
-		'[attr.data-state]': 'progressState()',
-		'[attr.data-value]': 'value() ?? undefined',
-		'[attr.data-max]': 'max()',
+		'[attr.data-state]': 'progress.state()',
+		'[attr.data-value]': 'progress.value()',
+		'[attr.data-max]': 'progress.max()',
 	},
 })
 export class BrnProgressIndicatorComponent {
-	private readonly _parent = inject(BrnProgressComponent);
-	protected readonly progressState = this._parent.progressState;
-	protected readonly max = this._parent.$max;
-	protected readonly value = this._parent.$value;
+	protected readonly progress = injectBrnProgress();
 }

--- a/libs/ui/progress/brain/src/lib/brn-progress.component.spec.ts
+++ b/libs/ui/progress/brain/src/lib/brn-progress.component.spec.ts
@@ -1,0 +1,118 @@
+import { Component } from '@angular/core';
+import { render } from '@testing-library/angular';
+import { BrnProgressIndicatorComponent } from './brn-progress-indicator.component';
+import { BrnProgressComponent, BrnProgressLabelFn } from './brn-progress.component';
+
+@Component({
+	template: `
+    <brn-progress [value]="value" [max]="max" [getValueLabel]="getValueLabel">
+      <brn-progress-indicator />
+    </brn-progress>
+  `,
+})
+class TestHostComponent {
+	value: number | null | undefined = 0;
+	max = 100;
+	getValueLabel: BrnProgressLabelFn = (value, max) => `${Math.round((value / max) * 100)}%`;
+}
+
+describe('BrnProgressComponent', () => {
+	it('should initialize with default values and set aria attributes', async () => {
+		const { container } = await render(TestHostComponent, {
+			imports: [BrnProgressComponent, BrnProgressIndicatorComponent],
+		});
+		const progressBar = container.querySelector('brn-progress');
+
+		expect(progressBar?.getAttribute('aria-valuemax')).toBe('100');
+		expect(progressBar?.getAttribute('aria-valuemin')).toBe('0');
+		expect(progressBar?.getAttribute('aria-valuenow')).toBe('0');
+		expect(progressBar?.getAttribute('aria-valuetext')).toBe('0%');
+	});
+
+	it('should display "indeterminate" state when value is null or undefined', async () => {
+		const { fixture, container } = await render(TestHostComponent, {
+			imports: [BrnProgressComponent, BrnProgressIndicatorComponent],
+			componentProperties: { value: null },
+		});
+		fixture.detectChanges();
+
+		const progressBar = container.querySelector('brn-progress');
+		expect(progressBar?.getAttribute('data-state')).toBe('indeterminate');
+		expect(progressBar?.getAttribute('aria-valuetext')).toBe(null);
+	});
+
+	it('should set aria attributes based on provided value and max', async () => {
+		const { fixture, container } = await render(TestHostComponent, {
+			imports: [BrnProgressComponent, BrnProgressIndicatorComponent],
+			componentProperties: { value: 50, max: 200 },
+		});
+		fixture.detectChanges();
+
+		const progressBar = container.querySelector('brn-progress');
+		expect(progressBar?.getAttribute('aria-valuenow')).toBe('50');
+		expect(progressBar?.getAttribute('aria-valuemax')).toBe('200');
+		expect(progressBar?.getAttribute('aria-valuetext')).toBe('25%');
+	});
+
+	it('should set state to "complete" when value equals max', async () => {
+		const { fixture, container } = await render(TestHostComponent, {
+			imports: [BrnProgressComponent, BrnProgressIndicatorComponent],
+			componentProperties: { value: 100, max: 100 },
+		});
+		fixture.detectChanges();
+
+		const progressBar = container.querySelector('brn-progress');
+		expect(progressBar?.getAttribute('data-state')).toBe('complete');
+	});
+
+	it('should set state to "loading" when value is within bounds and not equal to max', async () => {
+		const { fixture, container } = await render(TestHostComponent, {
+			imports: [BrnProgressComponent, BrnProgressIndicatorComponent],
+			componentProperties: { value: 50, max: 100 },
+		});
+		fixture.detectChanges();
+
+		const progressBar = container.querySelector('brn-progress');
+		expect(progressBar?.getAttribute('data-state')).toBe('loading');
+	});
+
+	it('should throw an error if value is out of bounds', async () => {
+		const { fixture } = await render(TestHostComponent, {
+			imports: [BrnProgressComponent, BrnProgressIndicatorComponent],
+		});
+
+		expect(() => {
+			fixture.componentInstance.value = 150;
+			fixture.detectChanges();
+		}).toThrow('Value must be 0 or greater and less or equal to max');
+
+		expect(() => {
+			fixture.componentInstance.value = -10;
+			fixture.detectChanges();
+		}).toThrow('Value must be 0 or greater and less or equal to max');
+	});
+
+	it('should throw an error if max is set to a negative number', async () => {
+		const { fixture } = await render(TestHostComponent, {
+			imports: [BrnProgressComponent, BrnProgressIndicatorComponent],
+		});
+
+		expect(() => {
+			fixture.componentInstance.max = -50;
+			fixture.detectChanges();
+		}).toThrow('Value must be 0 or greater and less or equal to max');
+	});
+
+	it('should reflect state, value, and max in BrnProgressIndicatorComponent', async () => {
+		const { fixture, container } = await render(TestHostComponent, {
+			imports: [BrnProgressComponent, BrnProgressIndicatorComponent],
+			componentProperties: { value: 30, max: 100 },
+		});
+		fixture.detectChanges();
+
+		const indicator = container.querySelector('brn-progress-indicator');
+		expect(indicator?.getAttribute('data-state')).toBe('loading');
+		expect(indicator?.getAttribute('data-value')).toBe('30');
+		expect(indicator?.getAttribute('data-max')).toBe('100');
+	});
+});

--- a/libs/ui/progress/brain/src/lib/brn-progress.component.ts
+++ b/libs/ui/progress/brain/src/lib/brn-progress.component.ts
@@ -1,60 +1,65 @@
-import { type NumberInput, coerceNumberProperty } from '@angular/cdk/coercion';
-import { Component, Input, computed, signal } from '@angular/core';
+import { type NumberInput } from '@angular/cdk/coercion';
+import { Component, OnChanges, SimpleChanges, computed, input, numberAttribute } from '@angular/core';
+import { provideBrnProgress } from './brn-progress.token';
 
 @Component({
 	selector: 'brn-progress',
 	standalone: true,
 	template: '<ng-content/>',
+	exportAs: 'brnProgress',
+	providers: [provideBrnProgress(BrnProgressComponent)],
 	host: {
 		role: 'progressbar',
-		'[attr.aria-valuemax]': '_max()',
+		'[attr.aria-valuemax]': 'max()',
 		'[attr.aria-valuemin]': '0',
-		'[attr.aria-valuenow]': 'isNumber() ? _value() : undefined',
-		'[attr.aria-valuetext]': '_value() ? getValueLabel(_value(),_max()) : undefined',
-		'[attr.data-state]': 'progressState()',
-		'[attr.data-value]': '_value() ?? undefined',
-		'[attr.data-max]': '_max()',
+		'[attr.aria-valuenow]': 'value()',
+		'[attr.aria-valuetext]': 'label()',
+		'[attr.data-state]': 'state()',
+		'[attr.data-value]': 'value()',
+		'[attr.data-max]': 'max()',
 	},
 })
-export class BrnProgressComponent {
-	protected readonly _value = signal<number | null | undefined>(undefined);
-	public readonly $value = this._value.asReadonly();
-	@Input()
-	set value(newValue: NumberInput) {
-		if (newValue === undefined || newValue === null || newValue === 'null' || newValue === 'undefined') {
-			this._value.set(null);
+export class BrnProgressComponent implements OnChanges {
+	public readonly value = input<number | null | undefined, NumberInput>(undefined, {
+		transform: (value) => (value === undefined || value === null ? undefined : Number(value)),
+	});
+	public readonly max = input<number, NumberInput>(100, { transform: numberAttribute });
+	public readonly getValueLabel = input<BrnProgressLabelFn>((value, max) => `${Math.round((value / max) * 100)}%`);
+	protected readonly label = computed(() => {
+		const value = this.value();
+		return value === null || value === undefined ? undefined : this.getValueLabel()(value, this.max());
+	});
+
+	protected readonly state = computed(() => {
+		const value = this.value();
+		const max = this.max();
+
+		return value === null || value === undefined ? 'indeterminate' : value === max ? 'complete' : 'loading';
+	});
+
+	ngOnChanges(changes: SimpleChanges): void {
+		if ('value' in changes || 'max' in changes) {
+			this.validate();
+		}
+	}
+
+	private validate(): void {
+		// validate that the value is within the bounds of the max
+		const value = this.value();
+		const max = this.max();
+
+		if (value === null || value === undefined) {
 			return;
 		}
 
-		newValue = coerceNumberProperty(newValue);
-		if (newValue > this._max() || newValue < 0) {
+		if (value > max || value < 0) {
 			throw Error('Value must be 0 or greater and less or equal to max');
 		}
-		this._value.set(newValue);
-	}
 
-	protected readonly _max = signal(100);
-	public readonly $max = this._max.asReadonly();
-	@Input()
-	set max(value: NumberInput) {
-		const newValue = coerceNumberProperty(value);
-		if (newValue < 0) {
+		if (max < 0) {
 			throw Error('max must be greater than 0');
 		}
-		this._max.set(newValue);
 	}
-	@Input()
-	getValueLabel: (value: number, max: number) => string = (value, max) => `${Math.round((value / max) * 100)}%`;
-
-	isNumber() {
-		return typeof this._value() === 'number';
-	}
-
-	progressState = computed(() => {
-		return this._value() === null || this._value() === undefined
-			? 'indeterminate'
-			: this._value() === this._max()
-				? 'complete'
-				: 'loading';
-	});
 }
+
+export type BrnProgressLabelFn = (value: number, max: number) => string;

--- a/libs/ui/progress/brain/src/lib/brn-progress.token.ts
+++ b/libs/ui/progress/brain/src/lib/brn-progress.token.ts
@@ -1,0 +1,12 @@
+import { ExistingProvider, InjectionToken, Type, inject } from '@angular/core';
+import type { BrnProgressComponent } from './brn-progress.component';
+
+const BrnProgressToken = new InjectionToken<BrnProgressComponent>('BrnProgressComponent');
+
+export function provideBrnProgress(progress: Type<BrnProgressComponent>): ExistingProvider {
+	return { provide: BrnProgressToken, useExisting: progress };
+}
+
+export function injectBrnProgress(): BrnProgressComponent {
+	return inject(BrnProgressToken);
+}

--- a/libs/ui/progress/helm/src/lib/hlm-progress.directive.ts
+++ b/libs/ui/progress/helm/src/lib/hlm-progress.directive.ts
@@ -11,7 +11,7 @@ import type { ClassValue } from 'clsx';
 })
 export class HlmProgressDirective {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected _computedClass = computed(() =>
+	protected readonly _computedClass = computed(() =>
 		hlm('inline-flex relative h-4 w-full overflow-hidden rounded-full bg-secondary', this.userClass()),
 	);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [X] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #431 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- Migrating progress components/directives to use signals
- Adding unit tests
- Updating to use provider to retrieve value instead of querying the dom in ngDoCheck as that is quite an expensive task in such a frequently run function.
