### PR TITLE
fix(breadcrumb): vertical alignment of separator

### DIFF
--- a/libs/ui/breadcrumb/helm/src/lib/breadcrumb-separator.component.ts
+++ b/libs/ui/breadcrumb/helm/src/lib/breadcrumb-separator.component.ts
@@ -18,7 +18,7 @@ import type { ClassValue } from 'clsx';
 	},
 	template: `
 		<ng-content>
-			<ng-icon hlm name="lucideChevronRight" />
+			<ng-icon size="sm" hlm name="lucideChevronRight" />
 		</ng-content>
 	`,
 })
@@ -26,6 +26,6 @@ export class HlmBreadcrumbSeparatorComponent {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 
 	protected readonly _computedClass = computed(() =>
-		hlm('[&>hlm-icon]:w-3.5 [&>hlm-icon]:h-3.5 [&>hlm-icon]:flex', this.userClass()),
+		hlm('[&>hlm-icon]:w-3.5 [&>hlm-icon]:h-3.5 [&>hlm-icon]:flex flex items-center', this.userClass()),
 	);
 }


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

Aligns separators in the center and reduces the icon size to "sm" to better fit in the general appearance.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [x] breadcrumb
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Current: Out of center and to big. 
<img width="391" alt="image" src="https://github.com/user-attachments/assets/bf87c045-e03c-4203-b6ad-5ebee1799322" />

New: Vertically centered and smaller. 
<img width="377" alt="image" src="https://github.com/user-attachments/assets/08ea1895-f37e-4de1-bc1c-70b85d07798d" />




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
