### PR TITLE
docs(data-table): add Tasks example page

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(data-table)/data-table.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(data-table)/data-table.preview.ts
@@ -1,6 +1,6 @@
 import { SelectionModel } from '@angular/cdk/collections';
 import { DecimalPipe, TitleCasePipe } from '@angular/common';
-import { Component, type TrackByFunction, computed, effect, signal } from '@angular/core';
+import { Component, computed, effect, signal, type TrackByFunction } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';

--- a/apps/app/src/app/pages/(examples)/examples.page.ts
+++ b/apps/app/src/app/pages/(examples)/examples.page.ts
@@ -42,6 +42,7 @@ export const routeMeta: RouteMeta = {
 				<li><a class="!font-medium" spartanNavLink="/examples/typography">Typography</a></li>
 				<li><a class="!font-medium" spartanNavLink="/examples/authentication">Authentication</a></li>
 				<li><a class="!font-medium" spartanNavLink="/examples/music">Music</a></li>
+				<li><a class="!font-medium" spartanNavLink="/examples/tasks">Tasks</a></li>
 			</ul>
 		</nav>
 		<div class="border-border overflow-hidden rounded-lg border">

--- a/apps/app/src/app/pages/(examples)/examples/tasks/(tasks).page.ts
+++ b/apps/app/src/app/pages/(examples)/examples/tasks/(tasks).page.ts
@@ -1,0 +1,338 @@
+import { Component, computed, inject, signal, TrackByFunction } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+	lucideArrowUpDown,
+	lucideChevronDown,
+	lucideChevronLeft,
+	lucideChevronRight,
+	lucideChevronsUp,
+	lucideChevronUp,
+	lucideCircle,
+	lucideCircleCheckBig,
+	lucideCircleDashed,
+	lucideCircleDot,
+	lucideCircleHelp,
+	lucideCircleOff,
+	lucideCog,
+	lucideDot,
+	lucideEllipsis,
+	lucideLayers,
+	lucideLogOut,
+	lucideUser,
+} from '@ng-icons/lucide';
+import { BrnMenuTriggerDirective } from '@spartan-ng/brain/menu';
+import { BrnSelectModule } from '@spartan-ng/brain/select';
+import { BrnTableModule, PaginatorState } from '@spartan-ng/brain/table';
+import { HlmAvatarImports } from '@spartan-ng/ui-avatar-helm';
+import { HlmButtonModule } from '@spartan-ng/ui-button-helm';
+import { HlmCheckboxComponent } from '@spartan-ng/ui-checkbox-helm';
+import { HlmIconDirective } from '@spartan-ng/ui-icon-helm';
+import { HlmMenuModule } from '@spartan-ng/ui-menu-helm';
+import { HlmSelectModule } from '@spartan-ng/ui-select-helm';
+import { HlmTableModule } from '@spartan-ng/ui-table-helm';
+import { TableActionsComponent } from './components/table-actions.component';
+import { PriorityIconPipe } from './pipes/priority-icon.pipe';
+import { StatusIconPipe } from './pipes/status-icon.pipe';
+import { SortingColumns, Task, TasksService } from './services/tasks.service';
+
+@Component({
+	selector: 'spartan-data-table-preview',
+	standalone: true,
+	imports: [
+		FormsModule,
+
+		BrnMenuTriggerDirective,
+		HlmMenuModule,
+
+		BrnTableModule,
+		HlmTableModule,
+
+		HlmButtonModule,
+
+		HlmIconDirective,
+
+		HlmCheckboxComponent,
+
+		BrnSelectModule,
+		HlmSelectModule,
+		TableActionsComponent,
+		NgIcon,
+		StatusIconPipe,
+		PriorityIconPipe,
+		HlmAvatarImports,
+	],
+	providers: [
+		provideIcons({
+			lucideArrowUpDown,
+			lucideChevronDown,
+			lucideChevronLeft,
+			lucideChevronRight,
+			lucideChevronUp,
+			lucideChevronsUp,
+			lucideCircle,
+			lucideCircleCheckBig,
+			lucideCircleDashed,
+			lucideCircleDot,
+			lucideCircleHelp,
+			lucideCircleOff,
+			lucideCog,
+			lucideDot,
+			lucideEllipsis,
+			lucideLayers,
+			lucideLogOut,
+			lucideUser,
+		}),
+	],
+	host: {
+		class: 'w-full',
+	},
+	template: `
+		<div class="h-full flex-1 flex-col space-y-4 p-8 py-6">
+			<div class="flex items-center justify-between space-y-2">
+				<div class="flex flex-col">
+					<h2 class="text-2xl font-bold tracking-tight">Welcome back!</h2>
+					<p class="text-muted-foreground">Here's a list of your tasks for this month!</p>
+				</div>
+				<hlm-avatar [brnMenuTriggerFor]="profile" align="center">
+					<img src="/assets/avatar.png" alt="spartan logo. Resembling a spartanic shield" hlmAvatarImage />
+					<span class="bg-destructive text-white" hlmAvatarFallback>AH</span>
+				</hlm-avatar>
+
+				<ng-template #profile>
+					<hlm-menu>
+						<div class="flex flex-col space-y-1" hlmMenuItem>
+							<p class="text-sm font-medium leading-none">spartan</p>
+							<p class="text-muted-foreground text-xs leading-none">m&#64;example.com</p>
+						</div>
+
+						<hlm-menu-separator />
+
+						<hlm-menu-group>
+							<hlm-menu-group>
+								<button hlmMenuItem>
+									<ng-icon hlm name="lucideUser" hlmMenuIcon />
+									<span>Profile</span>
+									<hlm-menu-shortcut>⇧⌘P</hlm-menu-shortcut>
+								</button>
+
+								<button hlmMenuItem>
+									<ng-icon hlm name="lucideLayers" hlmMenuIcon />
+									<span>Billing</span>
+									<hlm-menu-shortcut>⌘B</hlm-menu-shortcut>
+								</button>
+
+								<button hlmMenuItem>
+									<ng-icon hlm name="lucideCog" hlmMenuIcon />
+									<span>Settings</span>
+									<hlm-menu-shortcut>⌘S</hlm-menu-shortcut>
+								</button>
+							</hlm-menu-group>
+
+							<hlm-menu-separator />
+
+							<button hlmMenuItem>
+								<ng-icon hlm name="lucideLogOut" hlmMenuIcon />
+								<span>Logout</span>
+								<hlm-menu-shortcut>⇧⌘Q</hlm-menu-shortcut>
+							</button>
+						</hlm-menu-group>
+					</hlm-menu>
+				</ng-template>
+			</div>
+
+			<table-actions />
+
+			<div class="wip-table">
+				<brn-table
+					hlm
+					stickyHeader
+					class="border-border mt-4 block max-h-[700px] overflow-auto rounded-md border"
+					[dataSource]="tableSource()"
+					[displayedColumns]="allDisplayedColumns()"
+					[trackBy]="trackBy"
+				>
+					<brn-column-def name="select" class="w-12">
+						<hlm-th *brnHeaderDef>
+							<hlm-checkbox [checked]="checkboxState()" (changed)="handleHeaderCheckboxChange()" />
+						</hlm-th>
+						<hlm-td *brnCellDef="let element">
+							<hlm-checkbox [checked]="isPaymentSelected(element)" (changed)="togglePayment(element)" />
+						</hlm-td>
+					</brn-column-def>
+					<brn-column-def name="id" class="w-32">
+						<hlm-th truncate *brnHeaderDef>
+							<button hlmBtn size="sm" variant="ghost" (click)="handleTaskSortChange('id')">
+								Id
+								<ng-icon hlm class="ml-3" size="sm" name="lucideArrowUpDown" />
+							</button>
+						</hlm-th>
+						<hlm-td truncate *brnCellDef="let element">
+							{{ element.id }}
+						</hlm-td>
+					</brn-column-def>
+					<brn-column-def name="title" class="w-60 flex-1">
+						<hlm-th *brnHeaderDef>
+							<button hlmBtn size="sm" variant="ghost" (click)="handleTaskSortChange('title')">
+								Title
+								<ng-icon hlm class="ml-3" size="sm" name="lucideArrowUpDown" />
+							</button>
+						</hlm-th>
+						<hlm-td truncate *brnCellDef="let element" class="font-medium">
+							<div
+								class="text-foreground inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold"
+							>
+								{{ element.type }}
+							</div>
+							{{ element.title }}
+						</hlm-td>
+					</brn-column-def>
+					<brn-column-def name="status" class="w-32">
+						<hlm-th *brnHeaderDef>
+							<button hlmBtn size="sm" variant="ghost" (click)="handleTaskSortChange('status')">
+								Status
+								<ng-icon hlm class="ml-3" size="sm" name="lucideArrowUpDown" />
+							</button>
+						</hlm-th>
+						<hlm-td truncate *brnCellDef="let element">
+							<div class="flex items-center">
+								<ng-icon hlm class="text-muted-foreground mr-2" size="sm" [name]="element.status | statusIcon" />
+								<span>{{ element.status }}</span>
+							</div>
+						</hlm-td>
+					</brn-column-def>
+					<brn-column-def name="priority" class="w-32">
+						<hlm-th *brnHeaderDef>
+							<button hlmBtn size="sm" variant="ghost" (click)="handleTaskSortChange('priority')">
+								Priority
+								<ng-icon hlm class="ml-3" size="sm" name="lucideArrowUpDown" />
+							</button>
+						</hlm-th>
+						<hlm-td *brnCellDef="let element">
+							<div class="flex items-center">
+								<ng-icon hlm class="text-muted-foreground mr-2" size="sm" [name]="element.priority | priorityIcon" />
+								{{ element.priority }}
+							</div>
+						</hlm-td>
+					</brn-column-def>
+					<brn-column-def name="actions" class="w-16">
+						<hlm-th *brnHeaderDef></hlm-th>
+						<hlm-td *brnCellDef="let element">
+							<button hlmBtn variant="ghost" class="h-6 w-6 p-0.5" align="end" [brnMenuTriggerFor]="menu">
+								<ng-icon hlm size="sm" name="lucideEllipsis" />
+							</button>
+
+							<ng-template #menu>
+								<hlm-menu>
+									<hlm-menu-label>Actions</hlm-menu-label>
+									<hlm-menu-separator />
+									<hlm-menu-group>
+										<button hlmMenuItem>Edit</button>
+										<button hlmMenuItem>Make a copy</button>
+										<button hlmMenuItem>Favorite</button>
+									</hlm-menu-group>
+									<hlm-menu-separator />
+									<hlm-menu-group>
+										<button hlmMenuItem [brnMenuTriggerFor]="labels">
+											Labels
+											<ng-icon hlm name="lucideChevronRight" class="ml-auto" size="sm" />
+										</button>
+									</hlm-menu-group>
+									<hlm-menu-separator />
+									<hlm-menu-group>
+										<button hlmMenuItem>
+											Delete
+											<span class="ml-auto text-xs tracking-widest opacity-60">⌘⌫</span>
+										</button>
+									</hlm-menu-group>
+								</hlm-menu>
+							</ng-template>
+							<ng-template #labels>
+								<hlm-menu>
+									<hlm-menu-group>
+										<button hlmMenuItemCheckbox [checked]="element.type === 'Bug'">
+											<hlm-menu-item-radio />
+											<span>Bug</span>
+										</button>
+
+										<button hlmMenuItemCheckbox [checked]="element.type === 'Feature'">
+											<hlm-menu-item-radio />
+											<span>Feature</span>
+										</button>
+
+										<button hlmMenuItemCheckbox [checked]="element.type === 'Documentation'">
+											<hlm-menu-item-radio />
+											<span>Documentation</span>
+										</button>
+									</hlm-menu-group>
+								</hlm-menu>
+							</ng-template>
+						</hlm-td>
+					</brn-column-def>
+					<div class="text-muted-foreground flex items-center justify-center p-20" brnNoDataRow>No data</div>
+				</brn-table>
+				<div
+					class="mt-4 flex flex-col justify-between sm:flex-row sm:items-center"
+					*brnPaginator="let ctx; totalElements: totalElements(); pageSize: pageSize(); onStateChange: _onStateChange"
+				>
+					<span class="text-muted-foreground text-sm">
+						{{ selected().length }} of {{ totalElements() }} row(s) selected
+					</span>
+					<div class="mt-2 flex sm:mt-0">
+						<brn-select class="inline-block" placeholder="{{ availablePageSizes[0] }}" [(ngModel)]="pageSize">
+							<hlm-select-trigger class="w-15 mr-1 inline-flex h-9">
+								<hlm-select-value />
+							</hlm-select-trigger>
+							<hlm-select-content>
+								@for (size of availablePageSizes; track size) {
+									<hlm-option [value]="size">
+										{{ size === 10000 ? 'All' : size }}
+									</hlm-option>
+								}
+							</hlm-select-content>
+						</brn-select>
+
+						<div class="flex space-x-1">
+							<button size="sm" variant="outline" hlmBtn [disabled]="!ctx.decrementable()" (click)="ctx.decrement()">
+								Previous
+							</button>
+							<button size="sm" variant="outline" hlmBtn [disabled]="!ctx.incrementable()" (click)="ctx.increment()">
+								Next
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	`,
+})
+export default class TasksExamplePageComponent {
+	private readonly _tasksService = inject(TasksService);
+
+	protected readonly trackBy: TrackByFunction<Task> = (_: number, p: Task) => p.id;
+	protected readonly totalElements = computed(() => this._tasksService._filteredTasks().length);
+	protected readonly availablePageSizes = [5, 10, 20, 10000];
+	protected readonly pageSize = signal(this.availablePageSizes[1]); // default to page size 10
+
+	protected readonly allDisplayedColumns = this._tasksService.getAllDisplayedColumns();
+	protected readonly selected = this._tasksService.getSelected();
+	protected readonly checkboxState = this._tasksService.getCheckboxState();
+	protected readonly tableSource = this._tasksService.getFilteredSortedPaginatedTasks();
+
+	protected readonly isPaymentSelected = (payment: Task) => this._tasksService.isTaskSelected(payment);
+
+	handleTaskSortChange(column: SortingColumns) {
+		this._tasksService.handleTaskSortChange(column);
+	}
+
+	togglePayment(payment: Task) {
+		this._tasksService.toggleTask(payment);
+	}
+
+	handleHeaderCheckboxChange() {
+		this._tasksService.handleHeaderCheckboxChange();
+	}
+
+	protected readonly _onStateChange = ({ startIndex, endIndex }: PaginatorState) =>
+		this._tasksService.setDisplayedIndices(startIndex, endIndex);
+}

--- a/apps/app/src/app/pages/(examples)/examples/tasks/components/table-actions.component.ts
+++ b/apps/app/src/app/pages/(examples)/examples/tasks/components/table-actions.component.ts
@@ -1,0 +1,275 @@
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+	lucideCheck,
+	lucideChevronDown,
+	lucideChevronLeft,
+	lucideChevronsUp,
+	lucideChevronUp,
+	lucideCircle,
+	lucideCircleCheckBig,
+	lucideCircleDashed,
+	lucideCircleDot,
+	lucideCircleHelp,
+	lucideCircleOff,
+	lucideCirclePlus,
+	lucideGlobe,
+	lucideMicVocal,
+	lucideSearch,
+	lucideSettings2,
+	lucideX,
+} from '@ng-icons/lucide';
+import { BrnCommandImports } from '@spartan-ng/brain/command';
+import { BrnMenuTriggerDirective } from '@spartan-ng/brain/menu';
+import { BrnPopoverImports } from '@spartan-ng/brain/popover';
+import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
+import { HlmCheckboxImports } from '@spartan-ng/ui-checkbox-helm';
+import { HlmCommandImports } from '@spartan-ng/ui-command-helm';
+import { HlmIconDirective } from '@spartan-ng/ui-icon-helm';
+import { HlmInputDirective } from '@spartan-ng/ui-input-helm';
+import { HlmMenuComponent, HlmMenuItemImports } from '@spartan-ng/ui-menu-helm';
+import { HlmPopoverImports } from '@spartan-ng/ui-popover-helm';
+import { PriorityIconPipe } from '../pipes/priority-icon.pipe';
+import { StatusIconPipe } from '../pipes/status-icon.pipe';
+import { LocalStorageService } from '../services/local-storage.service';
+import { TaskPriority, TasksService, TaskStatus } from '../services/tasks.service';
+
+@Component({
+	// eslint-disable-next-line @angular-eslint/component-selector
+	selector: 'table-actions',
+	standalone: true,
+	host: {
+		class: 'block',
+	},
+	imports: [
+		HlmButtonDirective,
+		FormsModule,
+		HlmInputDirective,
+		BrnMenuTriggerDirective,
+		NgIcon,
+		HlmIconDirective,
+		HlmMenuComponent,
+		HlmMenuItemImports,
+		BrnPopoverImports,
+		HlmCommandImports,
+		BrnCommandImports,
+		HlmPopoverImports,
+		HlmCheckboxImports,
+		PriorityIconPipe,
+		StatusIconPipe,
+	],
+	providers: [
+		provideIcons({
+			lucideCheck,
+			lucideChevronDown,
+			lucideChevronLeft,
+			lucideChevronUp,
+			lucideChevronsUp,
+			lucideCircle,
+			lucideCircleCheckBig,
+			lucideCircleDashed,
+			lucideCircleDot,
+			lucideCircleHelp,
+			lucideCircleOff,
+			lucideCirclePlus,
+			lucideGlobe,
+			lucideMicVocal,
+			lucideSearch,
+			lucideSettings2,
+			lucideX,
+		}),
+	],
+	template: `
+		<div class="wip-table-search flex flex-col justify-between gap-4 sm:flex-row">
+			<div class="flex flex-col justify-between gap-4 sm:flex-row">
+				<input
+					hlmInput
+					size="sm"
+					class="w-full md:w-80"
+					placeholder="Filter tasks..."
+					[ngModel]="taskFilter()"
+					(ngModelChange)="rawFilterInput.set($event)"
+				/>
+
+				<brn-popover
+					[state]="statusState()"
+					(stateChanged)="statusStateChanged($event)"
+					sideOffset="5"
+					closeDelay="100"
+					align="start"
+				>
+					<button hlmBtn brnPopoverTrigger variant="outline" size="sm" class="border-dashed">
+						<ng-icon hlm name="lucideCirclePlus" class="mr-2" size="sm" />
+						Status
+						@if (statusFilter().length) {
+							<div data-orientation="vertical" role="none" class="bg-border mx-2 h-4 w-[1px] shrink-0"></div>
+
+							<div class="flex gap-1">
+								@for (status of statusFilter(); track status) {
+									<span class="bg-secondary text-secondary-foreground rounded px-1 py-0.5 text-xs">
+										{{ status }}
+									</span>
+								}
+							</div>
+						}
+					</button>
+					<hlm-command *brnPopoverContent="let ctx" hlmPopoverContent class="w-[200px] p-0">
+						<hlm-command-search>
+							<ng-icon hlm name="lucideSearch" class="text-muted-foreground" />
+							<input placeholder="Status" hlm-command-search-input />
+						</hlm-command-search>
+						<div *brnCommandEmpty hlmCommandEmpty>No results found.</div>
+						<hlm-command-list>
+							<hlm-command-group>
+								@for (status of statuses(); track status) {
+									<button hlm-command-item [value]="status" (selected)="statusSelected(status)">
+										<hlm-checkbox class="mr-2" [checked]="isStatusSelected(status)" />
+
+										<ng-icon hlm [name]="status | statusIcon" class="text-muted-foreground mx-2" size="sm" />
+										{{ status }}
+									</button>
+								}
+							</hlm-command-group>
+						</hlm-command-list>
+					</hlm-command>
+				</brn-popover>
+
+				<brn-popover
+					[state]="priorityState()"
+					(stateChanged)="priorityStateChanged($event)"
+					sideOffset="5"
+					closeDelay="100"
+					align="start"
+				>
+					<button hlmBtn brnPopoverTrigger variant="outline" size="sm" class="border-dashed">
+						<ng-icon hlm name="lucideCirclePlus" class="mr-2" size="sm" />
+						Priority
+						@if (priorityFilter().length) {
+							<div data-orientation="vertical" role="none" class="bg-border mx-2 h-4 w-[1px] shrink-0"></div>
+
+							<div class="flex gap-1">
+								@for (priority of priorityFilter(); track priority) {
+									<span class="bg-secondary text-secondary-foreground rounded px-1 py-0.5 text-xs">
+										{{ priority }}
+									</span>
+								}
+							</div>
+						}
+					</button>
+					<hlm-command *brnPopoverContent="let ctx" hlmPopoverContent class="w-[200px] p-0">
+						<hlm-command-search>
+							<ng-icon hlm name="lucideSearch" class="text-muted-foreground" />
+							<input placeholder="Priority" hlm-command-search-input />
+						</hlm-command-search>
+						<div *brnCommandEmpty hlmCommandEmpty>No results found.</div>
+						<hlm-command-list>
+							<hlm-command-group>
+								@for (priority of priorities(); track priority) {
+									<button hlm-command-item [value]="priority" (selected)="prioritySelected(priority)">
+										<hlm-checkbox class="mr-2" [checked]="isPrioritySelected(priority)" />
+
+										<ng-icon hlm [name]="priority | priorityIcon" class="text-muted-foreground mx-2" size="sm" />
+										{{ priority }}
+									</button>
+								}
+							</hlm-command-group>
+						</hlm-command-list>
+					</hlm-command>
+				</brn-popover>
+
+				@if (statusFilter().length || priorityFilter().length) {
+					<button hlmBtn variant="ghost" size="sm" align="end" (click)="resetFilters()">
+						Reset
+						<ng-icon hlm name="lucideX" class="ml-2" size="sm" />
+					</button>
+				}
+			</div>
+
+			<button hlmBtn variant="outline" size="sm" align="end" [brnMenuTriggerFor]="menu">
+				<ng-icon hlm name="lucideSettings2" class="mr-2" size="sm" />
+				View
+			</button>
+			<ng-template #menu>
+				<hlm-menu class="w-32">
+					@for (column of columnManager.allColumns; track column.name) {
+						<button
+							hlmMenuItemCheckbox
+							[disabled]="columnManager.isColumnDisabled(column.name)"
+							[checked]="columnManager.isColumnVisible(column.name)"
+							(triggered)="onColumnFilterChanged(column.name)"
+						>
+							<hlm-menu-item-check />
+							<span>{{ column.label }}</span>
+						</button>
+					}
+				</hlm-menu>
+			</ng-template>
+		</div>
+	`,
+})
+export class TableActionsComponent {
+	private readonly _tasksService = inject(TasksService);
+	private readonly _localStorageService = inject(LocalStorageService);
+
+	protected readonly columnManager = this._tasksService.getColumnManager();
+	protected readonly taskFilter = this._tasksService.getTaskFilter();
+	protected readonly rawFilterInput = this._tasksService.getRawFilterInput();
+	protected readonly statusFilter = this._tasksService.getStatusFilter();
+	protected readonly statuses = signal(['Backlog', 'Todo', 'In Progress', 'Done', 'Canceled'] satisfies TaskStatus[]);
+	protected readonly statusState = signal<'closed' | 'open'>('closed');
+
+	protected readonly priorityFilter = this._tasksService.getPriorityFilter();
+	protected readonly priorities = signal(['Low', 'Medium', 'High', 'Critical'] satisfies TaskPriority[]);
+	protected readonly priorityState = signal<'closed' | 'open'>('closed');
+
+	onColumnFilterChanged(columnName: string): void {
+		this.columnManager.toggleVisibility(columnName as any);
+		const isVisible = this.columnManager.isColumnVisible(columnName);
+		if (isVisible) {
+			this._localStorageService.saveTaskTableColumn(columnName);
+		} else {
+			this._localStorageService.deleteTaskTableColumn(columnName);
+		}
+	}
+
+	isStatusSelected(status: TaskStatus): boolean {
+		return this.statusFilter().some((s) => s === status);
+	}
+
+	statusStateChanged(state: 'open' | 'closed') {
+		this.statusState.set(state);
+	}
+
+	statusSelected(status: TaskStatus): void {
+		const current = this.statusFilter();
+		const index = current.indexOf(status);
+		if (index === -1) {
+			this.statusFilter.set([...current, status]);
+		} else {
+			this.statusFilter.set(current.filter((s) => s !== status));
+		}
+	}
+
+	isPrioritySelected(priority: TaskPriority): boolean {
+		return this.priorityFilter().some((p) => p === priority);
+	}
+
+	priorityStateChanged(state: 'open' | 'closed') {
+		this.priorityState.set(state);
+	}
+
+	prioritySelected(priority: TaskPriority): void {
+		const current = this.priorityFilter();
+		const index = current.indexOf(priority);
+		if (index === -1) {
+			this.priorityFilter.set([...current, priority]);
+		} else {
+			this.priorityFilter.set(current.filter((p) => p !== priority));
+		}
+	}
+
+	resetFilters(): void {
+		this._tasksService.resetFilters();
+	}
+}

--- a/apps/app/src/app/pages/(examples)/examples/tasks/pipes/priority-icon.pipe.ts
+++ b/apps/app/src/app/pages/(examples)/examples/tasks/pipes/priority-icon.pipe.ts
@@ -1,0 +1,23 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { TaskPriority } from '../services/tasks.service';
+
+@Pipe({
+	name: 'priorityIcon',
+	standalone: true,
+})
+export class PriorityIconPipe implements PipeTransform {
+	transform(value: TaskPriority): string {
+		switch (value) {
+			case 'Low':
+				return 'lucideChevronDown';
+			case 'Medium':
+				return 'lucideChevronLeft';
+			case 'High':
+				return 'lucideChevronUp';
+			case 'Critical':
+				return 'lucideChevronsUp';
+			default:
+				return 'lucideCircleHelp'; // Default icon if not recognized
+		}
+	}
+}

--- a/apps/app/src/app/pages/(examples)/examples/tasks/pipes/status-icon.pipe.ts
+++ b/apps/app/src/app/pages/(examples)/examples/tasks/pipes/status-icon.pipe.ts
@@ -1,0 +1,25 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { TaskStatus } from '../services/tasks.service';
+
+@Pipe({
+	name: 'statusIcon',
+	standalone: true,
+})
+export class StatusIconPipe implements PipeTransform {
+	transform(value: TaskStatus): string {
+		switch (value) {
+			case 'Todo':
+				return 'lucideCircle';
+			case 'In Progress':
+				return 'lucideCircleDot';
+			case 'Backlog':
+				return 'lucideCircleDashed';
+			case 'Canceled':
+				return 'lucideCircleOff';
+			case 'Done':
+				return 'lucideCircleCheckBig';
+			default:
+				return 'lucideCircleHelp'; // Default icon if not recognized
+		}
+	}
+}

--- a/apps/app/src/app/pages/(examples)/examples/tasks/services/local-storage.service.ts
+++ b/apps/app/src/app/pages/(examples)/examples/tasks/services/local-storage.service.ts
@@ -1,0 +1,56 @@
+import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+
+const EXAMPLES_TASK_SETTINGS_KEY = 'spartan-examples';
+
+const DEFAULT_TASK_TABLE_COLUMNS = ['id', 'title', 'status', 'priority'];
+
+/**
+ * Manages local storage settings for the task table.
+ * It persists the users selected columns.
+ */
+@Injectable({
+	providedIn: 'root',
+})
+export class LocalStorageService {
+	private readonly _isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
+	private readonly _settings = {
+		taskTable: {
+			selectedColumns: this.getSelectedColumnsSettings(EXAMPLES_TASK_SETTINGS_KEY) ?? DEFAULT_TASK_TABLE_COLUMNS,
+		},
+	};
+
+	saveTaskTableColumn(value: any): void {
+		this._settings.taskTable.selectedColumns.push(value);
+		this.updateSettings(EXAMPLES_TASK_SETTINGS_KEY, this._settings.taskTable);
+	}
+
+	deleteTaskTableColumn(value: any): void {
+		this._settings.taskTable.selectedColumns = this._settings.taskTable.selectedColumns.filter(
+			(column: any) => column !== value,
+		);
+		this.updateSettings(EXAMPLES_TASK_SETTINGS_KEY, this._settings.taskTable);
+	}
+
+	getTaskTableColumns(): string[] {
+		return this._settings.taskTable.selectedColumns;
+	}
+
+	private updateSettings(key: string, settings: any) {
+		if (this._isBrowser) {
+			localStorage.setItem(key, JSON.stringify(settings));
+		}
+	}
+
+	private getSelectedColumnsSettings(key: string) {
+		if (!this._isBrowser) {
+			return DEFAULT_TASK_TABLE_COLUMNS;
+		}
+		const settings = localStorage.getItem(key);
+		if (!settings) {
+			return undefined;
+		}
+		return JSON.parse(settings).selectedColumns;
+	}
+}

--- a/apps/app/src/app/pages/(examples)/examples/tasks/services/tasks.service.ts
+++ b/apps/app/src/app/pages/(examples)/examples/tasks/services/tasks.service.ts
@@ -1,0 +1,624 @@
+import { SelectionModel } from '@angular/cdk/collections';
+import { computed, effect, inject, Injectable, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { useBrnColumnManager } from '@spartan-ng/brain/table';
+import { debounceTime, map } from 'rxjs/operators';
+import { LocalStorageService } from './local-storage.service';
+
+@Injectable({
+	providedIn: 'root',
+})
+export class TasksService {
+	private readonly _localStorageService = inject(LocalStorageService);
+
+	protected readonly _rawFilterInput = signal('');
+	protected readonly _taskFilter = signal('');
+	protected readonly _statusFilter = signal<TaskStatus[]>([]);
+	protected readonly _priorityFilter = signal<TaskPriority[]>([]);
+	private readonly _debouncedFilter = toSignal(toObservable(this._rawFilterInput).pipe(debounceTime(300)));
+	protected readonly _brnColumnManager = useBrnColumnManager({
+		id: { visible: false, label: 'Id' },
+		title: { visible: false, label: 'Title' },
+		status: { visible: false, label: 'Status' },
+		priority: { visible: false, label: 'Priority' },
+	});
+	protected readonly _allDisplayedColumns = computed(() => [
+		'select',
+		...this._brnColumnManager.displayedColumns(),
+		'actions',
+	]);
+
+	private readonly _displayedIndices = signal({ start: 0, end: 0 });
+
+	private readonly _selectionModel = new SelectionModel<Task>(true);
+	protected readonly _selected = toSignal(this._selectionModel.changed.pipe(map((change) => change.source.selected)), {
+		initialValue: [],
+	});
+
+	private readonly _tasks = signal(TASK_DATA);
+
+	public readonly _filteredTasks = computed(() => {
+		let tasks = this._tasks();
+		const taskFilter = this._taskFilter()?.trim()?.toLowerCase();
+		const statusFilter = this._statusFilter();
+		const priorityFilter = this._priorityFilter();
+
+		// status filter
+		if (statusFilter.length) {
+			tasks = tasks.filter((a) => statusFilter.includes(a.status));
+		}
+
+		// priority filter
+		if (priorityFilter.length) {
+			tasks = tasks.filter((a) => priorityFilter.includes(a.priority));
+		}
+
+		// search filter
+		if (taskFilter && taskFilter.length > 0) {
+			tasks = tasks.filter(
+				(a) => a.title.toLowerCase().includes(taskFilter) || a.id.toLowerCase().includes(taskFilter),
+			);
+		}
+		return tasks;
+	});
+
+	private readonly _taskSort = signal<'ASC' | 'DESC' | null>(null);
+	private readonly _taskSortColumn = signal<SortingColumns | null>(null);
+
+	protected readonly _filteredSortedPaginatedTasks = computed(() => {
+		const sort = this._taskSort();
+		const start = this._displayedIndices().start;
+		const end = this._displayedIndices().end + 1;
+		const tasks = this._filteredTasks();
+		const sortColumn = this._taskSortColumn();
+		return [...tasks]
+			.sort((a1, a2) => {
+				if (!sortColumn) return 0;
+				const value1 = a1[sortColumn];
+				const value2 = a2[sortColumn];
+				if (typeof value1 === 'number' && typeof value2 === 'number') {
+					return (sort === 'ASC' ? 1 : -1) * (value1 - value2);
+				} else if (typeof value1 === 'string' && typeof value2 === 'string') {
+					return (sort === 'ASC' ? 1 : -1) * value1.localeCompare(value2);
+				} else {
+					throw new Error(`Unsupported sorting type: ${typeof value1}`);
+				}
+			})
+			.slice(start, end);
+	});
+	protected readonly _allFilteredPaginatedTasksSelected = computed(() =>
+		this._filteredSortedPaginatedTasks().every((task: Task) => this._selected().includes(task)),
+	);
+	protected readonly _checkboxState = computed(() => {
+		const noneSelected = this._selected().length === 0;
+		const allSelectedOrIndeterminate = this._allFilteredPaginatedTasksSelected() ? true : 'indeterminate';
+		return noneSelected ? false : allSelectedOrIndeterminate;
+	});
+
+	constructor() {
+		// needed to sync the debounced filter to the name filter, but being able to override the
+		// filter when loading new users without debounce
+		effect(() => this._taskFilter.set(this._debouncedFilter() ?? ''), { allowSignalWrites: true });
+		const columnSettings = this._localStorageService.getTaskTableColumns();
+		for (const column of columnSettings) {
+			this._brnColumnManager.setVisible(column as any);
+		}
+	}
+
+	isTaskSelected(task: Task) {
+		return this._selectionModel.isSelected(task);
+	}
+
+	toggleTask(task: Task) {
+		this._selectionModel.toggle(task);
+	}
+
+	handleHeaderCheckboxChange() {
+		const previousCbState = this._checkboxState();
+		if (previousCbState === 'indeterminate' || !previousCbState) {
+			this._selectionModel.select(...this._filteredSortedPaginatedTasks());
+		} else {
+			this._selectionModel.deselect(...this._filteredSortedPaginatedTasks());
+		}
+	}
+
+	handleTaskSortChange(column: SortingColumns) {
+		this._taskSortColumn.set(column);
+		const sort = this._taskSort();
+		if (sort === 'ASC') {
+			this._taskSort.set('DESC');
+		} else if (sort === 'DESC') {
+			this._taskSort.set(null);
+		} else {
+			this._taskSort.set('ASC');
+		}
+	}
+
+	getColumnManager() {
+		return this._brnColumnManager;
+	}
+
+	getTaskFilter() {
+		return this._taskFilter;
+	}
+
+	getRawFilterInput() {
+		return this._rawFilterInput;
+	}
+
+	getStatusFilter() {
+		return this._statusFilter;
+	}
+
+	getPriorityFilter() {
+		return this._priorityFilter;
+	}
+
+	getAllDisplayedColumns() {
+		return this._allDisplayedColumns;
+	}
+
+	getSelected() {
+		return this._selected;
+	}
+
+	getFilteredSortedPaginatedTasks() {
+		return this._filteredSortedPaginatedTasks;
+	}
+
+	getCheckboxState() {
+		return this._checkboxState;
+	}
+
+	setDisplayedIndices(startIndex: number, endIndex: number) {
+		this._displayedIndices.set({ start: startIndex, end: endIndex });
+	}
+
+	resetFilters() {
+		this._priorityFilter.set([]);
+		this._statusFilter.set([]);
+	}
+}
+
+export type SortingColumns = 'id' | 'title' | 'status' | 'priority';
+export type TaskType = 'Bug' | 'Feature' | 'Documentation';
+export type TaskStatus = 'Todo' | 'In Progress' | 'Backlog' | 'Canceled' | 'Done';
+export type TaskPriority = 'Critical' | 'High' | 'Medium' | 'Low';
+
+export type Task = {
+	id: string;
+	title: string;
+	type: TaskType;
+	status: TaskStatus;
+	priority: TaskPriority;
+};
+
+const TASK_DATA: Task[] = [
+	{
+		id: 'TASK-8782',
+		title: "You can't compress the program without quantifying the open-source SSD",
+		status: 'In Progress',
+		priority: 'Low',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-7878',
+		title: 'Try to calculate the EXE feed, maybe it will index the multi-byte pixel!',
+		status: 'Backlog',
+		priority: 'Medium',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-7839',
+		title: 'We need to bypass the neural TCP card!',
+		status: 'Todo',
+		priority: 'High',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-5562',
+		title: 'The SAS interface is down, bypass the open-source pixel so we can back up the PNG bandwidth!',
+		status: 'Backlog',
+		priority: 'Medium',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-8686',
+		title: "I'll parse the wireless SSL protocol, that should driver the API panel!",
+		status: 'Canceled',
+		priority: 'Medium',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-1280',
+		title: 'Use the digital TLS panel, then you can transmit the haptic system!',
+		status: 'Done',
+		priority: 'High',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-7262',
+		title: "I'll transmit the wireless JBOD capacitor, that should hard drive the SSD feed!",
+		status: 'Done',
+		priority: 'High',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-1138',
+		title: "Transmitting the transmitter won't do anything, we need to compress the virtual HDD sensor!",
+		status: 'In Progress',
+		priority: 'Medium',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-7184',
+		title: 'We need to program the back-end THX pixel!',
+		status: 'Done',
+		priority: 'Low',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-5160',
+		title: 'The SQL interface is down, override the optical bus so we can program the ASCII interface!',
+		status: 'In Progress',
+		priority: 'High',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9001',
+		title: 'Need to refactor the quantum blockchain to optimize the AI neural mesh',
+		status: 'Todo',
+		priority: 'High',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9002',
+		title: 'The IPv6 matrix is overflowing, debug the recursive GPU bandwidth',
+		status: 'In Progress',
+		priority: 'Medium',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9003',
+		title: 'Deploy microservice containers to scale the holographic RAM interface',
+		status: 'Backlog',
+		priority: 'Low',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9004',
+		title: 'Synchronize the blockchain ledger with the quantum entangled cache',
+		status: 'Todo',
+		priority: 'High',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9005',
+		title: 'The machine learning pipeline is corrupting the serverless Docker nodes',
+		status: 'In Progress',
+		priority: 'High',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9006',
+		title: "Implement zero-trust authentication for the neural network's REST API",
+		status: 'Done',
+		priority: 'Medium',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9007',
+		title: 'The distributed NoSQL cluster is fragmenting the WebAssembly heap',
+		status: 'Backlog',
+		priority: 'Low',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9008',
+		title: 'Need to recompile the quantum-resistant encryption module in WebGL',
+		status: 'In Progress',
+		priority: 'High',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9009',
+		title: 'The edge computing mesh is destabilizing the blockchain consensus',
+		status: 'Todo',
+		priority: 'Medium',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9010',
+		title: "Optimize the neural network's deep learning tensor for Web3 integration",
+		status: 'Canceled',
+		priority: 'Low',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9011',
+		title: 'The quantum fuzzy logic parser is corrupting the blockchain NFTs',
+		status: 'Todo',
+		priority: 'High',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9012',
+		title: 'Need to recompile the Metaverse VR modules using Web Assembly',
+		status: 'In Progress',
+		priority: 'Medium',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-1337',
+		title: 'The AI is generating recursive blockchain smart contracts',
+		status: 'Backlog',
+		priority: 'Critical',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9013',
+		title: 'Optimize WASM compilation for metaverse sharding',
+		status: 'Backlog',
+		priority: 'High',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9014',
+		title: 'Implement reactive blockchain state management',
+		status: 'Done',
+		priority: 'Medium',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9015',
+		title: 'Debug quantum decoherence in ML training pipeline',
+		status: 'In Progress',
+		priority: 'Critical',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9016',
+		title: 'Optimize GPU raytracing for NFT rendering',
+		status: 'Todo',
+		priority: 'Low',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9017',
+		title: 'Implement zero-knowledge proofs for AI models',
+		status: 'Backlog',
+		priority: 'High',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9018',
+		title: 'Debug smart contract recursive overflow',
+		status: 'In Progress',
+		priority: 'Medium',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9019',
+		title: 'Optimize neural network for quantum supremacy',
+		status: 'Done',
+		priority: 'High',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9020',
+		title: 'Implement distributed consensus for VR nodes',
+		status: 'Todo',
+		priority: 'Medium',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9021',
+		title: 'Debug quantum entanglement in cache layer',
+		status: 'In Progress',
+		priority: 'High',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9022',
+		title: 'Optimize CUDA cores for blockchain mining',
+		status: 'Backlog',
+		priority: 'Low',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9023',
+		title: 'Implement neural cryptography for Web3',
+		status: 'Done',
+		priority: 'Medium',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9024',
+		title: 'Debug recursive smart contract calls',
+		status: 'In Progress',
+		priority: 'High',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9025',
+		title: 'Optimize quantum compiler for WASM',
+		status: 'Todo',
+		priority: 'Critical',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9026',
+		title: 'Implement sharding for NFT marketplace',
+		status: 'Backlog',
+		priority: 'Medium',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9027',
+		title: 'Debug neural network race conditions',
+		status: 'In Progress',
+		priority: 'High',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9028',
+		title: 'Optimize GPU pipeline for metaverse rendering',
+		status: 'Done',
+		priority: 'Low',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9029',
+		title: 'Implement quantum-safe cryptography',
+		status: 'Todo',
+		priority: 'High',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9030',
+		title: 'Debug distributed ledger consensus',
+		status: 'In Progress',
+		priority: 'Medium',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9031',
+		title: 'Optimize AI models for edge computing',
+		status: 'Backlog',
+		priority: 'High',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9032',
+		title: 'Implement zero-day exploit detection',
+		status: 'Done',
+		priority: 'Critical',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9033',
+		title: 'Debug quantum teleportation protocol',
+		status: 'In Progress',
+		priority: 'Medium',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9034',
+		title: 'Optimize blockchain for IoT devices',
+		status: 'Todo',
+		priority: 'Low',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9035',
+		title: 'Implement neural feedback loops',
+		status: 'Backlog',
+		priority: 'High',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9036',
+		title: 'Debug smart contract gas optimization',
+		status: 'In Progress',
+		priority: 'Medium',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9037',
+		title: 'Optimize quantum circuits for ML',
+		status: 'Done',
+		priority: 'High',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9038',
+		title: 'Implement distributed VR rendering',
+		status: 'Todo',
+		priority: 'Low',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9039',
+		title: 'Debug neural network backpropagation',
+		status: 'In Progress',
+		priority: 'Critical',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9040',
+		title: 'Optimize WASM for blockchain validation',
+		status: 'Backlog',
+		priority: 'Medium',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9041',
+		title: 'Implement quantum error correction',
+		status: 'Done',
+		priority: 'High',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9042',
+		title: 'Debug distributed cache coherency',
+		status: 'In Progress',
+		priority: 'Low',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9043',
+		title: 'Optimize neural network pruning',
+		status: 'Todo',
+		priority: 'Medium',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9044',
+		title: 'Implement zero-trust blockchain',
+		status: 'Backlog',
+		priority: 'High',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9045',
+		title: 'Debug quantum state preparation',
+		status: 'In Progress',
+		priority: 'Critical',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9046',
+		title: 'Optimize GPU kernels for NFTs',
+		status: 'Done',
+		priority: 'Medium',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9047',
+		title: 'Implement neural hardware acceleration',
+		status: 'Todo',
+		priority: 'Low',
+		type: 'Bug',
+	},
+	{
+		id: 'TASK-9048',
+		title: 'Debug smart contract memory leaks',
+		status: 'In Progress',
+		priority: 'High',
+		type: 'Feature',
+	},
+	{
+		id: 'TASK-9049',
+		title: 'Optimize quantum gate operations',
+		status: 'Backlog',
+		priority: 'Medium',
+		type: 'Documentation',
+	},
+	{
+		id: 'TASK-9050',
+		title: 'Implement distributed ML training',
+		status: 'Done',
+		priority: 'Critical',
+		type: 'Bug',
+	},
+];


### PR DESCRIPTION
Hey, my goal with this PR is to enhance the current examples with a tasks table.

## PR Type

### What kind of change does this PR introduce?

Adding more examples to the spartan docs demonstrating a complex data table for tasks.

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?
none, just docs

## What is the current behavior?

The examples in the app do not showcase complex data tables.

## What is the new behavior?

I added an extra example to showcase a complex data table managing tasks (you might have seen that example before ;)) 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
I wanted to add that the reason for me pushing to use spartan in my company (and we do now in production across multiple module federated apps), was the amazing feel of working with spartan and the data table was one big selling part.
Therefore, i thought it would be nice to add a more elaborate example to show others what one can achieve with spartan.
Let me know of any improvements i shall make.