### PR TITLE
fix(pagination): styles

### DIFF
--- a/libs/ui/pagination/helm/src/lib/hlm-numbered-pagination.component.ts
+++ b/libs/ui/pagination/helm/src/lib/hlm-numbered-pagination.component.ts
@@ -35,7 +35,7 @@ import { HlmPaginationDirective } from './hlm-pagination.directive';
 				<ul hlmPaginationContent>
 					@if (showEdges() && !isFirstPageActive()) {
 						<li hlmPaginationItem (click)="goToPrevious()">
-							<hlm-pagination-previous />
+							<hlm-pagination-previous class="cursor-pointer" />
 						</li>
 					}
 
@@ -44,7 +44,12 @@ import { HlmPaginationDirective } from './hlm-pagination.directive';
 							@if (page === '...') {
 								<hlm-pagination-ellipsis />
 							} @else {
-								<a hlmPaginationLink [isActive]="currentPage() === page" (click)="currentPage.set(page)">
+								<a
+									hlmPaginationLink
+									class="cursor-pointer"
+									[isActive]="currentPage() === page"
+									(click)="currentPage.set(page)"
+								>
 									{{ page }}
 								</a>
 							}
@@ -53,7 +58,7 @@ import { HlmPaginationDirective } from './hlm-pagination.directive';
 
 					@if (showEdges() && !isLastPageActive()) {
 						<li hlmPaginationItem (click)="goToNext()">
-							<hlm-pagination-next />
+							<hlm-pagination-next class="cursor-pointer" />
 						</li>
 					}
 				</ul>

--- a/libs/ui/pagination/helm/src/lib/hlm-numbered-pagination.component.ts
+++ b/libs/ui/pagination/helm/src/lib/hlm-numbered-pagination.component.ts
@@ -35,7 +35,7 @@ import { HlmPaginationDirective } from './hlm-pagination.directive';
 				<ul hlmPaginationContent>
 					@if (showEdges() && !isFirstPageActive()) {
 						<li hlmPaginationItem (click)="goToPrevious()">
-							<hlm-pagination-previous class="cursor-pointer" />
+							<hlm-pagination-previous />
 						</li>
 					}
 
@@ -44,12 +44,7 @@ import { HlmPaginationDirective } from './hlm-pagination.directive';
 							@if (page === '...') {
 								<hlm-pagination-ellipsis />
 							} @else {
-								<a
-									hlmPaginationLink
-									class="cursor-pointer"
-									[isActive]="currentPage() === page"
-									(click)="currentPage.set(page)"
-								>
+								<a hlmPaginationLink [isActive]="currentPage() === page" (click)="currentPage.set(page)">
 									{{ page }}
 								</a>
 							}
@@ -58,7 +53,7 @@ import { HlmPaginationDirective } from './hlm-pagination.directive';
 
 					@if (showEdges() && !isLastPageActive()) {
 						<li hlmPaginationItem (click)="goToNext()">
-							<hlm-pagination-next class="cursor-pointer" />
+							<hlm-pagination-next />
 						</li>
 					}
 				</ul>

--- a/libs/ui/pagination/helm/src/lib/hlm-pagination-link.directive.ts
+++ b/libs/ui/pagination/helm/src/lib/hlm-pagination-link.directive.ts
@@ -47,6 +47,7 @@ export class HlmPaginationLinkDirective {
 	protected readonly _computedClass = computed(() =>
 		hlm(
 			paginationLinkVariants(),
+			this.link() === undefined ? 'cursor-pointer' : '',
 			buttonVariants({
 				variant: this.isActive() ? 'outline' : 'ghost',
 				size: this.size(),

--- a/libs/ui/pagination/helm/src/lib/hlm-pagination-previous.component.ts
+++ b/libs/ui/pagination/helm/src/lib/hlm-pagination-previous.component.ts
@@ -25,5 +25,5 @@ export class HlmPaginationPreviousComponent {
 	public readonly ariaLabel = input<string>('Go to previous page', { alias: 'aria-label' });
 	public readonly text = input<string>('Previous');
 
-	protected readonly _computedClass = computed(() => hlm('gap-1 pr-2.5', this.userClass()));
+	protected readonly _computedClass = computed(() => hlm('gap-1 pl-2.5', this.userClass()));
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [X] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Pagination previous had the wrong `pr-2.5` style applied.
Advanced Pagination hover styles showed the cursor text by default, because `RouterLink` is used as hostDirective for `hlmPaginationLink` and it does not receive a `link`.

## What is the new behavior?

Update pagination previous styles to `pl-2.5`.
Add `cursor-pointer` to advanced pagination to `hlmPaginationLink` and previous/next buttons.

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Breaking change because styles change and need to copied over

## Other information
