### PR TITLE
fix(dropdown-menu): add missing outputs from CdkMenuTrigger to brnMenuTriggerFor (#533)

### DIFF
--- a/libs/brain/menu/src/lib/brn-menu-trigger.directive.ts
+++ b/libs/brain/menu/src/lib/brn-menu-trigger.directive.ts
@@ -6,7 +6,13 @@ import { BrnMenuAlign, getBrnMenuAlign } from './brn-menu-align';
 @Directive({
 	selector: '[brnMenuTriggerFor]',
 	standalone: true,
-	hostDirectives: [{ directive: CdkMenuTrigger, inputs: ['cdkMenuTriggerFor: brnMenuTriggerFor'] }],
+	hostDirectives: [
+		{
+			directive: CdkMenuTrigger,
+			inputs: ['cdkMenuTriggerFor: brnMenuTriggerFor'],
+			outputs: ['cdkMenuOpened: brnMenuOpened', 'cdkMenuClosed: brnMenuClosed'],
+		},
+	],
 })
 export class BrnMenuTriggerDirective {
 	private readonly _cdkTrigger = inject(CdkMenuTrigger, { host: true });


### PR DESCRIPTION
fix(dropdown-menu): add missing outputs from CdkMenuTrigger to brnMenuTriggerFor (#533)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [x] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Missing outputs `cdkMenuOpened` and `cdkMenuClosed` for `[brnMenuTriggerFor]`

Closes #533

add outputs to `brnMenuTriggerFor` with names outputs: `['cdkMenuOpened: brnMenuOpened', 'cdkMenuClosed: brnMenuClosed'],`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
