### PR TITLE
docs: add package installer tabs component

### DIFF
--- a/apps/app/src/app/pages/(documentation)/documentation/cli.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/cli.page.ts
@@ -3,8 +3,8 @@ import { Component } from '@angular/core';
 import { provideIcons } from '@ng-icons/core';
 import { lucideTriangleAlert } from '@ng-icons/lucide';
 import { hlmCode, hlmH4, hlmP } from '@spartan-ng/ui-typography-helm';
-import { CodeComponent } from '../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../shared/layout/main-section.directive';
+import { PackageInstallerTabsComponent } from '../../../shared/layout/package-installer-tabs.component';
 import { PageBottomNavLinkComponent } from '../../../shared/layout/page-bottom-nav/page-bottom-nav-link.component';
 import { PageBottomNavComponent } from '../../../shared/layout/page-bottom-nav/page-bottom-nav.component';
 import { PageNavComponent } from '../../../shared/layout/page-nav/page-nav.component';
@@ -29,8 +29,8 @@ export const routeMeta: RouteMeta = {
 		PageBottomNavLinkComponent,
 		PageNavComponent,
 		SectionSubHeadingComponent,
-		CodeComponent,
 		TabsCliComponent,
+		PackageInstallerTabsComponent,
 	],
 	providers: [provideIcons({ lucideTriangleAlert })],
 	template: `
@@ -52,7 +52,7 @@ export const routeMeta: RouteMeta = {
 				<code class="${hlmCode}">spartan</code>
 				to your Angular CLI project or Nx workspace simply install the plugin with the command below:
 			</p>
-			<spartan-code class="mt-4" code="npm i -D @spartan-ng/cli" />
+			<spartan-package-installer-tab class="mt-4" />
 
 			<h3 id="nx__ui" class="${hlmH4} mt-12">ui</h3>
 			<p class="${hlmP}">

--- a/apps/app/src/app/shared/layout/package-installer-tabs.component.ts
+++ b/apps/app/src/app/shared/layout/package-installer-tabs.component.ts
@@ -1,0 +1,68 @@
+import { KeyValuePipe } from '@angular/common';
+import { Component, computed, input, signal } from '@angular/core';
+import {
+	BrnTabsContentDirective,
+	BrnTabsDirective,
+	BrnTabsListDirective,
+	BrnTabsTriggerDirective,
+} from '@spartan-ng/brain/tabs';
+import { CodeComponent } from '../code/code.component';
+
+const packageInstallationCommands = {
+	npm: 'npm i -D @spartan-ng/cli',
+	pnpm: 'pnpm add -D @spartan-ng/cli',
+	yarn: 'yarn add -D @spartan-ng/cli',
+	bun: 'bun install -D @spartan-ng/cli',
+} as const;
+
+type PackageKey = keyof typeof packageInstallationCommands;
+
+const tabBtn =
+	'inline-flex items-center justify-center whitespace-nowrap py-1 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background relative h-9 rounded-none border-b-2 border-b-transparent bg-transparent px-4 pb-3 pt-2 font-semibold text-muted-foreground shadow-none transition-none data-[state=active]:border-b-primary data-[state=active]:text-foreground data-[state=active]:shadow-none';
+const tabContent =
+	'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 relative rounded-md border border-border';
+@Component({
+	selector: 'spartan-package-installer-tab',
+	standalone: true,
+	imports: [
+		BrnTabsDirective,
+		BrnTabsListDirective,
+		BrnTabsTriggerDirective,
+		BrnTabsContentDirective,
+		CodeComponent,
+		KeyValuePipe,
+	],
+	host: {
+		class: 'block',
+	},
+	template: `
+		<div [brnTabs]="value()" class="block" (tabActivated)="onTabActivated($event)">
+			<div
+				brnTabsList
+				class="border-border text-muted-foreground mb-4 inline-flex h-9 w-full items-center justify-start rounded-none border-b bg-transparent p-0"
+			>
+				@for (item of cliInstallationCommands | keyvalue: collationComparator; track item.key) {
+					<button class="${tabBtn}" [brnTabsTrigger]="item.key">{{ item.key }}</button>
+				}
+			</div>
+			<div class="${tabContent}" [brnTabsContent]="value()">
+				<spartan-code [language]="language()" [code]="installCommand()" />
+			</div>
+		</div>
+	`,
+})
+export class PackageInstallerTabsComponent {
+	public readonly value = signal<PackageKey>('npm');
+	public readonly installCommand = computed(() => {
+		const activeTab = this.value();
+		return this.cliInstallationCommands[activeTab] ?? '';
+	});
+	public language = input<'ts' | 'sh' | 'js'>('sh');
+	public cliInstallationCommands = packageInstallationCommands;
+
+	public collationComparator = () => 0;
+
+	protected onTabActivated(value: string) {
+		this.value.set(value as PackageKey);
+	}
+}


### PR DESCRIPTION
add component to display installation commands for package managers.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?



- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] Other... Please describe:

## What is the new behavior?

This PR introduces the PackageInstallerTabsComponent. It displays installation commands for various package managers (npm, pnpm, yarn, bun) in a tabbed interface, allowing users to switch tabs and view the relevant commands dynamically.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

