### PR TITLE
refactor(checkbox): migration to signals

### DIFF
--- a/libs/ui/checkbox/brain/src/lib/brn-checkbox-ng-model.component.spec.ts
+++ b/libs/ui/checkbox/brain/src/lib/brn-checkbox-ng-model.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, input, model } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrnCheckboxComponent } from './brn-checkbox.component';
 
@@ -7,15 +7,14 @@ import { BrnCheckboxComponent } from './brn-checkbox.component';
 	standalone: true,
 	template: `
 		<label>
-			Airplane mode is: {{ airplaneMode ? 'on' : 'off' }}
-			<brn-checkbox [disabled]="disabled" [(ngModel)]="airplaneMode"></brn-checkbox>
+			Airplane mode is: {{ airplaneMode() ? 'on' : 'off' }}
+			<brn-checkbox [disabled]="disabled()" [(ngModel)]="airplaneMode"></brn-checkbox>
 		</label>
 	`,
 	imports: [BrnCheckboxComponent, FormsModule],
 })
 export class BrnCheckboxNgModelSpecComponent {
-	@Input()
-	public disabled = false;
-	@Input()
-	public airplaneMode = false;
+	public readonly disabled = input(false);
+
+	public readonly airplaneMode = model(false);
 }

--- a/libs/ui/checkbox/brain/src/lib/brn-checkbox-ng-model.spec.ts
+++ b/libs/ui/checkbox/brain/src/lib/brn-checkbox-ng-model.spec.ts
@@ -24,7 +24,7 @@ describe('BrnCheckboxComponentNgModelIntegration', () => {
 		expect(labelElement).toBeInTheDocument();
 		await user.click(labelElement);
 		await screen.findByDisplayValue('on');
-		expect(container.fixture.componentInstance.airplaneMode).toBe(true);
+		expect(container.fixture.componentInstance.airplaneMode()).toBe(true);
 	});
 
 	it('should set input as default correctly and click should toggle then', async () => {
@@ -32,21 +32,21 @@ describe('BrnCheckboxComponentNgModelIntegration', () => {
 
 		await user.click(labelElement);
 		await screen.findByDisplayValue('off');
-		expect(container.fixture.componentInstance.airplaneMode).toBe(false);
+		expect(container.fixture.componentInstance.airplaneMode()).toBe(false);
 
 		await user.click(labelElement);
 		await screen.findByDisplayValue('on');
-		expect(container.fixture.componentInstance.airplaneMode).toBe(true);
+		expect(container.fixture.componentInstance.airplaneMode()).toBe(true);
 	});
 
 	it('should set input as default correctly and enter should toggle then', async () => {
 		const { user, container } = await setup(true);
 
 		await user.keyboard('[Tab][Enter]');
-		expect(container.fixture.componentInstance.airplaneMode).toBe(false);
+		expect(container.fixture.componentInstance.airplaneMode()).toBe(false);
 
 		await user.keyboard('[Enter]');
-		expect(container.fixture.componentInstance.airplaneMode).toBe(true);
+		expect(container.fixture.componentInstance.airplaneMode()).toBe(true);
 	});
 
 	it('should do nothing when disabled', async () => {
@@ -54,10 +54,10 @@ describe('BrnCheckboxComponentNgModelIntegration', () => {
 
 		await user.click(labelElement);
 		await screen.findByDisplayValue('off');
-		expect(container.fixture.componentInstance.airplaneMode).toBe(false);
+		expect(container.fixture.componentInstance.airplaneMode()).toBe(false);
 
 		await user.click(labelElement);
 		await screen.findByDisplayValue('off');
-		expect(container.fixture.componentInstance.airplaneMode).toBe(false);
+		expect(container.fixture.componentInstance.airplaneMode()).toBe(false);
 	});
 });

--- a/libs/ui/checkbox/helm/src/lib/hlm-checkbox.component.ts
+++ b/libs/ui/checkbox/helm/src/lib/hlm-checkbox.component.ts
@@ -1,15 +1,4 @@
-import {
-	Component,
-	EventEmitter,
-	Output,
-	booleanAttribute,
-	computed,
-	effect,
-	forwardRef,
-	input,
-	model,
-	signal,
-} from '@angular/core';
+import { Component, booleanAttribute, computed, forwardRef, input, model, output, signal } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { BrnCheckboxComponent } from '@spartan-ng/ui-checkbox-brain';
 import { hlm } from '@spartan-ng/ui-core';
@@ -32,7 +21,7 @@ export const HLM_CHECKBOX_VALUE_ACCESSOR = {
 			[name]="name()"
 			[class]="_computedClass()"
 			[checked]="checked()"
-			[disabled]="_disabled()"
+			[disabled]="state().disabled()"
 			[required]="required()"
 			[aria-label]="ariaLabel()"
 			[aria-labelledby]="ariaLabelledby()"
@@ -59,7 +48,7 @@ export class HlmCheckboxComponent {
 			'group inline-flex border border-foreground shrink-0 cursor-pointer items-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' +
 				' focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=checked]:text-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-background',
 			this.userClass(),
-			this._disabled() ? 'cursor-not-allowed opacity-50' : '',
+			this.state().disabled() ? 'cursor-not-allowed opacity-50' : '',
 		),
 	);
 
@@ -80,25 +69,20 @@ export class HlmCheckboxComponent {
 	public readonly name = input<string | null>(null);
 	public readonly required = input(false, { transform: booleanAttribute });
 
-	protected readonly _disabled = signal(false);
 	public readonly disabled = input(false, { transform: booleanAttribute });
 
-	private disableInput = effect(
-		() => {
-			this._disabled.set(this.disabled());
-		},
-		{ allowSignalWrites: true },
-	);
+	protected readonly state = computed(() => ({
+		disabled: signal(this.disabled()),
+	}));
 
 	// icon inputs
 	public readonly checkIconName = input<string>('lucideCheck');
-	public readonly checkIconClass = input<string>('');
+	public readonly checkIconClass = input<ClassValue>('');
 
-	@Output()
-	public changed = new EventEmitter<boolean>();
+	public readonly changed = output<boolean>();
 
 	protected _handleChange(): void {
-		if (this._disabled()) return;
+		if (this.state().disabled()) return;
 
 		const previousChecked = this.checked();
 		this.checked.set(previousChecked === 'indeterminate' ? true : !previousChecked);
@@ -128,6 +112,6 @@ export class HlmCheckboxComponent {
 	}
 
 	setDisabledState(isDisabled: boolean): void {
-		this._disabled.set(isDisabled);
+		this.state().disabled.set(isDisabled);
 	}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [X] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #441

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- Replace Output and ViewChild
- Replace internal disabled signal with computed state.

