### PR TITLE
refactor(icon): migrate to signals

### DIFF
--- a/libs/ui/accordion/helm/src/lib/hlm-accordion-icon.directive.ts
+++ b/libs/ui/accordion/helm/src/lib/hlm-accordion-icon.directive.ts
@@ -1,27 +1,20 @@
-import { Directive, computed, inject, input } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { lucideChevronDown } from '@ng-icons/lucide';
 import { hlm } from '@spartan-ng/ui-core';
-import { HlmIconComponent, provideIcons } from '@spartan-ng/ui-icon-helm';
+import { provideHlmIconConfig, provideIcons } from '@spartan-ng/ui-icon-helm';
 import type { ClassValue } from 'clsx';
 
 @Directive({
 	selector: 'hlm-icon[hlmAccordionIcon], hlm-icon[hlmAccIcon]',
 	standalone: true,
-	providers: [provideIcons({ lucideChevronDown })],
+	providers: [provideIcons({ lucideChevronDown }), provideHlmIconConfig({ name: 'lucideChevronDown', size: 'none' })],
 	host: {
 		'[class]': '_computedClass()',
 	},
 })
 export class HlmAccordionIconDirective {
-	private readonly _hlmIcon = inject(HlmIconComponent);
-
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() =>
 		hlm('inline-block h-4 w-4 transition-transform [animation-duration:200]', this.userClass()),
 	);
-
-	constructor() {
-		this._hlmIcon.size = 'none';
-		this._hlmIcon.name = 'lucideChevronDown';
-	}
 }

--- a/libs/ui/alert/helm/src/lib/hlm-alert-icon.directive.ts
+++ b/libs/ui/alert/helm/src/lib/hlm-alert-icon.directive.ts
@@ -1,15 +1,9 @@
-import { Directive, inject } from '@angular/core';
-import { HlmIconComponent } from '@spartan-ng/ui-icon-helm';
+import { Directive } from '@angular/core';
+import { provideHlmIconConfig } from '@spartan-ng/ui-icon-helm';
 
 @Directive({
 	selector: '[hlmAlertIcon]',
 	standalone: true,
+	providers: [provideHlmIconConfig({ size: 'sm' })],
 })
-export class HlmAlertIconDirective {
-	private _icon = inject(HlmIconComponent, { host: true, optional: true });
-
-	constructor() {
-		if (!this._icon) return;
-		this._icon.size = 'sm';
-	}
-}
+export class HlmAlertIconDirective {}

--- a/libs/ui/command/helm/src/lib/hlm-command-item-icon.directive.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-item-icon.directive.ts
@@ -1,23 +1,17 @@
-import { Directive, computed, inject, input } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
-import { HlmIconComponent } from '@spartan-ng/ui-icon-helm';
+import { provideHlmIconConfig } from '@spartan-ng/ui-icon-helm';
 import type { ClassValue } from 'clsx';
 
 @Directive({
 	selector: '[hlmCmdIcon]',
 	standalone: true,
+	providers: [provideHlmIconConfig({ size: 'none' })],
 	host: {
 		'[class]': '_computedClass()',
 	},
 })
 export class HlmCommandItemIconDirective {
-	private _menuIcon = inject(HlmIconComponent, { host: true, optional: true });
-
-	constructor() {
-		if (!this._menuIcon) return;
-		this._menuIcon.size = 'none';
-	}
-
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() => hlm('mr-2 h-4 w-4', this.userClass()));
 }

--- a/libs/ui/icon/helm/src/index.ts
+++ b/libs/ui/icon/helm/src/index.ts
@@ -3,6 +3,7 @@ import { provideIcons as provideIconsImport } from '@ng-icons/core';
 import { HlmIconComponent } from './lib/hlm-icon.component';
 
 export * from './lib/hlm-icon.component';
+export * from './lib/hlm-icon.token';
 
 export const provideIcons = provideIconsImport;
 

--- a/libs/ui/icon/helm/src/lib/hlm-icon.component.ts
+++ b/libs/ui/icon/helm/src/lib/hlm-icon.component.ts
@@ -3,18 +3,19 @@ import {
 	ChangeDetectionStrategy,
 	Component,
 	ElementRef,
-	Input,
 	type OnDestroy,
 	PLATFORM_ID,
 	ViewEncapsulation,
 	computed,
 	inject,
+	input,
 	signal,
 } from '@angular/core';
-import { type IconName, NgIconComponent } from '@ng-icons/core';
+import { type IconType, NgIconComponent } from '@ng-icons/core';
 import { hlm } from '@spartan-ng/ui-core';
-import { cva } from 'class-variance-authority';
+import { type VariantProps, cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
+import { injectHlmIconConfig } from './hlm-icon.token';
 
 const DEFINED_SIZES = ['xs', 'sm', 'base', 'lg', 'xl', 'none'] as const;
 
@@ -36,6 +37,8 @@ export const iconVariants = cva('inline-flex', {
 	},
 });
 
+export type IconVariants = VariantProps<typeof iconVariants>;
+
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type IconSize = DefinedSizes | (Record<never, never> & string);
 
@@ -53,11 +56,11 @@ const TAILWIND_H_W_PATTERN = /\b(h-\d+|w-\d+)\b/g;
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		<ng-icon
-			[class]="ngIconCls()"
+			[class]="ngIconClass()"
 			[size]="ngIconSize()"
-			[name]="_name()"
-			[color]="_color()"
-			[strokeWidth]="_strokeWidth()"
+			[name]="name()"
+			[color]="color()"
+			[strokeWidth]="strokeWidth()"
 		/>
 	`,
 	host: {
@@ -67,26 +70,32 @@ const TAILWIND_H_W_PATTERN = /\b(h-\d+|w-\d+)\b/g;
 export class HlmIconComponent implements OnDestroy {
 	private readonly _host = inject(ElementRef);
 	private readonly _platformId = inject(PLATFORM_ID);
+	private readonly _config = injectHlmIconConfig();
 
 	private _mutObs?: MutationObserver;
 
 	private readonly _hostClasses = signal<string>('');
 
-	protected readonly _name = signal<IconName | string>('');
-	protected readonly _size = signal<IconSize>('base');
-	protected readonly _color = signal<string | undefined>(undefined);
-	protected readonly _strokeWidth = signal<string | number | undefined>(undefined);
-	protected readonly userCls = signal<ClassValue>('');
-	protected readonly ngIconSize = computed(() => (isDefinedSize(this._size()) ? '100%' : (this._size() as string)));
-	protected readonly ngIconCls = signal<ClassValue>('');
+	public readonly name = input<IconType>(this._config.name);
+
+	public readonly size = input<IconSize>(this._config.size);
+
+	protected readonly ngIconSize = computed(() => (isDefinedSize(this.size()) ? '100%' : (this.size() as string)));
+
+	public readonly color = input<string | undefined>(undefined);
+
+	public readonly strokeWidth = input<string | number | undefined>(undefined);
+
+	public readonly ngIconClass = input<ClassValue>('');
+
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 
 	protected readonly _computedClass = computed(() => {
-		const size: IconSize = this._size();
+		const size: IconSize = this.size();
 		const hostClasses = this._hostClasses();
-		const userCls = this.userCls();
 		const variant = isDefinedSize(size) ? size : 'none';
 		const classes = variant === 'none' && size === 'none' ? hostClasses : hostClasses.replace(TAILWIND_H_W_PATTERN, '');
-		return hlm(iconVariants({ variant }), userCls, classes);
+		return hlm(iconVariants({ variant }), this.userClass(), classes);
 	});
 
 	constructor() {
@@ -106,35 +115,5 @@ export class HlmIconComponent implements OnDestroy {
 	ngOnDestroy() {
 		this._mutObs?.disconnect();
 		this._mutObs = undefined;
-	}
-
-	@Input()
-	set name(value: IconName | string) {
-		this._name.set(value);
-	}
-
-	@Input()
-	set size(value: IconSize) {
-		this._size.set(value);
-	}
-
-	@Input()
-	set color(value: string | undefined) {
-		this._color.set(value);
-	}
-
-	@Input()
-	set strokeWidth(value: string | number | undefined) {
-		this._strokeWidth.set(value);
-	}
-
-	@Input()
-	set ngIconClass(cls: ClassValue) {
-		this.ngIconCls.set(cls);
-	}
-
-	@Input()
-	set class(cls: ClassValue) {
-		this.userCls.set(cls);
 	}
 }

--- a/libs/ui/icon/helm/src/lib/hlm-icon.token.ts
+++ b/libs/ui/icon/helm/src/lib/hlm-icon.token.ts
@@ -1,0 +1,23 @@
+import { InjectionToken, ValueProvider, inject } from '@angular/core';
+import { type IconType } from '@ng-icons/core';
+import type { IconSize } from './hlm-icon.component';
+
+export interface HlmIconConfig {
+	name: IconType;
+	size: IconSize;
+}
+
+const defaultConfig: HlmIconConfig = {
+	name: '',
+	size: 'base',
+};
+
+const HlmIconConfigToken = new InjectionToken<HlmIconConfig>('HlmIconConfig');
+
+export function provideHlmIconConfig(config: Partial<HlmIconConfig>): ValueProvider {
+	return { provide: HlmIconConfigToken, useValue: { ...defaultConfig, ...config } };
+}
+
+export function injectHlmIconConfig(): HlmIconConfig {
+	return inject(HlmIconConfigToken, { optional: true }) ?? defaultConfig;
+}

--- a/libs/ui/icon/icon.stories.ts
+++ b/libs/ui/icon/icon.stories.ts
@@ -25,7 +25,7 @@ export const Default: Story = {
 		name: 'lucideCheck',
 		size: 'sm',
 		color: 'red',
-		class: '',
+		userClass: '',
 		strokeWidth: 1,
 	},
 	argTypes: {
@@ -41,7 +41,7 @@ export const Default: Story = {
 
 export const Tailwind: Story = {
 	args: {
-		class: 'text-red-600 text-5xl',
+		userClass: 'text-red-600 text-5xl',
 		name: 'lucideCheck',
 	},
 	argTypes: {

--- a/libs/ui/menu/helm/src/lib/hlm-menu-item-icon.directive.ts
+++ b/libs/ui/menu/helm/src/lib/hlm-menu-item-icon.directive.ts
@@ -1,23 +1,17 @@
-import { Directive, computed, inject, input } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { hlm } from '@spartan-ng/ui-core';
-import { HlmIconComponent } from '@spartan-ng/ui-icon-helm';
+import { provideHlmIconConfig } from '@spartan-ng/ui-icon-helm';
 import type { ClassValue } from 'clsx';
 
 @Directive({
 	selector: '[hlmMenuIcon]',
 	standalone: true,
+	providers: [provideHlmIconConfig({ size: 'none' })],
 	host: {
 		'[class]': '_computedClass()',
 	},
 })
 export class HlmMenuItemIconDirective {
-	private _menuIcon = inject(HlmIconComponent, { host: true, optional: true });
-
-	constructor() {
-		if (!this._menuIcon) return;
-		this._menuIcon.size = 'none';
-	}
-
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() => hlm('mr-2 h-4 w-4', this.userClass()));
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [x] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #417

## What is the new behavior?

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

Components that we previously using the icon as a HostDirective and were setting the inputs programmatically should now use the `provideHlmIconConfig` provider instead.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- `provideHlmIconConfig` for other components to set defaults (pattern from @ashley-hunter #447) 
