### PR TITLE
refactor(tabs): use signal contentChildren for paginated tabs

### DIFF
--- a/libs/ui/tabs/helm/src/lib/hlm-tabs-paginated-list.component.ts
+++ b/libs/ui/tabs/helm/src/lib/hlm-tabs-paginated-list.component.ts
@@ -62,23 +62,25 @@ import { listVariants } from './hlm-tabs-list.component';
 	},
 })
 export class HlmTabsPaginatedListComponent extends BrnTabsPaginatedListDirective {
-	public _items = contentChildren(BrnTabsTriggerDirective, { descendants: false });
-	public _itemsChanges = toObservable(this._items);
+	public readonly _items = contentChildren(BrnTabsTriggerDirective, { descendants: false });
+	public readonly _itemsChanges = toObservable(this._items);
 
-	public _tabListContainer = viewChild.required<ElementRef<HTMLElement>>('tabListContainer');
-	public _tabList = viewChild.required<ElementRef<HTMLElement>>('tabList');
-	public _tabListInner = viewChild.required<ElementRef<HTMLElement>>('tabListInner');
-	public _nextPaginator = viewChild.required<ElementRef<HTMLElement>>('nextPaginator');
-	public _previousPaginator = viewChild.required<ElementRef<HTMLElement>>('previousPaginator');
+	public readonly _tabListContainer = viewChild.required<ElementRef<HTMLElement>>('tabListContainer');
+	public readonly _tabList = viewChild.required<ElementRef<HTMLElement>>('tabList');
+	public readonly _tabListInner = viewChild.required<ElementRef<HTMLElement>>('tabListInner');
+	public readonly _nextPaginator = viewChild.required<ElementRef<HTMLElement>>('nextPaginator');
+	public readonly _previousPaginator = viewChild.required<ElementRef<HTMLElement>>('previousPaginator');
 
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected _computedClass = computed(() => hlm('flex overflow-hidden relative flex-shrink-0', this.userClass()));
+	protected readonly _computedClass = computed(() =>
+		hlm('flex overflow-hidden relative flex-shrink-0', this.userClass()),
+	);
 
 	public readonly tabLisClass = input<ClassValue>('', { alias: 'class' });
-	protected _tabListClass = computed(() => hlm(listVariants(), this.tabLisClass()));
+	protected readonly _tabListClass = computed(() => hlm(listVariants(), this.tabLisClass()));
 
 	public readonly paginationButtonClass = input<ClassValue>('', { alias: 'class' });
-	protected _paginationButtonClass = computed(() =>
+	protected readonly _paginationButtonClass = computed(() =>
 		hlm(
 			'relative z-[2] select-none data-[pagination=previous]:pr-1 data-[pagination=next]:pl-1 disabled:cursor-default',
 			buttonVariants({ variant: 'ghost', size: 'icon' }),

--- a/libs/ui/tabs/helm/src/lib/hlm-tabs-paginated-list.component.ts
+++ b/libs/ui/tabs/helm/src/lib/hlm-tabs-paginated-list.component.ts
@@ -1,5 +1,6 @@
 import { CdkObserveContent } from '@angular/cdk/observers';
-import { Component, ContentChildren, type ElementRef, type QueryList, computed, input, viewChild } from '@angular/core';
+import { Component, type ElementRef, computed, contentChildren, input, viewChild } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { lucideChevronLeft, lucideChevronRight } from '@ng-icons/lucide';
 import { buttonVariants } from '@spartan-ng/ui-button-helm';
 import { hlm } from '@spartan-ng/ui-core';
@@ -61,8 +62,8 @@ import { listVariants } from './hlm-tabs-list.component';
 	},
 })
 export class HlmTabsPaginatedListComponent extends BrnTabsPaginatedListDirective {
-	@ContentChildren(BrnTabsTriggerDirective, { descendants: false })
-	public _items!: QueryList<BrnTabsTriggerDirective>;
+	public _items = contentChildren(BrnTabsTriggerDirective, { descendants: false });
+	public _itemsChanges = toObservable(this._items);
 
 	public _tabListContainer = viewChild.required<ElementRef<HTMLElement>>('tabListContainer');
 	public _tabList = viewChild.required<ElementRef<HTMLElement>>('tabList');

--- a/libs/ui/tabs/helm/src/lib/hlm-tabs-paginated-list.component.ts
+++ b/libs/ui/tabs/helm/src/lib/hlm-tabs-paginated-list.component.ts
@@ -73,7 +73,7 @@ export class HlmTabsPaginatedListComponent extends BrnTabsPaginatedListDirective
 
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('flex overflow-hidden relative flex-shrink-0', this.userClass()),
+		hlm('flex overflow-hidden relative gap-1 flex-shrink-0', this.userClass()),
 	);
 
 	public readonly tabLisClass = input<ClassValue>('', { alias: 'class' });
@@ -82,7 +82,7 @@ export class HlmTabsPaginatedListComponent extends BrnTabsPaginatedListDirective
 	public readonly paginationButtonClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _paginationButtonClass = computed(() =>
 		hlm(
-			'relative z-[2] select-none data-[pagination=previous]:pr-1 data-[pagination=next]:pl-1 disabled:cursor-default',
+			'relative z-[2] select-none disabled:cursor-default',
 			buttonVariants({ variant: 'ghost', size: 'icon' }),
 			this.paginationButtonClass(),
 		),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [X] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #436

## What is the new behavior?

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
`HlmTabsPaginatedListComponent` must be updated to use `contenChildren`.

## Other information

Tab changes work fine with keyboard and also with the arrow buttons.
