### PR TITLE
docs: add cdk styles import to manual installation section

### DIFF
--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
@@ -200,6 +200,11 @@ module.exports = {
 "
 			/>
 			<p class="${hlmP}">
+				If you have manually added the variables to your style entrypoint, don't forget to import the Angular CDK
+				overlay styles too.
+			</p>
+			<spartan-code class="mb-6 mt-4" code="@import '@angular/cdk/overlay-prebuilt.css';" />
+			<p class="${hlmP}">
 				Also, make sure to check out the theming section to better understand the convention behind them and learn how
 				to customize your theme.
 			</p>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Running the Nx plugin or Angular CLI will add the overlay styles to styles entrypoint.  But the section for manual installation doesn't provide any information for Angular CDK overlay styles.

## What is the new behavior?

Reminder to import the CDK overlay styles is now added to the UI installation docs below the manually adding variables section.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I've been following the manual installation recently and spent some time debugging the dropdown menu component due to lack of CDK overlay styles import.  I think it could be helpful if we clarify this.
