### PR TITLE
fix: resolving issue preventing cli from generating all components

### DIFF
--- a/libs/cli/src/generators/ui/generator.ts
+++ b/libs/cli/src/generators/ui/generator.ts
@@ -10,7 +10,7 @@ export default async function hlmUIGenerator(tree: Tree, options: HlmUIGenerator
 	const config = await getOrCreateConfig(tree, {
 		componentsPath: options.directory,
 	});
-	const availablePrimitives = await import('./supported-ui-libraries.json');
+	const availablePrimitives: ComponentDefintions = await import('./supported-ui-libraries.json').then((m) => m.default);
 	const availablePrimitiveNames = [...Object.keys(availablePrimitives), 'collapsible', 'menubar', 'contextmenu'];
 	let response: { primitives: string[] } = { primitives: [] };
 	if (options.name && availablePrimitiveNames.includes(options.name)) {
@@ -36,7 +36,7 @@ async function createPrimitiveLibraries(
 		primitives: string[];
 	},
 	availablePrimitiveNames: string[],
-	availablePrimitives,
+	availablePrimitives: ComponentDefintions,
 	tree: Tree,
 	options: HlmUIGeneratorSchema & { angularCli?: boolean },
 	config: Config,
@@ -114,3 +114,10 @@ const replaceContextAndMenuBar = async (primtivesToCreate: string[], silent = fa
 		primtivesToCreate.splice(menubarIndex, 1);
 	}
 };
+
+interface ComponentDefintions {
+	[componentName: string]: {
+		internalName: string;
+		peerDependencies: Record<string, string>;
+	};
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Selecting "all" in the CLI causes the task to fail:

![image](https://github.com/user-attachments/assets/cf122988-41e5-469e-bbc0-ecddbe5fd01c)

Originally posted on discord:
https://discord.com/channels/1145362148621557921/1314345787337080982

## What is the new behavior?

This was because importing json resulted in a `default` import being included in the returned data. As there is no `default` component this caused this to fail.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
