### PR TITLE
fix(command): add valueChanged again

### DIFF
--- a/libs/brain/command/src/lib/brn-command.directive.ts
+++ b/libs/brain/command/src/lib/brn-command.directive.ts
@@ -15,7 +15,6 @@ import {
 	PLATFORM_ID,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { BrnCommandItemDirective } from './brn-command-item.directive';
 import { BrnCommandItemToken } from './brn-command-item.token';
 import { BrnCommandSearchInputDirective } from './brn-command-search-input.directive';
 import { provideBrnCommand } from './brn-command.token';
@@ -46,7 +45,7 @@ export class BrnCommandDirective implements AfterViewInit {
 	public readonly filter = input<CommandFilter>(this._defaultFilter);
 
 	/** when the selection has changed */
-	public readonly valueChanged = output<string>();
+	public readonly valueChange = output<string>();
 
 	/** @internal The search query */
 	public readonly search = computed(() => this._searchInput()?.value() ?? '');
@@ -84,9 +83,9 @@ export class BrnCommandDirective implements AfterViewInit {
 		);
 
 		this.keyManager.change.pipe(takeUntilDestroyed()).subscribe(() => {
-			const value = (this.keyManager.activeItem as BrnCommandItemDirective)?.value();
+			const value = this.keyManager.activeItem?.value();
 			if (value) {
-				this.valueChanged.emit(value);
+				this.valueChange.emit(value);
 			}
 		});
 	}

--- a/libs/brain/command/src/lib/brn-command.directive.ts
+++ b/libs/brain/command/src/lib/brn-command.directive.ts
@@ -11,8 +11,11 @@ import {
 	inject,
 	Injector,
 	input,
+	output,
 	PLATFORM_ID,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { BrnCommandItemDirective } from './brn-command-item.directive';
 import { BrnCommandItemToken } from './brn-command-item.token';
 import { BrnCommandSearchInputDirective } from './brn-command-search-input.directive';
 import { provideBrnCommand } from './brn-command.token';
@@ -41,6 +44,9 @@ export class BrnCommandDirective implements AfterViewInit {
 
 	/** A custom filter function to use when searching. */
 	public readonly filter = input<CommandFilter>(this._defaultFilter);
+
+	/** when the selection has changed */
+	public readonly valueChanged = output<string>();
 
 	/** @internal The search query */
 	public readonly search = computed(() => this._searchInput()?.value() ?? '');
@@ -76,6 +82,13 @@ export class BrnCommandDirective implements AfterViewInit {
 			},
 			{ allowSignalWrites: true },
 		);
+
+		this.keyManager.change.pipe(takeUntilDestroyed()).subscribe(() => {
+			const value = (this.keyManager.activeItem as BrnCommandItemDirective)?.value();
+			if (value) {
+				this.valueChanged.emit(value);
+			}
+		});
 	}
 
 	ngAfterViewInit(): void {

--- a/libs/ui/command/helm/src/lib/hlm-command.component.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command.component.ts
@@ -8,7 +8,12 @@ import { hlm } from '@spartan-ng/brain/core';
 	template: `
 		<ng-content />
 	`,
-	hostDirectives: [BrnCommandDirective],
+	hostDirectives: [
+		{
+			directive: BrnCommandDirective,
+			outputs: ['valueChanged'],
+		},
+	],
 	host: {
 		'[class]': '_computedClass()',
 	},

--- a/libs/ui/command/helm/src/lib/hlm-command.component.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command.component.ts
@@ -11,7 +11,7 @@ import { hlm } from '@spartan-ng/brain/core';
 	hostDirectives: [
 		{
 			directive: BrnCommandDirective,
-			outputs: ['valueChanged'],
+			outputs: ['valueChange'],
 		},
 	],
 	host: {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [x] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

valueChanged Event does not exist anymore, but it was implemented in the cmdk version. 

Closes #589 

## What is the new behavior?

``valueChanged`` was added and returns the value of the active item. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
