### PR TITLE
fix(toggle): sync initial internal toggle group state when toggle con…

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip--simple.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip--simple.example.ts
@@ -5,11 +5,7 @@ import { HlmTooltipComponent, HlmTooltipTriggerDirective } from '@spartan-ng/ui-
 @Component({
 	selector: 'spartan-tooltip-simple',
 	standalone: true,
-	imports: [
-		HlmTooltipComponent,
-		HlmTooltipTriggerDirective,
-		HlmButtonDirective,
-	],
+	imports: [HlmTooltipComponent, HlmTooltipTriggerDirective, HlmButtonDirective],
 	template: `
 		<button [hlmTooltipTrigger]="'Simple tooltip'" aria-describedby="Simple tooltip" hlmBtn variant="outline">
 			Simple
@@ -39,4 +35,3 @@ import { HlmTooltipComponent, HlmTooltipTriggerDirective } from '@spartan-ng/ui-
 })
 export class TooltipSimpleComponent {}
 `;
-

--- a/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
@@ -13,8 +13,8 @@ import { SectionSubHeadingComponent } from '../../../../shared/layout/section-su
 import { TabsCliComponent } from '../../../../shared/layout/tabs-cli.component';
 import { TabsComponent } from '../../../../shared/layout/tabs.component';
 import { metaWith } from '../../../../shared/meta/meta.util';
-import { TooltipPreviewComponent, defaultCode, defaultImports, defaultSkeleton } from './tooltip.preview';
 import { TooltipSimpleComponent, simpleCode } from './tooltip--simple.example';
+import { TooltipPreviewComponent, defaultCode, defaultImports, defaultSkeleton } from './tooltip.preview';
 
 export const routeMeta: RouteMeta = {
 	data: { breadcrumb: 'Tooltip' },

--- a/apps/ui-storybook-e2e/src/integration/toggle/toggle--toggle-group-form.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/toggle/toggle--toggle-group-form.cy.ts
@@ -1,0 +1,64 @@
+describe('toggle--toggle-group-single', () => {
+	describe('default', () => {
+		beforeEach(() => {
+			cy.visit('/iframe.html?id=toggle--toggle-group-form');
+			cy.injectAxe();
+		});
+
+		const verifyToggleGroupSetup = () => {
+			cy.checkA11y('#storybook-root', {
+				rules: {
+					'page-has-heading-one': { enabled: false },
+					'landmark-one-main': { enabled: false },
+				},
+			});
+			cy.findByTestId(/selectedCity/i).contains(/sparta/i);
+			cy.findByRole('group').should('exist');
+			cy.findByRole('group').children('button').should('have.length', 4);
+			cy.findByRole('group')
+				.children('button')
+				.not(':contains("Sparta")')
+				.each((btn) => cy.wrap(btn).should('have.attr', 'aria-pressed', 'false'));
+			cy.findByRole('group')
+				.findByText(/sparta/i)
+				.should('have.attr', 'aria-pressed', 'true')
+				.should('have.attr', 'data-state', 'on');
+		};
+
+		it(`
+    1. should sparta selected by default.
+    2. should have toggle-group with role=group and 3 buttons toggled off and sparta toggled on.
+    3. click on sparta should not unselect sparta.
+    4. click on syracuse should unselect sparta and select syracuse
+    `, () => {
+			// 1. + 2.
+			verifyToggleGroupSetup();
+			//3.
+			cy.findByRole('group')
+				.findByText(/sparta/i)
+				.click();
+			cy.findByRole('group')
+				.findByText(/sparta/i)
+				.should('have.attr', 'aria-pressed', 'true')
+				.should('have.attr', 'data-state', 'on');
+			cy.findByRole('group')
+				.children('button')
+				.not(':contains("Sparta")')
+				.each((btn) => cy.wrap(btn).should('have.attr', 'aria-pressed', 'false'));
+			cy.findByTestId(/selectedCity/i).contains(/sparta/i);
+			// 4.
+			cy.findByRole('group')
+				.findByText(/syracuse/i)
+				.click();
+			cy.findByRole('group')
+				.findByText(/syracuse/i)
+				.should('have.attr', 'aria-pressed', 'true')
+				.should('have.attr', 'data-state', 'on');
+			cy.findByRole('group')
+				.children('button')
+				.not(':contains("Syracuse")')
+				.each((btn) => cy.wrap(btn).should('have.attr', 'aria-pressed', 'false'));
+			cy.findByTestId(/selectedCity/i).contains(/syracuse/i);
+		});
+	});
+});

--- a/libs/ui/toggle/brain/src/lib/brn-toggle-group.component.spec.ts
+++ b/libs/ui/toggle/brain/src/lib/brn-toggle-group.component.spec.ts
@@ -121,11 +121,12 @@ describe('BrnToggleGroupDirective', () => {
 	});
 
 	it('should initially select the button with the provided value (multiple = false) using ngModel', async () => {
-		const { getAllByRole } = await render(BrnToggleGroupDirectiveFormSpec, {
+		const { getAllByRole, detectChanges } = await render(BrnToggleGroupDirectiveFormSpec, {
 			inputs: {
 				value: 'option-2',
 			},
 		});
+		detectChanges();
 		const buttons = getAllByRole('button');
 
 		expect(buttons[0]).toHaveAttribute('data-state', 'off');
@@ -134,12 +135,13 @@ describe('BrnToggleGroupDirective', () => {
 	});
 
 	it('should initially select the buttons with the provided values (multiple = true) using ngModel', async () => {
-		const { getAllByRole } = await render(BrnToggleGroupDirectiveFormSpec, {
+		const { getAllByRole, detectChanges } = await render(BrnToggleGroupDirectiveFormSpec, {
 			inputs: {
 				value: ['option-1', 'option-3'],
 				multiple: true,
 			},
 		});
+		detectChanges();
 		const buttons = getAllByRole('button');
 
 		expect(buttons[0]).toHaveAttribute('data-state', 'on');

--- a/libs/ui/toggle/brain/src/lib/brn-toggle-group.component.ts
+++ b/libs/ui/toggle/brain/src/lib/brn-toggle-group.component.ts
@@ -1,5 +1,6 @@
 import { BooleanInput } from '@angular/cdk/coercion';
 import {
+	AfterViewInit,
 	Component,
 	OnChanges,
 	SimpleChanges,
@@ -46,7 +47,7 @@ export class BrnButtonToggleChange<T = unknown> {
 		<ng-content />
 	`,
 })
-export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccessor, OnChanges {
+export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccessor, OnChanges, AfterViewInit {
 	/**
 	 * The method to be called in order to update ngModel.
 	 */
@@ -88,6 +89,12 @@ export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccesso
 
 	/** The toggles within the group. */
 	private readonly _toggleButtons = contentChildren(BrnToggleDirective, { descendants: true });
+
+	ngAfterViewInit() {
+		// This is needed because we need access to our toggles through
+		// contentChildren to sync initial values set in writeValue before they are available, e.g. default values in a form
+		this.updateSelectionState();
+	}
 
 	ngOnChanges(changes: SimpleChanges): void {
 		if ('value' in changes) {

--- a/libs/ui/toggle/brain/src/lib/brn-toggle-group.component.ts
+++ b/libs/ui/toggle/brain/src/lib/brn-toggle-group.component.ts
@@ -1,18 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import {
-	AfterViewInit,
-	Component,
-	OnChanges,
-	SimpleChanges,
-	booleanAttribute,
-	computed,
-	contentChildren,
-	forwardRef,
-	input,
-	model,
-	output,
-	signal,
-} from '@angular/core';
+import { Component, booleanAttribute, computed, forwardRef, input, model, output, signal } from '@angular/core';
 import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { provideBrnToggleGroup } from './brn-toggle-group.token';
 import { BrnToggleDirective } from './brn-toggle.directive';
@@ -47,7 +34,7 @@ export class BrnButtonToggleChange<T = unknown> {
 		<ng-content />
 	`,
 })
-export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccessor, OnChanges, AfterViewInit {
+export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccessor {
 	/**
 	 * The method to be called in order to update ngModel.
 	 */
@@ -87,24 +74,8 @@ export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccesso
 	/** Emit event when the group value changes. */
 	readonly change = output<BrnButtonToggleChange<T>>();
 
-	/** The toggles within the group. */
-	private readonly _toggleButtons = contentChildren(BrnToggleDirective, { descendants: true });
-
-	ngAfterViewInit() {
-		// This is needed because we need access to our toggles through
-		// contentChildren to sync initial values set in writeValue before they are available, e.g. default values in a form
-		this.updateSelectionState();
-	}
-
-	ngOnChanges(changes: SimpleChanges): void {
-		if ('value' in changes) {
-			this.updateSelectionState();
-		}
-	}
-
 	writeValue(value: ToggleValue<T>): void {
 		this.value.set(value);
-		this.updateSelectionState();
 	}
 
 	registerOnChange(fn: (value: ToggleValue<T>) => void) {
@@ -163,7 +134,7 @@ export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccesso
 	 * Deselects a value.
 	 */
 	deselect(value: T, source: BrnToggleDirective<T>): void {
-		if (this.state().disabled() || !this.isSelected(value)) {
+		if (this.state().disabled() || !this.isSelected(value) || !this.canDeselect(value)) {
 			return;
 		}
 
@@ -174,25 +145,8 @@ export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccesso
 				((currentValue ?? []) as T[]).filter((v) => v !== value),
 				source,
 			);
-		} else if (currentValue === value && this.canDeselect(value)) {
+		} else if (currentValue === value) {
 			this.emitSelectionChange(null, source);
-		}
-	}
-
-	/** Update the value of the group */
-	private emitSelectionChange(value: ToggleValue<T>, source: BrnToggleDirective<T>): void {
-		this.value.set(value);
-		this._onChange(value);
-		this.change.emit(new BrnButtonToggleChange<T>(source, this.value()));
-
-		// propagate the change to the other toggles in the group
-		this.updateSelectionState();
-	}
-
-	/** Update the selection state in the toggle buttons. */
-	private updateSelectionState(): void {
-		for (const toggle of this._toggleButtons()) {
-			this.isSelected(toggle.value() as T) ? toggle.toggleOn() : toggle.toggleOff();
 		}
 	}
 
@@ -200,7 +154,7 @@ export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccesso
 	 * @internal
 	 * Determines whether a value is selected.
 	 */
-	private isSelected(value: T): boolean {
+	isSelected(value: T): boolean {
 		const currentValue = this.value();
 
 		if (
@@ -215,6 +169,13 @@ export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccesso
 			return (currentValue as T[])?.includes(value);
 		}
 		return currentValue === value;
+	}
+
+	/** Update the value of the group */
+	private emitSelectionChange(value: ToggleValue<T>, source: BrnToggleDirective<T>): void {
+		this.value.set(value);
+		this._onChange(value);
+		this.change.emit(new BrnButtonToggleChange<T>(source, this.value()));
 	}
 }
 

--- a/libs/ui/toggle/toggle.stories.ts
+++ b/libs/ui/toggle/toggle.stories.ts
@@ -1,6 +1,6 @@
-import { NgForOf, NgIf } from '@angular/common';
+import { JsonPipe, NgForOf, NgIf } from '@angular/common';
 import { Component, Input } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { lucideItalic } from '@ng-icons/lucide';
 import { type Meta, type StoryObj, moduleMetadata } from '@storybook/angular';
 import { HlmButtonDirective } from '../button/helm/src';
@@ -169,6 +169,7 @@ export const ToggleGroupSingle: StoryObj<{ city: City }> = {
 		template: '<hlm-toggle-group-story [selected]="city"/>',
 	}),
 };
+
 export const ToggleGroupDisabled: StoryObj<{ city: City }> = {
 	name: 'Toggle Group - Disabled',
 	decorators: [
@@ -198,5 +199,40 @@ export const ToggleGroupMultiple: StoryObj<{ cities: City[] }> = {
 	render: ({ cities }) => ({
 		props: { cities },
 		template: '<hlm-toggle-group-story [selected]="cities" multiple="true"/>',
+	}),
+};
+
+@Component({
+	selector: 'hlm-toggle-group-form-story',
+	standalone: true,
+	imports: [BrnToggleGroupModule, HlmToggleGroupModule, FormsModule, NgForOf, ReactiveFormsModule, JsonPipe],
+	template: `
+		<form class="flex space-x-4" [formGroup]="citiesForm">
+			<brn-toggle-group hlm formControlName="selectedCity">
+				<button variant="outline" *ngFor="let city of cities; let last = last" [value]="city" hlm brnToggle>
+					{{ city.name }}
+				</button>
+			</brn-toggle-group>
+		</form>
+
+		<pre class="${hlmP}" data-testid='selectedCity'>{{ citiesForm.controls.selectedCity?.getRawValue()?.name }}</pre>
+	`,
+})
+class HlmToggleGroupFormStoryComponent {
+	protected readonly cities: City[] = CITIES;
+	protected readonly citiesForm = new FormGroup({
+		selectedCity: new FormControl(CITIES[0]),
+	});
+}
+
+export const ToggleGroupForm: StoryObj<{}> = {
+	name: 'Toggle Group - Form',
+	decorators: [
+		moduleMetadata({
+			imports: [HlmToggleGroupFormStoryComponent],
+		}),
+	],
+	render: () => ({
+		template: '<hlm-toggle-group-form-story/>',
 	}),
 };


### PR DESCRIPTION
…tent children become available

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [x] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

initial value set from form was not reflected in UI
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #408

## What is the new behavior?

toggles are in sync from the start 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
