### PR TITLE
Tooltip signals input 2

### DIFF
--- a/libs/brain/tooltip/src/index.ts
+++ b/libs/brain/tooltip/src/index.ts
@@ -8,6 +8,7 @@ export * from './lib/brn-tooltip-content.component';
 export * from './lib/brn-tooltip-content.directive';
 export * from './lib/brn-tooltip-trigger.directive';
 export * from './lib/brn-tooltip.directive';
+export * from './lib/brn-tooltip.token';
 
 export const BrnTooltipImports = [
 	BrnTooltipDirective,

--- a/libs/brain/tooltip/src/lib/brn-tooltip-content.component.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-content.component.ts
@@ -4,20 +4,20 @@
  * Check them out! Give them a try! Leave a star! Their work is incredible!
  */
 
-import { NgTemplateOutlet, isPlatformBrowser } from '@angular/common';
+import { isPlatformBrowser, NgTemplateOutlet } from '@angular/common';
 import {
 	ChangeDetectionStrategy,
 	ChangeDetectorRef,
 	Component,
-	type ElementRef,
+	ElementRef,
+	inject,
 	type OnDestroy,
 	PLATFORM_ID,
 	Renderer2,
-	type TemplateRef,
-	ViewChild,
-	ViewEncapsulation,
-	inject,
 	signal,
+	type TemplateRef,
+	viewChild,
+	ViewEncapsulation,
 } from '@angular/core';
 import { Subject } from 'rxjs';
 
@@ -82,12 +82,7 @@ export class BrnTooltipContentComponent implements OnDestroy {
 	public _exitAnimationDuration = 0;
 
 	/** Reference to the internal tooltip element. */
-	@ViewChild('tooltip', {
-		// Use a static query here since we interact directly with
-		// the DOM which can happen before `ngAfterViewInit`.
-		static: true,
-	})
-	public _tooltip?: ElementRef<HTMLElement>;
+	public _tooltip = viewChild('tooltip', { read: ElementRef<HTMLElement> });
 
 	/** Whether interactions on the page should close the tooltip */
 	private _closeOnInteraction = false;
@@ -216,7 +211,7 @@ export class BrnTooltipContentComponent implements OnDestroy {
 		// We set the classes directly here ourselves so that toggling the tooltip state
 		// isn't bound by change detection. This allows us to hide it even if the
 		// view ref has been detached from the CD tree.
-		const tooltip = this._tooltip?.nativeElement;
+		const tooltip = this._tooltip()?.nativeElement;
 		if (!tooltip || !this._isBrowser) return;
 		this._renderer2.setStyle(tooltip, 'visibility', isVisible ? 'visible' : 'hidden');
 		if (isVisible) {
@@ -231,7 +226,7 @@ export class BrnTooltipContentComponent implements OnDestroy {
 		// We set the classes directly here ourselves so that toggling the tooltip state
 		// isn't bound by change detection. This allows us to hide it even if the
 		// view ref has been detached from the CD tree.
-		const tooltip = this._tooltip?.nativeElement;
+		const tooltip = this._tooltip()?.nativeElement;
 		if (!tooltip || !this._isBrowser) return;
 		this._renderer2.setAttribute(tooltip, 'data-side', side);
 		this._renderer2.setAttribute(tooltip, 'data-state', isVisible ? 'open' : 'closed');

--- a/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
@@ -11,9 +11,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { AriaDescriber, FocusMonitor } from '@angular/cdk/a11y';
-import { Directionality } from '@angular/cdk/bidi';
-import { hasModifierKey } from '@angular/cdk/keycodes';
+import {AriaDescriber, FocusMonitor} from '@angular/cdk/a11y';
+import {Directionality} from '@angular/cdk/bidi';
+import {hasModifierKey} from '@angular/cdk/keycodes';
 import {
 	type ConnectedPosition,
 	type ConnectionPositionPair,
@@ -27,9 +27,9 @@ import {
 	type ScrollStrategy,
 	type VerticalConnectionPos,
 } from '@angular/cdk/overlay';
-import { normalizePassiveListenerOptions, Platform } from '@angular/cdk/platform';
-import { ComponentPortal } from '@angular/cdk/portal';
-import { DOCUMENT } from '@angular/common';
+import {normalizePassiveListenerOptions, Platform} from '@angular/cdk/platform';
+import {ComponentPortal} from '@angular/cdk/portal';
+import {DOCUMENT} from '@angular/common';
 import {
 	type AfterViewInit,
 	booleanAttribute,
@@ -49,11 +49,11 @@ import {
 	untracked,
 	ViewContainerRef,
 } from '@angular/core';
-import { brnDevMode, computedPrevious } from '@spartan-ng/ui-core';
-import { Subject } from 'rxjs';
-import { take, takeUntil } from 'rxjs/operators';
-import { BrnTooltipContentComponent } from './brn-tooltip-content.component';
-import { BrnTooltipDirective } from './brn-tooltip.directive';
+import {brnDevMode, computedPrevious} from '@spartan-ng/ui-core';
+import {Subject} from 'rxjs';
+import {take, takeUntil} from 'rxjs/operators';
+import {BrnTooltipContentComponent} from './brn-tooltip-content.component';
+import {BrnTooltipDirective} from './brn-tooltip.directive';
 
 export type TooltipPosition = 'left' | 'right' | 'above' | 'below' | 'before' | 'after';
 export type TooltipTouchGestures = 'auto' | 'on' | 'off';
@@ -72,8 +72,8 @@ export const BRN_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER = {
 	deps: [Overlay],
 	useFactory:
 		(overlay: Overlay): (() => ScrollStrategy) =>
-		() =>
-			overlay.scrollStrategies.reposition({ scrollThrottle: SCROLL_THROTTLE_MS }),
+			() =>
+				overlay.scrollStrategies.reposition({scrollThrottle: SCROLL_THROTTLE_MS}),
 };
 
 export function BRN_TOOLTIP_DEFAULT_OPTIONS_FACTORY(): BrnTooltipOptions {
@@ -112,7 +112,7 @@ export interface BrnTooltipOptions {
 const PANEL_CLASS = 'tooltip-panel';
 
 /** Options used to bind passive event listeners. */
-const passiveListenerOptions = normalizePassiveListenerOptions({ passive: true });
+const passiveListenerOptions = normalizePassiveListenerOptions({passive: true});
 
 /**
  * Time between the user putting the pointer on a tooltip
@@ -135,12 +135,12 @@ const UNBOUNDED_ANCHOR_GAP = 8;
 	},
 })
 export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
-	private readonly _tooltipDirective = inject(BrnTooltipDirective, { optional: true });
+	private readonly _tooltipDirective = inject(BrnTooltipDirective, {optional: true});
 	private readonly _tooltipComponent = BrnTooltipContentComponent;
 	private readonly _cssClassPrefix: string = 'brn';
 	private readonly _destroyed = new Subject<void>();
 	private readonly _passiveListeners: (readonly [string, EventListenerOrEventListenerObject])[] = [];
-	private readonly _defaultOptions = inject(BRN_TOOLTIP_DEFAULT_OPTIONS, { optional: true });
+	private readonly _defaultOptions = inject(BRN_TOOLTIP_DEFAULT_OPTIONS, {optional: true});
 	private readonly _overlay = inject(Overlay);
 	private readonly _elementRef = inject(ElementRef<HTMLElement>);
 	private readonly _scrollDispatcher = inject(ScrollDispatcher);
@@ -174,31 +174,31 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 	 * instead of outside the element bounding box.
 	 */
 
-	public readonly positionAtOrigin = input(false, { transform: booleanAttribute });
+	public readonly positionAtOrigin = input(false, {transform: booleanAttribute});
 	private readonly _writeablePositionAtOrigin = computed(() => signal(this.positionAtOrigin()));
 	public readonly positionAtOriginState = computed(() => this._writeablePositionAtOrigin()());
 
 	/** Disables the display of the tooltip. */
 
-	public readonly brnTooltipDisabled = input(false, { transform: booleanAttribute });
+	public readonly brnTooltipDisabled = input(false, {transform: booleanAttribute});
 	private readonly _mutableBrnTooltipDisabled = computed(() => signal(this.brnTooltipDisabled()));
 	public readonly brnTooltipDisabledState = computed(() => this._mutableBrnTooltipDisabled()());
 
 	/** The default delay in ms before showing the tooltip after show is called */
 
-	public readonly showDelay = input(0, { transform: numberAttribute });
+	public readonly showDelay = input(0, {transform: numberAttribute});
 	public readonly mutableShowDelay = computed(() => signal(this.showDelay()));
 	public readonly showDelayState = computed(() => this.mutableShowDelay()());
 
 	/** The default delay in ms before hiding the tooltip after hide is called */
 
-	public readonly hideDelay = input(0, { transform: numberAttribute });
+	public readonly hideDelay = input(0, {transform: numberAttribute});
 	public readonly mutableHideDelay = computed(() => signal(this.hideDelay()));
 	public readonly hideDelayState = computed(() => this.mutableHideDelay()());
 
 	/** The default duration in ms that exit animation takes before hiding */
 
-	public readonly exitAnimationDuration = input(0, { transform: numberAttribute });
+	public readonly exitAnimationDuration = input(0, {transform: numberAttribute});
 	public readonly mutableExitAnimationDuration = computed(() => signal(this.exitAnimationDuration()));
 	public readonly exitAnimationDurationState = computed(() => this.mutableExitAnimationDuration()());
 
@@ -229,14 +229,14 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 
 	/** The message to be used to describe the aria in the tooltip */
 
-	public readonly ariaDescribedBy = input('', { alias: 'aria-describedby' });
+	public readonly ariaDescribedBy = input('', {alias: 'aria-describedby'});
 	public readonly mutableAriaDescribedBy = computed(() => signal(this.ariaDescribedBy()));
 	public readonly ariaDescribedByState = computed(() => this.mutableAriaDescribedBy()());
 	public readonly ariaDescribedByPrevious = computedPrevious(this.mutableAriaDescribedBy());
 
 	/** The content to be displayed in the tooltip */
 
-	public readonly brnTooltipTrigger = input<string | TemplateRef<unknown> | null>(null, { alias: 'brnTooltipTrigger' });
+	public readonly brnTooltipTrigger = input<string | TemplateRef<unknown> | null>(null);
 	public readonly mutableBrnTooltipTrigger = computed(() => signal(this.brnTooltipTrigger()));
 	public readonly brnTooltipTriggerState = computed(() => this.mutableBrnTooltipTrigger()());
 
@@ -273,7 +273,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 						this.mutableBrnTooltipTrigger().set(this._tooltipDirective.tooltipTemplate());
 					}
 				},
-				{ allowSignalWrites: true },
+				{allowSignalWrites: true},
 			);
 		}
 		this._initBrnTooltipTriggerEffect();
@@ -351,7 +351,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 					});
 				}
 			},
-			{ allowSignalWrites: true },
+			{allowSignalWrites: true},
 		);
 	}
 
@@ -365,7 +365,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 					this._updateTooltipContent();
 				}
 			},
-			{ allowSignalWrites: true },
+			{allowSignalWrites: true},
 		);
 	}
 
@@ -560,8 +560,8 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 		const overlay = this._getOverlayPosition();
 
 		position.withPositions([
-			this._addOffset({ ...origin.main, ...overlay.main }),
-			this._addOffset({ ...origin.fallback, ...overlay.fallback }),
+			this._addOffset({...origin.main, ...overlay.main}),
+			this._addOffset({...origin.fallback, ...overlay.fallback}),
 		]);
 	}
 
@@ -593,20 +593,20 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 		let originPosition: OriginConnectionPosition;
 
 		if (position === 'above' || position === 'below') {
-			originPosition = { originX: 'center', originY: position === 'above' ? 'top' : 'bottom' };
+			originPosition = {originX: 'center', originY: position === 'above' ? 'top' : 'bottom'};
 		} else if (position === 'before' || (position === 'left' && isLtr) || (position === 'right' && !isLtr)) {
-			originPosition = { originX: 'start', originY: 'center' };
+			originPosition = {originX: 'start', originY: 'center'};
 		} else if (position === 'after' || (position === 'right' && isLtr) || (position === 'left' && !isLtr)) {
-			originPosition = { originX: 'end', originY: 'center' };
+			originPosition = {originX: 'end', originY: 'center'};
 		} else if (typeof isDevMode() === 'undefined' || isDevMode()) {
 			throw getBrnTooltipInvalidPositionError(position);
 		}
 
-		const { x, y } = this._invertPosition(originPosition!.originX, originPosition!.originY);
+		const {x, y} = this._invertPosition(originPosition!.originX, originPosition!.originY);
 
 		return {
 			main: originPosition!,
-			fallback: { originX: x, originY: y },
+			fallback: {originX: x, originY: y},
 		};
 	}
 
@@ -617,22 +617,22 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 		let overlayPosition: OverlayConnectionPosition;
 
 		if (position === 'above') {
-			overlayPosition = { overlayX: 'center', overlayY: 'bottom' };
+			overlayPosition = {overlayX: 'center', overlayY: 'bottom'};
 		} else if (position === 'below') {
-			overlayPosition = { overlayX: 'center', overlayY: 'top' };
+			overlayPosition = {overlayX: 'center', overlayY: 'top'};
 		} else if (position === 'before' || (position === 'left' && isLtr) || (position === 'right' && !isLtr)) {
-			overlayPosition = { overlayX: 'end', overlayY: 'center' };
+			overlayPosition = {overlayX: 'end', overlayY: 'center'};
 		} else if (position === 'after' || (position === 'right' && isLtr) || (position === 'left' && !isLtr)) {
-			overlayPosition = { overlayX: 'start', overlayY: 'center' };
+			overlayPosition = {overlayX: 'start', overlayY: 'center'};
 		} else if (typeof isDevMode() === 'undefined' || isDevMode()) {
 			throw getBrnTooltipInvalidPositionError(position);
 		}
 
-		const { x, y } = this._invertPosition(overlayPosition!.overlayX, overlayPosition!.overlayY);
+		const {x, y} = this._invertPosition(overlayPosition!.overlayX, overlayPosition!.overlayY);
 
 		return {
 			main: overlayPosition!,
-			fallback: { overlayX: x, overlayY: y },
+			fallback: {overlayX: x, overlayY: y},
 		};
 	}
 
@@ -668,12 +668,12 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 			}
 		}
 
-		return { x, y };
+		return {x, y};
 	}
 
 	/** Updates the class on the overlay panel based on the current position of the tooltip. */
 	private _updateCurrentPositionClass(connectionPair: ConnectionPositionPair): void {
-		const { overlayY, originX, originY } = connectionPair;
+		const {overlayY, originX, originY} = connectionPair;
 		let newPosition: TooltipPosition;
 
 		// If the overlay is in the middle along the Y axis,
@@ -730,7 +730,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 				'touchstart',
 				(event) => {
 					const touch = (event as TouchEvent).targetTouches?.[0];
-					const origin = touch ? { x: touch.clientX, y: touch.clientY } : undefined;
+					const origin = touch ? {x: touch.clientX, y: touch.clientY} : undefined;
 					// Note that it's important that we don't `preventDefault` here,
 					// because it can prevent click events from firing on the element.
 					this._setupPointerExitEventsIfNeeded();

--- a/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
@@ -11,9 +11,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AriaDescriber, FocusMonitor} from '@angular/cdk/a11y';
-import {Directionality} from '@angular/cdk/bidi';
-import {hasModifierKey} from '@angular/cdk/keycodes';
+import { AriaDescriber, FocusMonitor } from '@angular/cdk/a11y';
+import { Directionality } from '@angular/cdk/bidi';
+import { hasModifierKey } from '@angular/cdk/keycodes';
 import {
 	type ConnectedPosition,
 	type ConnectionPositionPair,
@@ -27,9 +27,9 @@ import {
 	type ScrollStrategy,
 	type VerticalConnectionPos,
 } from '@angular/cdk/overlay';
-import {normalizePassiveListenerOptions, Platform} from '@angular/cdk/platform';
-import {ComponentPortal} from '@angular/cdk/portal';
-import {DOCUMENT} from '@angular/common';
+import { normalizePassiveListenerOptions, Platform } from '@angular/cdk/platform';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { DOCUMENT } from '@angular/common';
 import {
 	type AfterViewInit,
 	booleanAttribute,
@@ -49,11 +49,11 @@ import {
 	untracked,
 	ViewContainerRef,
 } from '@angular/core';
-import {brnDevMode, computedPrevious} from '@spartan-ng/ui-core';
-import {Subject} from 'rxjs';
-import {take, takeUntil} from 'rxjs/operators';
-import {BrnTooltipContentComponent} from './brn-tooltip-content.component';
-import {BrnTooltipDirective} from './brn-tooltip.directive';
+import { brnDevMode, computedPrevious } from '@spartan-ng/ui-core';
+import { Subject } from 'rxjs';
+import { take, takeUntil } from 'rxjs/operators';
+import { BrnTooltipContentComponent } from './brn-tooltip-content.component';
+import { BrnTooltipDirective } from './brn-tooltip.directive';
 
 export type TooltipPosition = 'left' | 'right' | 'above' | 'below' | 'before' | 'after';
 export type TooltipTouchGestures = 'auto' | 'on' | 'off';
@@ -72,8 +72,8 @@ export const BRN_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER = {
 	deps: [Overlay],
 	useFactory:
 		(overlay: Overlay): (() => ScrollStrategy) =>
-			() =>
-				overlay.scrollStrategies.reposition({scrollThrottle: SCROLL_THROTTLE_MS}),
+		() =>
+			overlay.scrollStrategies.reposition({ scrollThrottle: SCROLL_THROTTLE_MS }),
 };
 
 export function BRN_TOOLTIP_DEFAULT_OPTIONS_FACTORY(): BrnTooltipOptions {
@@ -112,7 +112,7 @@ export interface BrnTooltipOptions {
 const PANEL_CLASS = 'tooltip-panel';
 
 /** Options used to bind passive event listeners. */
-const passiveListenerOptions = normalizePassiveListenerOptions({passive: true});
+const passiveListenerOptions = normalizePassiveListenerOptions({ passive: true });
 
 /**
  * Time between the user putting the pointer on a tooltip
@@ -135,12 +135,12 @@ const UNBOUNDED_ANCHOR_GAP = 8;
 	},
 })
 export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
-	private readonly _tooltipDirective = inject(BrnTooltipDirective, {optional: true});
+	private readonly _tooltipDirective = inject(BrnTooltipDirective, { optional: true });
 	private readonly _tooltipComponent = BrnTooltipContentComponent;
 	private readonly _cssClassPrefix: string = 'brn';
 	private readonly _destroyed = new Subject<void>();
 	private readonly _passiveListeners: (readonly [string, EventListenerOrEventListenerObject])[] = [];
-	private readonly _defaultOptions = inject(BRN_TOOLTIP_DEFAULT_OPTIONS, {optional: true});
+	private readonly _defaultOptions = inject(BRN_TOOLTIP_DEFAULT_OPTIONS, { optional: true });
 	private readonly _overlay = inject(Overlay);
 	private readonly _elementRef = inject(ElementRef<HTMLElement>);
 	private readonly _scrollDispatcher = inject(ScrollDispatcher);
@@ -174,31 +174,31 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 	 * instead of outside the element bounding box.
 	 */
 
-	public readonly positionAtOrigin = input(false, {transform: booleanAttribute});
+	public readonly positionAtOrigin = input(false, { transform: booleanAttribute });
 	private readonly _writeablePositionAtOrigin = computed(() => signal(this.positionAtOrigin()));
 	public readonly positionAtOriginState = computed(() => this._writeablePositionAtOrigin()());
 
 	/** Disables the display of the tooltip. */
 
-	public readonly brnTooltipDisabled = input(false, {transform: booleanAttribute});
+	public readonly brnTooltipDisabled = input(false, { transform: booleanAttribute });
 	private readonly _mutableBrnTooltipDisabled = computed(() => signal(this.brnTooltipDisabled()));
 	public readonly brnTooltipDisabledState = computed(() => this._mutableBrnTooltipDisabled()());
 
 	/** The default delay in ms before showing the tooltip after show is called */
 
-	public readonly showDelay = input(0, {transform: numberAttribute});
+	public readonly showDelay = input(0, { transform: numberAttribute });
 	public readonly mutableShowDelay = computed(() => signal(this.showDelay()));
 	public readonly showDelayState = computed(() => this.mutableShowDelay()());
 
 	/** The default delay in ms before hiding the tooltip after hide is called */
 
-	public readonly hideDelay = input(0, {transform: numberAttribute});
+	public readonly hideDelay = input(0, { transform: numberAttribute });
 	public readonly mutableHideDelay = computed(() => signal(this.hideDelay()));
 	public readonly hideDelayState = computed(() => this.mutableHideDelay()());
 
 	/** The default duration in ms that exit animation takes before hiding */
 
-	public readonly exitAnimationDuration = input(0, {transform: numberAttribute});
+	public readonly exitAnimationDuration = input(0, { transform: numberAttribute });
 	public readonly mutableExitAnimationDuration = computed(() => signal(this.exitAnimationDuration()));
 	public readonly exitAnimationDurationState = computed(() => this.mutableExitAnimationDuration()());
 
@@ -229,7 +229,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 
 	/** The message to be used to describe the aria in the tooltip */
 
-	public readonly ariaDescribedBy = input('', {alias: 'aria-describedby'});
+	public readonly ariaDescribedBy = input('', { alias: 'aria-describedby' });
 	public readonly mutableAriaDescribedBy = computed(() => signal(this.ariaDescribedBy()));
 	public readonly ariaDescribedByState = computed(() => this.mutableAriaDescribedBy()());
 	public readonly ariaDescribedByPrevious = computedPrevious(this.mutableAriaDescribedBy());
@@ -273,7 +273,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 						this.mutableBrnTooltipTrigger().set(this._tooltipDirective.tooltipTemplate());
 					}
 				},
-				{allowSignalWrites: true},
+				{ allowSignalWrites: true },
 			);
 		}
 		this._initBrnTooltipTriggerEffect();
@@ -351,7 +351,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 					});
 				}
 			},
-			{allowSignalWrites: true},
+			{ allowSignalWrites: true },
 		);
 	}
 
@@ -365,7 +365,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 					this._updateTooltipContent();
 				}
 			},
-			{allowSignalWrites: true},
+			{ allowSignalWrites: true },
 		);
 	}
 
@@ -560,8 +560,8 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 		const overlay = this._getOverlayPosition();
 
 		position.withPositions([
-			this._addOffset({...origin.main, ...overlay.main}),
-			this._addOffset({...origin.fallback, ...overlay.fallback}),
+			this._addOffset({ ...origin.main, ...overlay.main }),
+			this._addOffset({ ...origin.fallback, ...overlay.fallback }),
 		]);
 	}
 
@@ -593,20 +593,20 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 		let originPosition: OriginConnectionPosition;
 
 		if (position === 'above' || position === 'below') {
-			originPosition = {originX: 'center', originY: position === 'above' ? 'top' : 'bottom'};
+			originPosition = { originX: 'center', originY: position === 'above' ? 'top' : 'bottom' };
 		} else if (position === 'before' || (position === 'left' && isLtr) || (position === 'right' && !isLtr)) {
-			originPosition = {originX: 'start', originY: 'center'};
+			originPosition = { originX: 'start', originY: 'center' };
 		} else if (position === 'after' || (position === 'right' && isLtr) || (position === 'left' && !isLtr)) {
-			originPosition = {originX: 'end', originY: 'center'};
+			originPosition = { originX: 'end', originY: 'center' };
 		} else if (typeof isDevMode() === 'undefined' || isDevMode()) {
 			throw getBrnTooltipInvalidPositionError(position);
 		}
 
-		const {x, y} = this._invertPosition(originPosition!.originX, originPosition!.originY);
+		const { x, y } = this._invertPosition(originPosition!.originX, originPosition!.originY);
 
 		return {
 			main: originPosition!,
-			fallback: {originX: x, originY: y},
+			fallback: { originX: x, originY: y },
 		};
 	}
 
@@ -617,22 +617,22 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 		let overlayPosition: OverlayConnectionPosition;
 
 		if (position === 'above') {
-			overlayPosition = {overlayX: 'center', overlayY: 'bottom'};
+			overlayPosition = { overlayX: 'center', overlayY: 'bottom' };
 		} else if (position === 'below') {
-			overlayPosition = {overlayX: 'center', overlayY: 'top'};
+			overlayPosition = { overlayX: 'center', overlayY: 'top' };
 		} else if (position === 'before' || (position === 'left' && isLtr) || (position === 'right' && !isLtr)) {
-			overlayPosition = {overlayX: 'end', overlayY: 'center'};
+			overlayPosition = { overlayX: 'end', overlayY: 'center' };
 		} else if (position === 'after' || (position === 'right' && isLtr) || (position === 'left' && !isLtr)) {
-			overlayPosition = {overlayX: 'start', overlayY: 'center'};
+			overlayPosition = { overlayX: 'start', overlayY: 'center' };
 		} else if (typeof isDevMode() === 'undefined' || isDevMode()) {
 			throw getBrnTooltipInvalidPositionError(position);
 		}
 
-		const {x, y} = this._invertPosition(overlayPosition!.overlayX, overlayPosition!.overlayY);
+		const { x, y } = this._invertPosition(overlayPosition!.overlayX, overlayPosition!.overlayY);
 
 		return {
 			main: overlayPosition!,
-			fallback: {overlayX: x, overlayY: y},
+			fallback: { overlayX: x, overlayY: y },
 		};
 	}
 
@@ -668,12 +668,12 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 			}
 		}
 
-		return {x, y};
+		return { x, y };
 	}
 
 	/** Updates the class on the overlay panel based on the current position of the tooltip. */
 	private _updateCurrentPositionClass(connectionPair: ConnectionPositionPair): void {
-		const {overlayY, originX, originY} = connectionPair;
+		const { overlayY, originX, originY } = connectionPair;
 		let newPosition: TooltipPosition;
 
 		// If the overlay is in the middle along the Y axis,
@@ -730,7 +730,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 				'touchstart',
 				(event) => {
 					const touch = (event as TouchEvent).targetTouches?.[0];
-					const origin = touch ? {x: touch.clientX, y: touch.clientY} : undefined;
+					const origin = touch ? { x: touch.clientX, y: touch.clientY } : undefined;
 					// Note that it's important that we don't `preventDefault` here,
 					// because it can prevent click events from firing on the element.
 					this._setupPointerExitEventsIfNeeded();

--- a/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
@@ -11,9 +11,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AriaDescriber, FocusMonitor} from '@angular/cdk/a11y';
-import {Directionality} from '@angular/cdk/bidi';
-import {hasModifierKey} from '@angular/cdk/keycodes';
+import { AriaDescriber, FocusMonitor } from '@angular/cdk/a11y';
+import { Directionality } from '@angular/cdk/bidi';
+import { hasModifierKey } from '@angular/cdk/keycodes';
 import {
 	type ConnectedPosition,
 	type ConnectionPositionPair,
@@ -27,9 +27,9 @@ import {
 	type ScrollStrategy,
 	type VerticalConnectionPos,
 } from '@angular/cdk/overlay';
-import {normalizePassiveListenerOptions, Platform} from '@angular/cdk/platform';
-import {ComponentPortal} from '@angular/cdk/portal';
-import {DOCUMENT} from '@angular/common';
+import { normalizePassiveListenerOptions, Platform } from '@angular/cdk/platform';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { DOCUMENT } from '@angular/common';
 import {
 	type AfterViewInit,
 	booleanAttribute,
@@ -49,11 +49,11 @@ import {
 	untracked,
 	ViewContainerRef,
 } from '@angular/core';
-import {brnDevMode, computedPrevious} from '@spartan-ng/ui-core';
-import {Subject} from 'rxjs';
-import {take, takeUntil} from 'rxjs/operators';
-import {BrnTooltipContentComponent} from './brn-tooltip-content.component';
-import {BrnTooltipDirective} from './brn-tooltip.directive';
+import { brnDevMode, computedPrevious } from '@spartan-ng/ui-core';
+import { Subject } from 'rxjs';
+import { take, takeUntil } from 'rxjs/operators';
+import { BrnTooltipContentComponent } from './brn-tooltip-content.component';
+import { BrnTooltipDirective } from './brn-tooltip.directive';
 
 export type TooltipPosition = 'left' | 'right' | 'above' | 'below' | 'before' | 'after';
 export type TooltipTouchGestures = 'auto' | 'on' | 'off';
@@ -72,8 +72,8 @@ export const BRN_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER = {
 	deps: [Overlay],
 	useFactory:
 		(overlay: Overlay): (() => ScrollStrategy) =>
-			() =>
-				overlay.scrollStrategies.reposition({scrollThrottle: SCROLL_THROTTLE_MS}),
+		() =>
+			overlay.scrollStrategies.reposition({ scrollThrottle: SCROLL_THROTTLE_MS }),
 };
 
 export function BRN_TOOLTIP_DEFAULT_OPTIONS_FACTORY(): BrnTooltipOptions {
@@ -112,7 +112,7 @@ export interface BrnTooltipOptions {
 const PANEL_CLASS = 'tooltip-panel';
 
 /** Options used to bind passive event listeners. */
-const passiveListenerOptions = normalizePassiveListenerOptions({passive: true});
+const passiveListenerOptions = normalizePassiveListenerOptions({ passive: true });
 
 /**
  * Time between the user putting the pointer on a tooltip
@@ -135,12 +135,12 @@ const UNBOUNDED_ANCHOR_GAP = 8;
 	},
 })
 export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
-	private readonly _tooltipDirective = inject(BrnTooltipDirective, {optional: true});
+	private readonly _tooltipDirective = inject(BrnTooltipDirective, { optional: true });
 	private readonly _tooltipComponent = BrnTooltipContentComponent;
 	private readonly _cssClassPrefix: string = 'brn';
 	private readonly _destroyed = new Subject<void>();
 	private readonly _passiveListeners: (readonly [string, EventListenerOrEventListenerObject])[] = [];
-	private readonly _defaultOptions = inject(BRN_TOOLTIP_DEFAULT_OPTIONS, {optional: true});
+	private readonly _defaultOptions = inject(BRN_TOOLTIP_DEFAULT_OPTIONS, { optional: true });
 	private readonly _overlay = inject(Overlay);
 	private readonly _elementRef = inject(ElementRef<HTMLElement>);
 	private readonly _scrollDispatcher = inject(ScrollDispatcher);
@@ -165,7 +165,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 
 	/** Allows the user to define the position of the tooltip relative to the parent element */
 
-	public readonly position = input<TooltipPosition>('above',);
+	public readonly position = input<TooltipPosition>('above');
 	private readonly _writeablePosition = computed(() => signal(this.position()));
 	public readonly positionState = computed(() => this._writeablePosition()());
 
@@ -174,34 +174,33 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 	 * instead of outside the element bounding box.
 	 */
 
-	public readonly positionAtOrigin = input(false, {transform: booleanAttribute});
+	public readonly positionAtOrigin = input(false, { transform: booleanAttribute });
 	private readonly _writeablePositionAtOrigin = computed(() => signal(this.positionAtOrigin()));
 	public readonly positionAtOriginState = computed(() => this._writeablePositionAtOrigin()());
 
 	/** Disables the display of the tooltip. */
 
-	public readonly brnTooltipDisabled = input(false, {transform: booleanAttribute});
+	public readonly brnTooltipDisabled = input(false, { transform: booleanAttribute });
 	private readonly _mutableBrnTooltipDisabled = computed(() => signal(this.brnTooltipDisabled()));
 	public readonly brnTooltipDisabledState = computed(() => this._mutableBrnTooltipDisabled()());
 
 	/** The default delay in ms before showing the tooltip after show is called */
 
-	public readonly showDelay = input(0, {transform: numberAttribute});
+	public readonly showDelay = input(0, { transform: numberAttribute });
 	public readonly mutableShowDelay = computed(() => signal(this.showDelay()));
 	public readonly showDelayState = computed(() => this.mutableShowDelay()());
 
 	/** The default delay in ms before hiding the tooltip after hide is called */
 
-	public readonly hideDelay = input(0, {transform: numberAttribute});
+	public readonly hideDelay = input(0, { transform: numberAttribute });
 	public readonly mutableHideDelay = computed(() => signal(this.hideDelay()));
 	public readonly hideDelayState = computed(() => this.mutableHideDelay()());
 
 	/** The default duration in ms that exit animation takes before hiding */
 
-	public readonly exitAnimationDuration = input(0, {transform: numberAttribute});
+	public readonly exitAnimationDuration = input(0, { transform: numberAttribute });
 	public readonly mutableExitAnimationDuration = computed(() => signal(this.exitAnimationDuration()));
 	public readonly exitAnimationDurationState = computed(() => this.mutableExitAnimationDuration()());
-
 
 	/** The default delay in ms before hiding the tooltip after hide is called */
 
@@ -230,14 +229,14 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 
 	/** The message to be used to describe the aria in the tooltip */
 
-	public readonly ariaDescribedBy = input('', {alias: 'aria-describedby'});
+	public readonly ariaDescribedBy = input('', { alias: 'aria-describedby' });
 	public readonly mutableAriaDescribedBy = computed(() => signal(this.ariaDescribedBy()));
 	public readonly ariaDescribedByState = computed(() => this.mutableAriaDescribedBy()());
 	public readonly ariaDescribedByPrevious = computedPrevious(this.mutableAriaDescribedBy());
 
 	/** The content to be displayed in the tooltip */
 
-	public readonly brnTooltipTrigger = input<string | TemplateRef<unknown> | null>(null, {alias: 'brnTooltipTrigger'});
+	public readonly brnTooltipTrigger = input<string | TemplateRef<unknown> | null>(null, { alias: 'brnTooltipTrigger' });
 	public readonly mutableBrnTooltipTrigger = computed(() => signal(this.brnTooltipTrigger()));
 	public readonly brnTooltipTriggerState = computed(() => this.mutableBrnTooltipTrigger()());
 
@@ -274,7 +273,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 						this.mutableBrnTooltipTrigger().set(this._tooltipDirective.tooltipTemplate());
 					}
 				},
-				{allowSignalWrites: true},
+				{ allowSignalWrites: true },
 			);
 		}
 		this._initBrnTooltipTriggerEffect();
@@ -352,7 +351,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 					});
 				}
 			},
-			{allowSignalWrites: true},
+			{ allowSignalWrites: true },
 		);
 	}
 
@@ -366,7 +365,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 					this._updateTooltipContent();
 				}
 			},
-			{allowSignalWrites: true},
+			{ allowSignalWrites: true },
 		);
 	}
 
@@ -561,8 +560,8 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 		const overlay = this._getOverlayPosition();
 
 		position.withPositions([
-			this._addOffset({...origin.main, ...overlay.main}),
-			this._addOffset({...origin.fallback, ...overlay.fallback}),
+			this._addOffset({ ...origin.main, ...overlay.main }),
+			this._addOffset({ ...origin.fallback, ...overlay.fallback }),
 		]);
 	}
 
@@ -594,20 +593,20 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 		let originPosition: OriginConnectionPosition;
 
 		if (position === 'above' || position === 'below') {
-			originPosition = {originX: 'center', originY: position === 'above' ? 'top' : 'bottom'};
+			originPosition = { originX: 'center', originY: position === 'above' ? 'top' : 'bottom' };
 		} else if (position === 'before' || (position === 'left' && isLtr) || (position === 'right' && !isLtr)) {
-			originPosition = {originX: 'start', originY: 'center'};
+			originPosition = { originX: 'start', originY: 'center' };
 		} else if (position === 'after' || (position === 'right' && isLtr) || (position === 'left' && !isLtr)) {
-			originPosition = {originX: 'end', originY: 'center'};
+			originPosition = { originX: 'end', originY: 'center' };
 		} else if (typeof isDevMode() === 'undefined' || isDevMode()) {
 			throw getBrnTooltipInvalidPositionError(position);
 		}
 
-		const {x, y} = this._invertPosition(originPosition!.originX, originPosition!.originY);
+		const { x, y } = this._invertPosition(originPosition!.originX, originPosition!.originY);
 
 		return {
 			main: originPosition!,
-			fallback: {originX: x, originY: y},
+			fallback: { originX: x, originY: y },
 		};
 	}
 
@@ -618,22 +617,22 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 		let overlayPosition: OverlayConnectionPosition;
 
 		if (position === 'above') {
-			overlayPosition = {overlayX: 'center', overlayY: 'bottom'};
+			overlayPosition = { overlayX: 'center', overlayY: 'bottom' };
 		} else if (position === 'below') {
-			overlayPosition = {overlayX: 'center', overlayY: 'top'};
+			overlayPosition = { overlayX: 'center', overlayY: 'top' };
 		} else if (position === 'before' || (position === 'left' && isLtr) || (position === 'right' && !isLtr)) {
-			overlayPosition = {overlayX: 'end', overlayY: 'center'};
+			overlayPosition = { overlayX: 'end', overlayY: 'center' };
 		} else if (position === 'after' || (position === 'right' && isLtr) || (position === 'left' && !isLtr)) {
-			overlayPosition = {overlayX: 'start', overlayY: 'center'};
+			overlayPosition = { overlayX: 'start', overlayY: 'center' };
 		} else if (typeof isDevMode() === 'undefined' || isDevMode()) {
 			throw getBrnTooltipInvalidPositionError(position);
 		}
 
-		const {x, y} = this._invertPosition(overlayPosition!.overlayX, overlayPosition!.overlayY);
+		const { x, y } = this._invertPosition(overlayPosition!.overlayX, overlayPosition!.overlayY);
 
 		return {
 			main: overlayPosition!,
-			fallback: {overlayX: x, overlayY: y},
+			fallback: { overlayX: x, overlayY: y },
 		};
 	}
 
@@ -669,12 +668,12 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 			}
 		}
 
-		return {x, y};
+		return { x, y };
 	}
 
 	/** Updates the class on the overlay panel based on the current position of the tooltip. */
 	private _updateCurrentPositionClass(connectionPair: ConnectionPositionPair): void {
-		const {overlayY, originX, originY} = connectionPair;
+		const { overlayY, originX, originY } = connectionPair;
 		let newPosition: TooltipPosition;
 
 		// If the overlay is in the middle along the Y axis,
@@ -701,7 +700,12 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 	/** Binds the pointer events to the tooltip trigger. */
 	private _setupPointerEnterEventsIfNeeded(): void {
 		// Optimization: Defer hooking up events if there's no content or the tooltip is disabled.
-		if (this.brnTooltipDisabledState() || !this.brnTooltipTriggerState || !this._viewInitialized || this._passiveListeners.length) {
+		if (
+			this.brnTooltipDisabledState() ||
+			!this.brnTooltipTriggerState ||
+			!this._viewInitialized ||
+			this._passiveListeners.length
+		) {
 			return;
 		}
 
@@ -726,7 +730,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 				'touchstart',
 				(event) => {
 					const touch = (event as TouchEvent).targetTouches?.[0];
-					const origin = touch ? {x: touch.clientX, y: touch.clientY} : undefined;
+					const origin = touch ? { x: touch.clientX, y: touch.clientY } : undefined;
 					// Note that it's important that we don't `preventDefault` here,
 					// because it can prevent click events from firing on the element.
 					this._setupPointerExitEventsIfNeeded();

--- a/libs/brain/tooltip/src/lib/brn-tooltip.token.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip.token.ts
@@ -1,0 +1,45 @@
+import { inject, InjectionToken, ValueProvider } from '@angular/core';
+import { TooltipPosition, TooltipTouchGestures } from './brn-tooltip-trigger.directive';
+
+export interface BrnTooltipOptions {
+	/** Default delay when the tooltip is shown. */
+	showDelay: number;
+	/** Default delay when the tooltip is hidden. */
+	hideDelay: number;
+	/** Default delay when hiding the tooltip on a touch device. */
+	touchendHideDelay: number;
+	/** Default exit animation duration for the tooltip. */
+	exitAnimationDuration: number;
+	/** Default touch gesture handling for tooltips. */
+	touchGestures?: TooltipTouchGestures;
+	/** Default position for tooltips. */
+	position?: TooltipPosition;
+	/**
+	 * Default value for whether tooltips should be positioned near the click or touch origin
+	 * instead of outside the element bounding box.
+	 */
+	positionAtOrigin?: boolean;
+	/** Disables the ability for the user to interact with the tooltip element. */
+	disableTooltipInteractivity?: boolean;
+	/** Default classes for the tooltip content. */
+	tooltipContentClasses?: string;
+}
+export const defaultOptions: BrnTooltipOptions = {
+	showDelay: 0,
+	hideDelay: 0,
+	exitAnimationDuration: 0,
+	touchendHideDelay: 1500,
+};
+
+const BRN_TOOLTIP_DEFAULT_OPTIONS = new InjectionToken<BrnTooltipOptions>('brn-tooltip-default-options', {
+	providedIn: 'root',
+	factory: () => defaultOptions,
+});
+
+export function provideBrnTooltipDefaultOptions(options: Partial<BrnTooltipOptions>): ValueProvider {
+	return { provide: BRN_TOOLTIP_DEFAULT_OPTIONS, useValue: { ...defaultOptions, ...options } };
+}
+
+export function injectBrnTooltipDefaultOptions(): BrnTooltipOptions {
+	return inject(BRN_TOOLTIP_DEFAULT_OPTIONS, { optional: true }) ?? defaultOptions;
+}

--- a/libs/ui/core/src/index.ts
+++ b/libs/ui/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/brain/computed-previous';
 export * from './lib/brain/custom-element-class-settable';
 export * from './lib/brain/dev-mode';
 export * from './lib/brain/exposes-side';

--- a/libs/ui/core/src/lib/brain/computed-previous.spec.ts
+++ b/libs/ui/core/src/lib/brain/computed-previous.spec.ts
@@ -1,44 +1,32 @@
-import { Component, signal } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
 import { computedPrevious } from './computed-previous';
 
 describe(computedPrevious.name, () => {
-	@Component({ standalone: true, template: '{{previous()}}' })
-	class TestComponent {
-		public readonly value = signal(0);
-		public readonly previous = computedPrevious(this.value);
-	}
-
-	function setup() {
-		const fixture = TestBed.createComponent(TestComponent);
-		fixture.detectChanges();
-		return fixture.componentInstance;
-	}
-
 	it('should work properly', () => {
-		const cmp = setup();
+		const value = signal(0);
+		const previous = computedPrevious(() => value());
 
-		expect(cmp.value()).toEqual(0);
-		expect(cmp.previous()).toEqual(0);
+		expect(value()).toEqual(0);
+		expect(previous()).toEqual(0);
 
-		cmp.value.set(1);
+		value.set(1);
 
-		expect(cmp.value()).toEqual(1);
-		expect(cmp.previous()).toEqual(0);
+		expect(value()).toEqual(1);
+		expect(previous()).toEqual(0);
 
-		cmp.value.set(2);
+		value.set(2);
 
-		expect(cmp.value()).toEqual(2);
-		expect(cmp.previous()).toEqual(1);
+		expect(value()).toEqual(2);
+		expect(previous()).toEqual(1);
 
-		cmp.value.set(2);
+		value.set(2);
 
-		expect(cmp.value()).toEqual(2);
-		expect(cmp.previous()).toEqual(1);
+		expect(value()).toEqual(2);
+		expect(previous()).toEqual(1);
 
-		cmp.value.set(3);
+		value.set(3);
 
-		expect(cmp.value()).toEqual(3);
-		expect(cmp.previous()).toEqual(2);
+		expect(value()).toEqual(3);
+		expect(previous()).toEqual(2);
 	});
 });

--- a/libs/ui/core/src/lib/brain/computed-previous.spec.ts
+++ b/libs/ui/core/src/lib/brain/computed-previous.spec.ts
@@ -1,0 +1,44 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { computedPrevious } from './computed-previous';
+
+describe(computedPrevious.name, () => {
+	@Component({ standalone: true, template: '{{previous()}}' })
+	class TestComponent {
+		public readonly value = signal(0);
+		public readonly previous = computedPrevious(this.value);
+	}
+
+	function setup() {
+		const fixture = TestBed.createComponent(TestComponent);
+		fixture.detectChanges();
+		return fixture.componentInstance;
+	}
+
+	it('should work properly', () => {
+		const cmp = setup();
+
+		expect(cmp.value()).toEqual(0);
+		expect(cmp.previous()).toEqual(0);
+
+		cmp.value.set(1);
+
+		expect(cmp.value()).toEqual(1);
+		expect(cmp.previous()).toEqual(0);
+
+		cmp.value.set(2);
+
+		expect(cmp.value()).toEqual(2);
+		expect(cmp.previous()).toEqual(1);
+
+		cmp.value.set(2);
+
+		expect(cmp.value()).toEqual(2);
+		expect(cmp.previous()).toEqual(1);
+
+		cmp.value.set(3);
+
+		expect(cmp.value()).toEqual(3);
+		expect(cmp.previous()).toEqual(2);
+	});
+});

--- a/libs/ui/core/src/lib/brain/computed-previous.ts
+++ b/libs/ui/core/src/lib/brain/computed-previous.ts
@@ -31,15 +31,15 @@ import { computed, type Signal, untracked } from '@angular/core';
  * // Previous value: 1
  *```
  *
- * @param s Signal to compute previous value for
- * @returns Signal that emits previous value of `s`
+ * @param computation Computation to compute previous value for
+ * @returns Signal that emits previous value of `computation`
  */
-export function computedPrevious<T>(s: Signal<T>): Signal<T> {
+export function computedPrevious<T>(computation: () => T): Signal<T> {
 	let current = null as T;
-	let previous = untracked(() => s()); // initial value is the current value
+	let previous = untracked(() => computation()); // initial value is the current value
 
 	return computed(() => {
-		current = s();
+		current = computation();
 		const result = previous;
 		previous = current;
 		return result;

--- a/libs/ui/core/src/lib/brain/computed-previous.ts
+++ b/libs/ui/core/src/lib/brain/computed-previous.ts
@@ -1,0 +1,47 @@
+import { computed, type Signal, untracked } from '@angular/core';
+
+/**
+ * Returns a signal that emits the previous value of the given signal.
+ * The first time the signal is emitted, the previous value will be the same as the current value.
+ *
+ * @example
+ * ```ts
+ * const value = signal(0);
+ * const previous = computedPrevious(value);
+ *
+ * effect(() => {
+ *  console.log('Current value:', value());
+ *  console.log('Previous value:', previous());
+ * });
+ *
+ * Logs:
+ * // Current value: 0
+ * // Previous value: 0
+ *
+ * value.set(1);
+ *
+ * Logs:
+ * // Current value: 1
+ * // Previous value: 0
+ *
+ * value.set(2);
+ *
+ * Logs:
+ * // Current value: 2
+ * // Previous value: 1
+ *```
+ *
+ * @param s Signal to compute previous value for
+ * @returns Signal that emits previous value of `s`
+ */
+export function computedPrevious<T>(s: Signal<T>): Signal<T> {
+	let current = null as T;
+	let previous = untracked(() => s()); // initial value is the current value
+
+	return computed(() => {
+		current = s();
+		const result = previous;
+		previous = current;
+		return result;
+	});
+}

--- a/libs/ui/tooltip/helm/src/lib/hlm-tooltip-trigger.directive.ts
+++ b/libs/ui/tooltip/helm/src/lib/hlm-tooltip-trigger.directive.ts
@@ -1,14 +1,30 @@
-import { Directive, inject, Input, type TemplateRef } from '@angular/core';
-import { BrnTooltipTriggerDirective } from '@spartan-ng/brain/tooltip';
+import { Directive } from '@angular/core';
+import { BrnTooltipTriggerDirective, provideBrnTooltipDefaultOptions } from '@spartan-ng/brain/tooltip';
+
+const DEFAULT_TOOLTIP_CONTENT_CLASSES =
+	'overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md fade-in-0 zoom-in-95 ' +
+	'data-[state=open]:animate-in ' +
+	'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ' +
+	'data-[side=below]:slide-in-from-top-2 data-[side=above]:slide-in-from-bottom-2 ' +
+	'data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 ';
 
 @Directive({
 	selector: '[hlmTooltipTrigger]',
 	standalone: true,
+	providers: [
+		provideBrnTooltipDefaultOptions({
+			showDelay: 150,
+			hideDelay: 300,
+			exitAnimationDuration: 150,
+			tooltipContentClasses: DEFAULT_TOOLTIP_CONTENT_CLASSES,
+		}),
+	],
 	hostDirectives: [
 		{
 			directive: BrnTooltipTriggerDirective,
 			inputs: [
 				'brnTooltipDisabled: hlmTooltipDisabled',
+				'brnTooltipTrigger: hlmTooltipTrigger',
 				'aria-describedby',
 				'position',
 				'positionAtOrigin',
@@ -20,28 +36,4 @@ import { BrnTooltipTriggerDirective } from '@spartan-ng/brain/tooltip';
 		},
 	],
 })
-export class HlmTooltipTriggerDirective {
-	private readonly _brnTooltipTrigger: BrnTooltipTriggerDirective = inject(BrnTooltipTriggerDirective, { host: true });
-
-	constructor() {
-		if (this._brnTooltipTrigger) {
-			this._brnTooltipTrigger.mutableExitAnimationDuration().set(150);
-			this._brnTooltipTrigger.mutableHideDelay().set(300);
-			this._brnTooltipTrigger.mutableShowDelay().set(150);
-			this._brnTooltipTrigger
-				.mutableTooltipContentClasses()
-				.set(
-					'overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md fade-in-0 zoom-in-95 ' +
-						'data-[state=open]:animate-in ' +
-						'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ' +
-						'data-[side=below]:slide-in-from-top-2 data-[side=above]:slide-in-from-bottom-2 ' +
-						'data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 ',
-				);
-		}
-	}
-
-	@Input()
-	public set hlmTooltipTrigger(value: string | TemplateRef<unknown> | null) {
-		this._brnTooltipTrigger.mutableBrnTooltipTrigger().set(value);
-	}
-}
+export class HlmTooltipTriggerDirective {}

--- a/libs/ui/tooltip/helm/src/lib/hlm-tooltip-trigger.directive.ts
+++ b/libs/ui/tooltip/helm/src/lib/hlm-tooltip-trigger.directive.ts
@@ -1,5 +1,5 @@
-import { Directive, Input, type TemplateRef, inject } from '@angular/core';
-import { BrnTooltipTriggerDirective } from '@spartan-ng/brain/tooltip';
+import {Directive, inject, Input, type TemplateRef} from '@angular/core';
+import {BrnTooltipTriggerDirective} from '@spartan-ng/brain/tooltip';
 
 @Directive({
 	selector: '[hlmTooltipTrigger]',
@@ -21,27 +21,27 @@ import { BrnTooltipTriggerDirective } from '@spartan-ng/brain/tooltip';
 	],
 })
 export class HlmTooltipTriggerDirective {
-	private readonly _brnTooltipTrigger: BrnTooltipTriggerDirective = inject(BrnTooltipTriggerDirective, { host: true });
+	private readonly _brnTooltipTrigger: BrnTooltipTriggerDirective = inject(BrnTooltipTriggerDirective, {host: true});
 
 	constructor() {
 		if (this._brnTooltipTrigger) {
-			this._brnTooltipTrigger.exitAnimationDurationState().set(150);
-			this._brnTooltipTrigger.hideDelayState().set(300);
-			this._brnTooltipTrigger.showDelayState().set(150);
+			this._brnTooltipTrigger.mutableExitAnimationDuration().set(150);
+			this._brnTooltipTrigger.mutableHideDelay().set(300);
+			this._brnTooltipTrigger.mutableShowDelay().set(150);
 			this._brnTooltipTrigger
-				.tooltipContentClassesState()
+				.mutableTooltipContentClasses()
 				.set(
 					'overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md fade-in-0 zoom-in-95 ' +
-						'data-[state=open]:animate-in ' +
-						'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ' +
-						'data-[side=below]:slide-in-from-top-2 data-[side=above]:slide-in-from-bottom-2 ' +
-						'data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 ',
+					'data-[state=open]:animate-in ' +
+					'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ' +
+					'data-[side=below]:slide-in-from-top-2 data-[side=above]:slide-in-from-bottom-2 ' +
+					'data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 ',
 				);
 		}
 	}
 
 	@Input()
 	public set hlmTooltipTrigger(value: string | TemplateRef<unknown> | null) {
-		this._brnTooltipTrigger.contentState().set(value);
+		this._brnTooltipTrigger.mutableBrnTooltipTrigger().set(value);
 	}
 }

--- a/libs/ui/tooltip/helm/src/lib/hlm-tooltip-trigger.directive.ts
+++ b/libs/ui/tooltip/helm/src/lib/hlm-tooltip-trigger.directive.ts
@@ -25,20 +25,23 @@ export class HlmTooltipTriggerDirective {
 
 	constructor() {
 		if (this._brnTooltipTrigger) {
-			this._brnTooltipTrigger.exitAnimationDuration = 150;
-			this._brnTooltipTrigger.hideDelay = 300;
-			this._brnTooltipTrigger.showDelay = 150;
-			this._brnTooltipTrigger.tooltipContentClasses =
-				'overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md fade-in-0 zoom-in-95 ' +
-				'data-[state=open]:animate-in ' +
-				'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ' +
-				'data-[side=below]:slide-in-from-top-2 data-[side=above]:slide-in-from-bottom-2 ' +
-				'data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 ';
+			this._brnTooltipTrigger.exitAnimationDurationState().set(150);
+			this._brnTooltipTrigger.hideDelayState().set(300);
+			this._brnTooltipTrigger.showDelayState().set(150);
+			this._brnTooltipTrigger
+				.tooltipContentClassesState()
+				.set(
+					'overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md fade-in-0 zoom-in-95 ' +
+						'data-[state=open]:animate-in ' +
+						'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ' +
+						'data-[side=below]:slide-in-from-top-2 data-[side=above]:slide-in-from-bottom-2 ' +
+						'data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 ',
+				);
 		}
 	}
 
 	@Input()
 	public set hlmTooltipTrigger(value: string | TemplateRef<unknown> | null) {
-		this._brnTooltipTrigger.content = value;
+		this._brnTooltipTrigger.contentState().set(value);
 	}
 }

--- a/libs/ui/tooltip/helm/src/lib/hlm-tooltip-trigger.directive.ts
+++ b/libs/ui/tooltip/helm/src/lib/hlm-tooltip-trigger.directive.ts
@@ -1,5 +1,5 @@
-import {Directive, inject, Input, type TemplateRef} from '@angular/core';
-import {BrnTooltipTriggerDirective} from '@spartan-ng/brain/tooltip';
+import { Directive, inject, Input, type TemplateRef } from '@angular/core';
+import { BrnTooltipTriggerDirective } from '@spartan-ng/brain/tooltip';
 
 @Directive({
 	selector: '[hlmTooltipTrigger]',
@@ -21,7 +21,7 @@ import {BrnTooltipTriggerDirective} from '@spartan-ng/brain/tooltip';
 	],
 })
 export class HlmTooltipTriggerDirective {
-	private readonly _brnTooltipTrigger: BrnTooltipTriggerDirective = inject(BrnTooltipTriggerDirective, {host: true});
+	private readonly _brnTooltipTrigger: BrnTooltipTriggerDirective = inject(BrnTooltipTriggerDirective, { host: true });
 
 	constructor() {
 		if (this._brnTooltipTrigger) {
@@ -32,10 +32,10 @@ export class HlmTooltipTriggerDirective {
 				.mutableTooltipContentClasses()
 				.set(
 					'overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md fade-in-0 zoom-in-95 ' +
-					'data-[state=open]:animate-in ' +
-					'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ' +
-					'data-[side=below]:slide-in-from-top-2 data-[side=above]:slide-in-from-bottom-2 ' +
-					'data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 ',
+						'data-[state=open]:animate-in ' +
+						'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ' +
+						'data-[side=below]:slide-in-from-top-2 data-[side=above]:slide-in-from-bottom-2 ' +
+						'data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 ',
 				);
 		}
 	}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [x] tooltip
- [ ] typography

## What is the current behavior?

This PR builds ontop of #503 but replaces the computed pattern with injecting the default options.

Closes #430 

## What is the new behavior?

Inputs and viewchild are now signal inputs and queries. 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

it is possible, that this will introduce a break, like the other input signal changes.

## Other information
