### PR TITLE
docs: fix bottom nav url to health-checks

### DIFF
--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/figma.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/figma.page.ts
@@ -68,7 +68,7 @@ export const routeMeta: RouteMeta = {
 				https://www.figma.com/community/file/1203061493325953101
 			</a>
 			<spartan-page-bottom-nav>
-				<spartan-page-bottom-nav-link href="/health-checks" label="Health Checks" />
+				<spartan-page-bottom-nav-link href="health-checks" label="Health Checks" />
 				<spartan-page-bottom-nav-link direction="previous" href="typography" label="Typography" />
 			</spartan-page-bottom-nav>
 		</section>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Bottom navigation of "Health Checks" on the Figma page navigates to the wrong url:
https://spartan.ng/health-checks

## What is the new behavior?

Bottom navigation of "Health Checks" on the Figma page navigates to the correct url:
https://spartan.ng/documentation/health-checks

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
