### PR TITLE
feat(accordion): add exportAs for brnAccordionItem and brnAccordion

### DIFF
--- a/libs/brain/accordion/src/lib/brn-accordion.directive.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.directive.ts
@@ -23,6 +23,7 @@ import { fromEvent } from 'rxjs';
 	host: {
 		'[attr.data-state]': 'state()',
 	},
+	exportAs: 'brnAccordionItem',
 })
 export class BrnAccordionItemDirective {
 	private static _itemIdGenerator = 0;
@@ -118,6 +119,7 @@ const VERTICAL_KEYS_TO_PREVENT_DEFAULT = ['ArrowUp', 'ArrowDown', 'PageDown', 'P
 		'[attr.data-state]': 'state()',
 		'[attr.data-orientation]': 'orientation()',
 	},
+	exportAs: 'brnAccordion',
 })
 export class BrnAccordionDirective implements AfterContentInit, OnDestroy {
 	private readonly _el = inject(ElementRef);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #535 

## What is the new behavior?

`BrnAccordionDirective` and `BrnAccordionItemDirective` can now be referenced by template variables with the added `exportAs` declaration.

e.g.
```html
<div brnAccordion hlm #accordion="brnAccordion">
  <!-- items -->
</div>

{{ accordion.openItemIds() }}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
It's a simple change, I'm not sure if (and how) this should be tested.