### PR TITLE
fix(accordion): can't write "space" symbol inside accordion

### DIFF
--- a/libs/brain/accordion/src/lib/brn-accordion.directive.spec.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.directive.spec.ts
@@ -45,7 +45,7 @@ describe('BrnAccordionDirective', () => {
 	const setupMulti = async () => {
 		const container = await render(
 			`
-      <div brnAccordion type="multi" orientation="horizontal" aria-label="acco">
+      <div brnAccordion type="multiple" orientation="horizontal" aria-label="acco">
         <div brnAccordionItem>
           <button brnAccordionTrigger aria-label="trigger">
             Is it accessible?
@@ -75,6 +75,31 @@ describe('BrnAccordionDirective', () => {
 			container,
 			triggers: screen.getAllByLabelText('trigger'),
 			accordion: screen.getByLabelText('acco'),
+		};
+	};
+	const setupWithInput = async () => {
+		const container = await render(
+			`
+      <div brnAccordion aria-label="acco">
+        <div brnAccordionItem>
+          <button brnAccordionTrigger aria-label="trigger">
+           	Enter your name
+          </button>
+
+          <input data-testid="accordion-input" />
+        </div>
+      </div>
+    `,
+			{
+				imports: [BrnAccordionDirective, BrnAccordionItemDirective, BrnAccordionTriggerDirective],
+			},
+		);
+		return {
+			user: userEvent.setup(),
+			container,
+			trigger: screen.getByLabelText('trigger'),
+			accordion: screen.getByLabelText('acco'),
+			input: screen.getByTestId('accordion-input'),
 		};
 	};
 	const validateOpenClosed = async (triggers: HTMLElement[], accordion: HTMLElement, openedTriggers: boolean[]) => {
@@ -151,6 +176,30 @@ describe('BrnAccordionDirective', () => {
 			await validateOpenClosed(triggers, accordion, [true, false, true]);
 			await user.click(triggers[1]);
 			await validateOpenClosed(triggers, accordion, [true, true, true]);
+		});
+	});
+	describe('accordion with input', () => {
+		it('should allow typing space', async () => {
+			const { user, trigger, input } = await setupWithInput();
+
+			// Open the accordion and tab to the input
+			await user.click(trigger);
+			await user.tab();
+
+			expect(trigger).toHaveAttribute('data-state', 'open');
+			expect(input).toHaveFocus();
+
+			// Type a name with a space
+			await user.type(input, 'John Doe');
+			expect(input).toHaveValue('John Doe');
+
+			// Go back to the trigger and hit space
+			await user.tab({shift: true})
+			await user.keyboard('[Space]');
+
+			// Trigger should be closed
+			expect(trigger).toHaveAttribute('data-state', 'closed');
+			expect(trigger).toHaveFocus();
 		});
 	});
 });

--- a/libs/brain/accordion/src/lib/brn-accordion.directive.spec.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.directive.spec.ts
@@ -194,7 +194,7 @@ describe('BrnAccordionDirective', () => {
 			expect(input).toHaveValue('John Doe');
 
 			// Go back to the trigger and hit space
-			await user.tab({shift: true})
+			await user.tab({ shift: true });
 			await user.keyboard('[Space]');
 
 			// Trigger should be closed

--- a/libs/brain/accordion/src/lib/brn-accordion.directive.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.directive.ts
@@ -144,9 +144,14 @@ export class BrnAccordionDirective implements AfterContentInit, OnDestroy {
 		if (this.orientation() === 'horizontal') {
 			this._keyManager.withHorizontalOrientation(this.dir() ?? 'ltr').withVerticalOrientation(false);
 		}
+
 		this._el.nativeElement.addEventListener('keydown', (event: KeyboardEvent) => {
-			this._keyManager?.onKeydown(event as KeyboardEvent);
-			this.preventDefaultEvents(event as KeyboardEvent);
+			const target = event.target as HTMLElement;
+
+			if(target.tagName === 'INPUT') return;
+
+			this._keyManager?.onKeydown(event);
+			this.preventDefaultEvents(event);
 		});
 		this._focusMonitor.monitor(this._el, true).subscribe((origin) => this._focused.set(origin !== null));
 	}
@@ -184,7 +189,7 @@ export class BrnAccordionDirective implements AfterContentInit, OnDestroy {
 
 		const keys =
 			this.orientation() === 'horizontal' ? HORIZONTAL_KEYS_TO_PREVENT_DEFAULT : VERTICAL_KEYS_TO_PREVENT_DEFAULT;
-		if (keys.includes(event.key as string) && event.code !== 'NumpadEnter') {
+		if (keys.includes(event.key) && event.code !== 'NumpadEnter') {
 			event.preventDefault();
 		}
 	}

--- a/libs/brain/accordion/src/lib/brn-accordion.directive.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.directive.ts
@@ -148,7 +148,7 @@ export class BrnAccordionDirective implements AfterContentInit, OnDestroy {
 		this._el.nativeElement.addEventListener('keydown', (event: KeyboardEvent) => {
 			const target = event.target as HTMLElement;
 
-			if(target.tagName === 'INPUT') return;
+			if (target.tagName === 'INPUT') return;
 
 			this._keyManager?.onKeydown(event);
 			this.preventDefaultEvents(event);

--- a/libs/ui/accordion/accordion.stories.ts
+++ b/libs/ui/accordion/accordion.stories.ts
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
 import { HlmIconComponent } from '../icon/helm/src';
 import { HlmAccordionImports } from './helm/src';
+import {HlmInputDirective} from "@spartan-ng/ui-input-helm";
 
 const meta: Meta<BrnAccordionDirective> = {
 	title: 'Accordion',
@@ -10,7 +11,7 @@ const meta: Meta<BrnAccordionDirective> = {
 	tags: ['autodocs'],
 	decorators: [
 		moduleMetadata({
-			imports: [BrnAccordionImports, HlmAccordionImports, HlmIconComponent],
+			imports: [BrnAccordionImports, HlmAccordionImports, HlmIconComponent, HlmInputDirective],
 		}),
 	],
 };
@@ -185,6 +186,26 @@ export const WithTapable: Story = {
 					</button>
 					<hlm-accordion-content>
 						<button data-testid="tapable-when-open">It should be when open</button>
+					</hlm-accordion-content>
+				</hlm-accordion-item>
+			</hlm-accordion>
+		`,
+	}),
+};
+
+export const AccordionWithInput: Story = {
+	render: () => ({
+		template: /* HTML */ `
+			<hlm-accordion>
+				<hlm-accordion-item>
+					<button hlmAccordionTrigger>
+						Enter your name
+						<hlm-icon hlmAccIcon />
+					</button>
+					<hlm-accordion-content>
+						<div class="px-1">
+							<input type="text" placeholder="Type your name here" hlmInput />
+						</div>
 					</hlm-accordion-content>
 				</hlm-accordion-item>
 			</hlm-accordion>

--- a/libs/ui/accordion/accordion.stories.ts
+++ b/libs/ui/accordion/accordion.stories.ts
@@ -1,9 +1,9 @@
 import { BrnAccordionDirective, BrnAccordionImports } from '@spartan-ng/brain/accordion';
+import { HlmInputDirective } from '@spartan-ng/ui-input-helm';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
 import { HlmIconComponent } from '../icon/helm/src';
 import { HlmAccordionImports } from './helm/src';
-import {HlmInputDirective} from "@spartan-ng/ui-input-helm";
 
 const meta: Meta<BrnAccordionDirective> = {
 	title: 'Accordion',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [X] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

It's not possible to type "space" inside an input located in the accordion component.

## What is the new behavior?

Prevent default is skipped if the target is an input allowing to type "space"

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

How to replicate:

```html
<hlm-accordion>
  <hlm-accordion-item>
    <button hlmAccordionTrigger>
      Is it accessible?

      <hlm-icon hlmAccIcon />
    </button>
    <hlm-accordion-content>
	<input />
	Yes. It adheres to the WAI-ARIA design pattern.
    </hlm-accordion-content>
  </hlm-accordion-item>
</hlm-accordion>
```
