### PR TITLE
feature(dropdown-menu): add brnMenuTriggerData

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(dropdown-menu)/dropdown-menu.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(dropdown-menu)/dropdown-menu.page.ts
@@ -13,6 +13,7 @@ import { TabsCliComponent } from '../../../../shared/layout/tabs-cli.component';
 import { TabsComponent } from '../../../../shared/layout/tabs.component';
 import { metaWith } from '../../../../shared/meta/meta.util';
 import { DropdownPreviewComponent, defaultCode, defaultImports, defaultSkeleton } from './dropdown-menu.preview';
+import { DropdownWithContextPreviewComponent, dropdownWithContextCode } from './dropdown-with-context.preview';
 import { DropdownWithStatePreviewComponent, dropdownWithStateCode } from './dropdown-with-state.preview';
 
 export const routeMeta: RouteMeta = {
@@ -40,6 +41,7 @@ export const routeMeta: RouteMeta = {
 		DropdownPreviewComponent,
 		DropdownPreviewComponent,
 		DropdownWithStatePreviewComponent,
+		DropdownWithContextPreviewComponent,
 	],
 	template: `
 		<section spartanMainSection>
@@ -73,6 +75,14 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="dropdownWithStateCode" />
 			</spartan-tabs>
 
+			<h3 id="examples__context" class="${hlmH4} mb-2 mt-6">Passing context to menu</h3>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-dropdown-with-context />
+				</div>
+				<spartan-code secondTab [code]="dropdownWithContextCode" />
+			</spartan-tabs>
+
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="hover-card" label="Hover Card" />
 				<spartan-page-bottom-nav-link direction="previous" href="dialog" label="Dialog" />
@@ -86,4 +96,5 @@ export default class DropdownPageComponent {
 	protected readonly defaultSkeleton = defaultSkeleton;
 	protected readonly defaultImports = defaultImports;
 	protected readonly dropdownWithStateCode = dropdownWithStateCode;
+	protected readonly dropdownWithContextCode = dropdownWithContextCode;
 }

--- a/apps/app/src/app/pages/(components)/components/(dropdown-menu)/dropdown-with-context.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(dropdown-menu)/dropdown-with-context.preview.ts
@@ -1,0 +1,246 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideUndo2 } from '@ng-icons/lucide';
+import { BrnMenuTriggerDirective } from '@spartan-ng/brain/menu';
+import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
+import { HlmIconDirective } from '@spartan-ng/ui-icon-helm';
+import {
+	HlmMenuComponent,
+	HlmMenuGroupComponent,
+	HlmMenuItemCheckComponent,
+	HlmMenuItemCheckboxDirective,
+	HlmMenuItemDirective,
+	HlmMenuItemIconDirective,
+	HlmMenuItemRadioComponent,
+	HlmMenuItemRadioDirective,
+	HlmMenuItemSubIndicatorComponent,
+	HlmMenuLabelComponent,
+	HlmMenuSeparatorComponent,
+	HlmMenuShortcutComponent,
+	HlmSubMenuComponent,
+} from '@spartan-ng/ui-menu-helm';
+
+@Component({
+	selector: 'spartan-dropdown-with-context',
+	standalone: true,
+	imports: [
+		BrnMenuTriggerDirective,
+
+		HlmMenuComponent,
+		HlmSubMenuComponent,
+		HlmMenuItemDirective,
+		HlmMenuItemSubIndicatorComponent,
+		HlmMenuLabelComponent,
+		HlmMenuShortcutComponent,
+		HlmMenuSeparatorComponent,
+		HlmMenuItemIconDirective,
+		HlmMenuItemCheckComponent,
+		HlmMenuItemRadioComponent,
+		HlmMenuGroupComponent,
+		HlmMenuItemRadioDirective,
+		HlmMenuItemCheckboxDirective,
+
+		HlmButtonDirective,
+		NgIcon,
+		HlmIconDirective,
+	],
+	providers: [provideIcons({ lucideUndo2 })],
+	template: `
+		<div class="flex w-full items-center justify-center pt-[20%]">
+			<button
+				hlmBtn
+				variant="outline"
+				align="center"
+				[brnMenuTriggerFor]="menu"
+				[brnMenuTriggerData]="{ $implicit: { data: 'SomeContext' } }"
+			>
+				Open
+			</button>
+		</div>
+		<ng-template #menu let-ctx>
+			<hlm-menu class="w-56">
+				<hlm-menu-group>
+					<hlm-menu-label>Context</hlm-menu-label>
+					<button hlmMenuItem inset>{{ ctx.data }}</button>
+				</hlm-menu-group>
+				<hlm-menu-group>
+					<hlm-menu-label>Appearance</hlm-menu-label>
+
+					<button hlmMenuItemCheckbox [checked]="isPanel" (triggered)="isPanel = !isPanel">
+						<hlm-menu-item-check />
+						<span>Panel</span>
+					</button>
+
+					<button hlmMenuItemCheckbox disabled [checked]="isActivityBar" (triggered)="isActivityBar = !isActivityBar">
+						<hlm-menu-item-check />
+						<span>Activity Bar</span>
+					</button>
+
+					<button hlmMenuItemCheckbox [checked]="isStatusBar" (triggered)="isStatusBar = !isStatusBar">
+						<hlm-menu-item-check />
+						<span>Status Bar</span>
+					</button>
+				</hlm-menu-group>
+
+				<hlm-menu-separator />
+
+				<hlm-menu-label>Panel Position</hlm-menu-label>
+
+				<hlm-menu-group>
+					@for (size of panelPositions; track size) {
+						<button hlmMenuItemRadio [checked]="size === selectedPosition" (triggered)="selectedPosition = size">
+							<hlm-menu-item-radio />
+							<span>{{ size }}</span>
+						</button>
+					}
+				</hlm-menu-group>
+
+				<hlm-menu-separator />
+
+				<button hlmMenuItem (triggered)="reset()">
+					<ng-icon hlm name="lucideUndo2" hlmMenuIcon />
+					Reset
+				</button>
+			</hlm-menu>
+		</ng-template>
+	`,
+})
+export class DropdownWithContextPreviewComponent {
+	public isStatusBar = false;
+	public isPanel = false;
+	public isActivityBar = false;
+
+	public panelPositions = ['Top', 'Bottom', 'Right', 'Left'] as const;
+	public selectedPosition: (typeof this.panelPositions)[number] | undefined = 'Bottom';
+
+	reset() {
+		this.isStatusBar = false;
+		this.isPanel = false;
+		this.isActivityBar = false;
+		this.selectedPosition = 'Bottom';
+	}
+}
+
+export const dropdownWithContextCode = `
+import { Component } from '@angular/core';
+import { provideIcons } from '@ng-icons/core';
+import { lucideUndo2 } from '@ng-icons/lucide';
+import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
+import { HlmIconDirective } from '@spartan-ng/ui-icon-helm';
+import { BrnMenuTriggerDirective } from '@spartan-ng/brain/menu';
+import {
+  HlmMenuComponent,
+  HlmMenuGroupComponent,
+  HlmMenuItemCheckboxDirective,
+  HlmMenuItemCheckComponent,
+  HlmMenuItemDirective,
+  HlmMenuItemIconDirective,
+  HlmMenuItemRadioComponent,
+  HlmMenuItemRadioDirective,
+  HlmMenuItemSubIndicatorComponent,
+  HlmMenuLabelComponent,
+  HlmMenuSeparatorComponent,
+  HlmMenuShortcutComponent,
+  HlmSubMenuComponent,
+} from '@spartan-ng/ui-menu-helm';
+
+@Component({
+  selector: 'spartan-dropdown-with-context',
+  standalone: true,
+  imports: [
+    BrnMenuTriggerDirective,
+
+    HlmMenuComponent,
+    HlmSubMenuComponent,
+    HlmMenuItemDirective,
+    HlmMenuItemSubIndicatorComponent,
+    HlmMenuLabelComponent,
+    HlmMenuShortcutComponent,
+    HlmMenuSeparatorComponent,
+    HlmMenuItemIconDirective,
+    HlmMenuItemCheckComponent,
+    HlmMenuItemRadioComponent,
+    HlmMenuGroupComponent,
+    HlmMenuItemRadioDirective,
+    HlmMenuItemCheckboxDirective,
+
+    HlmButtonDirective,
+    HlmIconDirective,
+  ],
+  providers: [provideIcons({ lucideUndo2 })],
+  template: \`
+    <div class="flex w-full items-center justify-center pt-[20%]">
+      <button 
+        hlmBtn 
+        variant="outline"
+        align="center"
+        [brnMenuTriggerFor]="menu"
+        [brnMenuTriggerData]="{ $implicit: { data: 'SomeContext' } }"
+      >
+        Open
+      </button>
+    </div>
+    <ng-template #menu let-ctx>
+      <hlm-menu class="w-56">
+        <hlm-menu-group>
+          <hlm-menu-label>Context</hlm-menu-label>
+          <button hlmMenuItem> {{ ctx.data }} </button>
+        </hlm-menu-group>
+        <hlm-menu-group>
+          <hlm-menu-label>Appearance</hlm-menu-label>
+
+          <button hlmMenuItemCheckbox [checked]="isPanel" (triggered)="isPanel = !isPanel">
+            <hlm-menu-item-check />
+            <span>Panel</span>
+          </button>
+
+          <button hlmMenuItemCheckbox disabled [checked]="isActivityBar" (triggered)="isActivityBar = !isActivityBar">
+            <hlm-menu-item-check />
+            <span>Activity Bar</span>
+          </button>
+
+          <button hlmMenuItemCheckbox [checked]="isStatusBar" (triggered)="isStatusBar = !isStatusBar">
+            <hlm-menu-item-check />
+            <span>Status Bar</span>
+          </button>
+        </hlm-menu-group>
+
+        <hlm-menu-separator />
+
+        <hlm-menu-label>Panel Position</hlm-menu-label>
+
+        <hlm-menu-group>
+          @for (size of panelPositions; track size) {
+            <button hlmMenuItemRadio [checked]="size === selectedPosition" (triggered)="selectedPosition = size">
+              <hlm-menu-item-radio />
+              <span>{{ size }}</span>
+            </button>
+          }
+        </hlm-menu-group>
+
+        <hlm-menu-separator />
+
+        <button hlmMenuItem (triggered)="reset()">
+          <ng-icon hlm name="lucideUndo2" hlmMenuIcon />
+          Reset
+        </button>
+      </hlm-menu>
+    </ng-template>
+  \`,
+})
+export class DropdownWithContextPreviewComponent {
+  isStatusBar = false;
+  isPanel = false;
+  isActivityBar = false;
+
+  panelPositions = ['Top', 'Bottom', 'Right', 'Left'] as const;
+  selectedPosition: (typeof this.panelPositions)[number] | undefined = 'Bottom';
+
+  reset() {
+    this.isStatusBar = false;
+    this.isPanel = false;
+    this.isActivityBar = false;
+    this.selectedPosition = 'Bottom';
+  }
+}
+`;

--- a/libs/brain/menu/src/lib/brn-menu-trigger.directive.ts
+++ b/libs/brain/menu/src/lib/brn-menu-trigger.directive.ts
@@ -9,7 +9,7 @@ import { BrnMenuAlign, getBrnMenuAlign } from './brn-menu-align';
 	hostDirectives: [
 		{
 			directive: CdkMenuTrigger,
-			inputs: ['cdkMenuTriggerFor: brnMenuTriggerFor'],
+			inputs: ['cdkMenuTriggerFor: brnMenuTriggerFor', 'cdkMenuTriggerData: brnMenuTriggerData'],
 			outputs: ['cdkMenuOpened: brnMenuOpened', 'cdkMenuClosed: brnMenuClosed'],
 		},
 	],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [X] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

#562 

## What is the new behavior?

This feature allows you to pass context to a dropdown menu template.
By using the cdkMenuTriggerData input, data is passed by setting the brnMenuTriggerData directive and then available using the let- keyword in the scope of the template.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
