### PR TITLE
fix(dropdown-menu,context-menu,menubar): set our menu side to default…

### DIFF
--- a/libs/brain/menu/src/lib/brn-menu.directive.ts
+++ b/libs/brain/menu/src/lib/brn-menu.directive.ts
@@ -39,6 +39,12 @@ export class BrnMenuDirective {
 			// we can access it here and determine the correct side.
 			// eslint-disable-next-line
 			const ps = (this._host as any)._parentTrigger._spartanLastPosition;
+			if (!ps) {
+				// if we have no last position we default to the most likely option
+				// I hate that we have to do this and hope we can revisit soon and improve
+				this._side.set(isRoot ? 'top' : 'left');
+				return;
+			}
 			const side = isRoot ? ps.originY : ps.originX === 'end' ? 'right' : 'left';
 			this._side.set(side);
 		});


### PR DESCRIPTION
…s if no prev position

we are using some ugly workaround to store the last position, of the menu we opened and then set the side based on that. sometimes there is no last position available so we should just set to defaults and return instead of throwing an error trying to access an undefined object

closes #553

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [x] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [x] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [x] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #553

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
