### PR TITLE
fix(command): dynamic options are loaded without error

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/command/command--dynamic.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/command/command--dynamic.cy.ts
@@ -1,0 +1,23 @@
+describe('command', () => {
+	describe('dynamic', () => {
+		beforeEach(() => {
+			cy.visit('/iframe.html?id=command--dynamic-options');
+			cy.injectAxe();
+		});
+		it(`
+	  should render items without error.
+	  `, () => {
+			cy.checkA11y('#storybook-root', {
+				rules: {
+					'page-has-heading-one': { enabled: false },
+					'landmark-one-main': { enabled: false },
+				},
+			});
+
+			cy.findByTestId('toggleButton').click();
+			cy.findByText('Profile').should('have.length', 1);
+			cy.findByText('Billing').should('have.length', 1);
+			cy.findByText('Settings').should('have.length', 1);
+		});
+	});
+});

--- a/libs/brain/command/src/lib/brn-command-item.directive.ts
+++ b/libs/brain/command/src/lib/brn-command-item.directive.ts
@@ -9,6 +9,7 @@ import {
 	HostListener,
 	inject,
 	input,
+	OnInit,
 	output,
 	PLATFORM_ID,
 	signal,
@@ -32,7 +33,7 @@ import { injectBrnCommand } from './brn-command.token';
 		'[attr.data-selected]': "active() ? '' : null",
 	},
 })
-export class BrnCommandItemDirective implements Highlightable {
+export class BrnCommandItemDirective implements Highlightable, OnInit {
 	private static _id = 0;
 
 	private readonly _platform = inject(PLATFORM_ID);
@@ -59,6 +60,11 @@ export class BrnCommandItemDirective implements Highlightable {
 		return this._disabled();
 	}
 
+	/** Whether the item is initialized, this is to prevent accessing the value-input before the component is initialized.
+	 * The brn-command-empty directive accesses the value before the component is initialized, which causes an error.
+	 */
+	private readonly _initialized = signal(false);
+
 	/** Whether the item is selected. */
 	protected readonly active = signal(false);
 
@@ -66,7 +72,12 @@ export class BrnCommandItemDirective implements Highlightable {
 	public readonly selected = output<void>();
 
 	/** @internal Determine if this item is visible based on the current search query */
-	public readonly visible = computed(() => this._command.filter()(this.value(), this._command.search()));
+	public readonly visible = computed(() => {
+		if (!this._initialized()) {
+			return false;
+		}
+		return this._command.filter()(this.value(), this._command.search());
+	});
 
 	/** @internal Get the display value */
 	public getLabel(): string {
@@ -92,5 +103,9 @@ export class BrnCommandItemDirective implements Highlightable {
 	protected onClick(): void {
 		this._command.keyManager.setActiveItem(this);
 		this.selected.emit();
+	}
+
+	ngOnInit(): void {
+		this._initialized.set(true);
 	}
 }

--- a/libs/ui/command/command.stories.ts
+++ b/libs/ui/command/command.stories.ts
@@ -205,3 +205,76 @@ export const Dialog: Story = {
 		template: '<command-dialog-component/>',
 	}),
 };
+
+@Component({
+	selector: 'command-dynamic-component',
+	standalone: true,
+	imports: [
+		BrnCommandImports,
+		HlmCommandImports,
+		BrnDialogImports,
+		HlmDialogOverlayDirective,
+		NgIcon,
+		HlmIconDirective,
+		HlmButtonDirective,
+		HlmCodeDirective,
+	],
+	template: `
+		<!-- we need to add a toggle because the test would not fail if the command is visible from the beginning -->
+		<button hlm-button variant="outline" data-testid="toggleButton" (click)="toggle.set(!toggle())">Toggle</button>
+		@if (toggle()) {
+			<hlm-command>
+				<hlm-command-search>
+					<ng-icon hlm name="lucideSearch" class="inline-flex" />
+
+					<input type="text" hlm-command-search-input placeholder="Type a command or search..." />
+				</hlm-command-search>
+
+				<hlm-command-list>
+					<hlm-command-group>
+						<hlm-command-group-label>Suggestions</hlm-command-group-label>
+						@for (item of items(); track item.value) {
+							<button hlm-command-item [value]="item.value">
+								<ng-icon hlm [name]="item.icon" hlmCommandIcon />
+								{{ item.label }}
+							</button>
+						}
+					</hlm-command-group>
+				</hlm-command-list>
+
+				<!-- Empty state -->
+				<div *brnCommandEmpty hlmCommandEmpty>No results found.</div>
+			</hlm-command>
+		}
+	`,
+})
+class CommandDynamicComponent {
+	protected readonly items = signal<{ label: string; value: string; icon: string; shortcut: string }[]>([
+		{ label: 'Profile', value: 'Profile', icon: 'lucideUser', shortcut: '⌘P' },
+		{ label: 'Billing', value: 'Billing', icon: 'lucideWallet', shortcut: '⌘B' },
+		{ label: 'Settings', value: 'Settings', icon: 'lucideCog', shortcut: '⌘S' },
+	]);
+	public command = signal('');
+	public state = signal<'closed' | 'open'>('closed');
+	protected toggle = signal(false);
+
+	stateChanged(state: 'open' | 'closed') {
+		this.state.set(state);
+	}
+
+	commandSelected(selected: string) {
+		this.state.set('closed');
+		this.command.set(selected);
+	}
+}
+
+export const DynamicOptions: Story = {
+	decorators: [
+		moduleMetadata({
+			imports: [CommandDynamicComponent],
+		}),
+	],
+	render: () => ({
+		template: '<command-dynamic-component/>',
+	}),
+};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [x] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

When adding the items of a command via for loop an  NG0950 exception occurs, because the input is not initialized.
the ``BrnCommandEmptyDirective`` calls the visible property via ``contentChildren``. visible() itself is a computed which accesses the value of the ``BrnCommandItemDirective``. 
Usually it is safe to use the input in computeds because inside a component this always is called after the input is initialized. 
The problem here is, that the input is accessed through a computed of another component.

Closes #587 

## What is the new behavior?

the directive waits until it is initialized before it accesses the input. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


