### PR TITLE
refactor(toggle): remove imperative calls to updateSelectionState

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip--simple.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip--simple.example.ts
@@ -5,11 +5,7 @@ import { HlmTooltipComponent, HlmTooltipTriggerDirective } from '@spartan-ng/ui-
 @Component({
 	selector: 'spartan-tooltip-simple',
 	standalone: true,
-	imports: [
-		HlmTooltipComponent,
-		HlmTooltipTriggerDirective,
-		HlmButtonDirective,
-	],
+	imports: [HlmTooltipComponent, HlmTooltipTriggerDirective, HlmButtonDirective],
 	template: `
 		<button [hlmTooltipTrigger]="'Simple tooltip'" aria-describedby="Simple tooltip" hlmBtn variant="outline">
 			Simple
@@ -39,4 +35,3 @@ import { HlmTooltipComponent, HlmTooltipTriggerDirective } from '@spartan-ng/ui-
 })
 export class TooltipSimpleComponent {}
 `;
-

--- a/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
@@ -13,8 +13,8 @@ import { SectionSubHeadingComponent } from '../../../../shared/layout/section-su
 import { TabsCliComponent } from '../../../../shared/layout/tabs-cli.component';
 import { TabsComponent } from '../../../../shared/layout/tabs.component';
 import { metaWith } from '../../../../shared/meta/meta.util';
-import { TooltipPreviewComponent, defaultCode, defaultImports, defaultSkeleton } from './tooltip.preview';
 import { TooltipSimpleComponent, simpleCode } from './tooltip--simple.example';
+import { TooltipPreviewComponent, defaultCode, defaultImports, defaultSkeleton } from './tooltip.preview';
 
 export const routeMeta: RouteMeta = {
 	data: { breadcrumb: 'Tooltip' },

--- a/libs/ui/toggle/brain/src/lib/brn-toggle-group.component.spec.ts
+++ b/libs/ui/toggle/brain/src/lib/brn-toggle-group.component.spec.ts
@@ -121,11 +121,12 @@ describe('BrnToggleGroupDirective', () => {
 	});
 
 	it('should initially select the button with the provided value (multiple = false) using ngModel', async () => {
-		const { getAllByRole } = await render(BrnToggleGroupDirectiveFormSpec, {
+		const { getAllByRole, detectChanges } = await render(BrnToggleGroupDirectiveFormSpec, {
 			inputs: {
 				value: 'option-2',
 			},
 		});
+		detectChanges();
 		const buttons = getAllByRole('button');
 
 		expect(buttons[0]).toHaveAttribute('data-state', 'off');
@@ -134,12 +135,13 @@ describe('BrnToggleGroupDirective', () => {
 	});
 
 	it('should initially select the buttons with the provided values (multiple = true) using ngModel', async () => {
-		const { getAllByRole } = await render(BrnToggleGroupDirectiveFormSpec, {
+		const { getAllByRole, detectChanges } = await render(BrnToggleGroupDirectiveFormSpec, {
 			inputs: {
 				value: ['option-1', 'option-3'],
 				multiple: true,
 			},
 		});
+		detectChanges();
 		const buttons = getAllByRole('button');
 
 		expect(buttons[0]).toHaveAttribute('data-state', 'on');

--- a/libs/ui/toggle/brain/src/lib/brn-toggle-group.component.ts
+++ b/libs/ui/toggle/brain/src/lib/brn-toggle-group.component.ts
@@ -1,14 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import {
-	Component,
-	booleanAttribute,
-	computed,
-	forwardRef,
-	input,
-	model,
-	output,
-	signal,
-} from '@angular/core';
+import { Component, booleanAttribute, computed, forwardRef, input, model, output, signal } from '@angular/core';
 import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { provideBrnToggleGroup } from './brn-toggle-group.token';
 import { BrnToggleDirective } from './brn-toggle.directive';
@@ -83,9 +74,6 @@ export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccesso
 	/** Emit event when the group value changes. */
 	readonly change = output<BrnButtonToggleChange<T>>();
 
-
-
-
 	writeValue(value: ToggleValue<T>): void {
 		this.value.set(value);
 	}
@@ -157,31 +145,31 @@ export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccesso
 				((currentValue ?? []) as T[]).filter((v) => v !== value),
 				source,
 			);
-		} else if (currentValue === value ) {
+		} else if (currentValue === value) {
 			this.emitSelectionChange(null, source);
 		}
 	}
 
-  /**
-   * @internal
-   * Determines whether a value is selected.
-   */
-  isSelected(value: T): boolean {
-    const currentValue = this.value();
+	/**
+	 * @internal
+	 * Determines whether a value is selected.
+	 */
+	isSelected(value: T): boolean {
+		const currentValue = this.value();
 
-    if (
-      currentValue == null ||
-      currentValue === undefined ||
-      (Array.isArray(currentValue) && currentValue.length === 0)
-    ) {
-      return false;
-    }
+		if (
+			currentValue == null ||
+			currentValue === undefined ||
+			(Array.isArray(currentValue) && currentValue.length === 0)
+		) {
+			return false;
+		}
 
-    if (this.multiple()) {
-      return (currentValue as T[])?.includes(value);
-    }
-    return currentValue === value;
-  }
+		if (this.multiple()) {
+			return (currentValue as T[])?.includes(value);
+		}
+		return currentValue === value;
+	}
 
 	/** Update the value of the group */
 	private emitSelectionChange(value: ToggleValue<T>, source: BrnToggleDirective<T>): void {

--- a/libs/ui/toggle/brain/src/lib/brn-toggle-group.component.ts
+++ b/libs/ui/toggle/brain/src/lib/brn-toggle-group.component.ts
@@ -1,12 +1,8 @@
 import { BooleanInput } from '@angular/cdk/coercion';
 import {
-	AfterViewInit,
 	Component,
-	OnChanges,
-	SimpleChanges,
 	booleanAttribute,
 	computed,
-	contentChildren,
 	forwardRef,
 	input,
 	model,
@@ -47,7 +43,7 @@ export class BrnButtonToggleChange<T = unknown> {
 		<ng-content />
 	`,
 })
-export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccessor, OnChanges, AfterViewInit {
+export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccessor {
 	/**
 	 * The method to be called in order to update ngModel.
 	 */
@@ -87,24 +83,11 @@ export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccesso
 	/** Emit event when the group value changes. */
 	readonly change = output<BrnButtonToggleChange<T>>();
 
-	/** The toggles within the group. */
-	private readonly _toggleButtons = contentChildren(BrnToggleDirective, { descendants: true });
 
-	ngAfterViewInit() {
-		// This is needed because we need access to our toggles through
-		// contentChildren to sync initial values set in writeValue before they are available, e.g. default values in a form
-		this.updateSelectionState();
-	}
 
-	ngOnChanges(changes: SimpleChanges): void {
-		if ('value' in changes) {
-			this.updateSelectionState();
-		}
-	}
 
 	writeValue(value: ToggleValue<T>): void {
 		this.value.set(value);
-		this.updateSelectionState();
 	}
 
 	registerOnChange(fn: (value: ToggleValue<T>) => void) {
@@ -163,7 +146,7 @@ export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccesso
 	 * Deselects a value.
 	 */
 	deselect(value: T, source: BrnToggleDirective<T>): void {
-		if (this.state().disabled() || !this.isSelected(value)) {
+		if (this.state().disabled() || !this.isSelected(value) || !this.canDeselect(value)) {
 			return;
 		}
 
@@ -174,47 +157,37 @@ export class BrnToggleGroupComponent<T = unknown> implements ControlValueAccesso
 				((currentValue ?? []) as T[]).filter((v) => v !== value),
 				source,
 			);
-		} else if (currentValue === value && this.canDeselect(value)) {
+		} else if (currentValue === value ) {
 			this.emitSelectionChange(null, source);
 		}
 	}
+
+  /**
+   * @internal
+   * Determines whether a value is selected.
+   */
+  isSelected(value: T): boolean {
+    const currentValue = this.value();
+
+    if (
+      currentValue == null ||
+      currentValue === undefined ||
+      (Array.isArray(currentValue) && currentValue.length === 0)
+    ) {
+      return false;
+    }
+
+    if (this.multiple()) {
+      return (currentValue as T[])?.includes(value);
+    }
+    return currentValue === value;
+  }
 
 	/** Update the value of the group */
 	private emitSelectionChange(value: ToggleValue<T>, source: BrnToggleDirective<T>): void {
 		this.value.set(value);
 		this._onChange(value);
 		this.change.emit(new BrnButtonToggleChange<T>(source, this.value()));
-
-		// propagate the change to the other toggles in the group
-		this.updateSelectionState();
-	}
-
-	/** Update the selection state in the toggle buttons. */
-	private updateSelectionState(): void {
-		for (const toggle of this._toggleButtons()) {
-			this.isSelected(toggle.value() as T) ? toggle.toggleOn() : toggle.toggleOff();
-		}
-	}
-
-	/**
-	 * @internal
-	 * Determines whether a value is selected.
-	 */
-	private isSelected(value: T): boolean {
-		const currentValue = this.value();
-
-		if (
-			currentValue == null ||
-			currentValue === undefined ||
-			(Array.isArray(currentValue) && currentValue.length === 0)
-		) {
-			return false;
-		}
-
-		if (this.multiple()) {
-			return (currentValue as T[])?.includes(value);
-		}
-		return currentValue === value;
 	}
 }
 

--- a/libs/ui/toggle/brain/src/lib/brn-toggle.directive.ts
+++ b/libs/ui/toggle/brain/src/lib/brn-toggle.directive.ts
@@ -43,7 +43,9 @@ export class BrnToggleDirective<T> {
 
 	/** Whether the toggle is in the on state. */
 	protected readonly isOn = computed(() => this._state() === 'on');
-	_state = computed(() => {
+
+	/** The current state that reflects the group state or the model state. */
+	protected readonly _state = computed(() => {
 		if (this.group) {
 			return this.group.isSelected(this.value() as T) ? 'on' : 'off';
 		}
@@ -61,6 +63,6 @@ export class BrnToggleDirective<T> {
 			}
 		} else {
 			this.state.set(this.isOn() ? 'off' : 'on');
-    }
+		}
 	}
 }

--- a/libs/ui/toggle/brain/src/lib/brn-toggle.directive.ts
+++ b/libs/ui/toggle/brain/src/lib/brn-toggle.directive.ts
@@ -9,7 +9,7 @@ import { injectBrnToggleGroup } from './brn-toggle-group.token';
 		id: 'id()',
 		'[attr.disabled]': 'disabled() || group?.disabled() ? true : null',
 		'[attr.data-disabled]': 'disabled() || group?.disabled() ? true : null',
-		'[attr.data-state]': 'state()',
+		'[attr.data-state]': '_state()',
 		'[attr.aria-pressed]': 'isOn()',
 		'(click)': 'toggle()',
 	},
@@ -33,7 +33,7 @@ export class BrnToggleDirective<T> {
 		transform: booleanAttribute,
 	});
 
-	/** The current state of the toggle. */
+	/** The current state of the toggle when not used in a group. */
 	readonly state = model<'on' | 'off'>('off');
 
 	/** Whether the toggle is responds to click events. */
@@ -42,55 +42,25 @@ export class BrnToggleDirective<T> {
 	});
 
 	/** Whether the toggle is in the on state. */
-	protected readonly isOn = computed(() => this.state() === 'on');
+	protected readonly isOn = computed(() => this._state() === 'on');
+	_state = computed(() => {
+		if (this.group) {
+			return this.group.isSelected(this.value() as T) ? 'on' : 'off';
+		}
+		return this.state();
+	});
 
 	toggle(): void {
 		if (this.disableToggleClick()) return;
 
-		if (this.state() === 'on') {
-			this.toggleOff();
+		if (this.group) {
+			if (this.isOn()) {
+				this.group.deselect(this.value() as T, this);
+			} else {
+				this.group.select(this.value() as T, this);
+			}
 		} else {
-			this.toggleOn();
-		}
-	}
-
-	/**
-	 * @internal
-	 */
-	toggleOff(): void {
-		// if we are already off, do nothing
-		if (this.state() === 'off' || (this.group && !this.group.canDeselect(this.value()))) return;
-
-		this.state.set('off');
-
-		const value = this.value();
-
-		if (value) {
-			this.group?.deselect(value, this);
-		}
-
-		// this is required as this may be called from writeValue (via ngModel/formControl)
-		// in the group which may not automatically run change detection
-		this.changeDetector.detectChanges();
-	}
-
-	/**
-	 * @internal
-	 */
-	toggleOn(): void {
-		// if we are already on, do nothing
-		if (this.state() === 'on') return;
-
-		this.state.set('on');
-
-		const value = this.value();
-
-		if (value) {
-			this.group?.select(value, this);
-		}
-
-		// this is required as this may be called from writeValue (via ngModel/formControl)
-		// in the group which may not automatically run change detection
-		this.changeDetector.detectChanges();
+			this.state.set(this.isOn() ? 'off' : 'on');
+    }
 	}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [x] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

There are some imperative calls to update the state.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

The state is derived in a more reactive way.
The state of the toggle is more coupled to the group (when inside a group).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
