### PR TITLE
fix(select): updating trigger width on element resize

### DIFF
--- a/libs/ui/select/brain/src/lib/tests/brn-select.component.numbers.spec.ts
+++ b/libs/ui/select/brain/src/lib/tests/brn-select.component.numbers.spec.ts
@@ -5,6 +5,14 @@ import userEvent from '@testing-library/user-event';
 import { BrnSelectImports } from '../../index';
 
 describe('BrnSelectComponent NumberValues', () => {
+	beforeAll(() => {
+		global.ResizeObserver = jest.fn().mockImplementation(() => ({
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+			disconnect: jest.fn(),
+		}));
+	});
+
 	const setup = async () => {
 		const selectedValue = signal(15);
 		const container = await render(

--- a/libs/ui/select/brain/src/lib/tests/brn-select.component.spec.ts
+++ b/libs/ui/select/brain/src/lib/tests/brn-select.component.spec.ts
@@ -3,6 +3,14 @@ import userEvent from '@testing-library/user-event';
 import { BrnSelectImports } from '../../index';
 
 describe('BrnSelectComponent', () => {
+	beforeAll(() => {
+		global.ResizeObserver = jest.fn().mockImplementation(() => ({
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+			disconnect: jest.fn(),
+		}));
+	});
+
 	const setup = async () => {
 		const openChangeSpy = jest.fn();
 		const container = await render(

--- a/libs/ui/select/brain/src/lib/tests/select-multi-mode.spec.ts
+++ b/libs/ui/select/brain/src/lib/tests/select-multi-mode.spec.ts
@@ -9,6 +9,14 @@ import {
 import { getFormControlStatus, getFormValidationClasses } from './utils';
 
 describe('Brn Select Component in multi-mode', () => {
+	beforeAll(() => {
+		global.ResizeObserver = jest.fn().mockImplementation(() => ({
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+			disconnect: jest.fn(),
+		}));
+	});
+
 	const DEFAULT_LABEL = 'Select a Fruit';
 
 	const setupWithFormValidationMulti = async () => {

--- a/libs/ui/select/brain/src/lib/tests/select-single-mode.spec.ts
+++ b/libs/ui/select/brain/src/lib/tests/select-single-mode.spec.ts
@@ -13,6 +13,14 @@ describe('Brn Select Component in single-mode', () => {
 	const INITIAL_VALUE_TEXT = 'Apple';
 	const INITIAL_VALUE = 'apple';
 
+	beforeAll(() => {
+		global.ResizeObserver = jest.fn().mockImplementation(() => ({
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+			disconnect: jest.fn(),
+		}));
+	});
+
 	const setupWithFormValidation = async () => {
 		const { fixture } = await render(SelectSingleValueTestComponent);
 		return {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [X] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #451

## What is the new behavior?

If the trigger element is resized the dropdown will not match the dropdown size. This PR adds a resize observer to update the trigger width on element resize.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
