### PR TITLE
fix(form-field): semantically link hint and error to input

### DIFF
--- a/libs/brain/form-field/src/index.ts
+++ b/libs/brain/form-field/src/index.ts
@@ -1,1 +1,4 @@
+export * from './lib/brn-error.directive';
 export * from './lib/brn-form-field-control';
+export * from './lib/brn-form-field.directive';
+export * from './lib/brn-hint.directive';

--- a/libs/brain/form-field/src/lib/brn-error.directive.ts
+++ b/libs/brain/form-field/src/lib/brn-error.directive.ts
@@ -1,0 +1,16 @@
+import { Directive, input } from '@angular/core';
+
+let uniqueId = 0;
+
+@Directive({
+	// eslint-disable-next-line @angular-eslint/directive-selector
+	selector: 'brn-error',
+	standalone: true,
+	host: {
+		'[id]': 'id()',
+	},
+})
+export class BrnErrorDirective {
+	/** The unique id for the header */
+	public readonly id = input(`brn-error-${uniqueId++}`);
+}

--- a/libs/brain/form-field/src/lib/brn-form-field.directive.ts
+++ b/libs/brain/form-field/src/lib/brn-form-field.directive.ts
@@ -1,0 +1,30 @@
+import { contentChild, contentChildren, Directive, effect } from '@angular/core';
+import { BrnInputDirective } from '@spartan-ng/brain/input';
+import { BrnErrorDirective } from './brn-error.directive';
+import { BrnFormFieldControl } from './brn-form-field-control';
+import { BrnHintDirective } from './brn-hint.directive';
+
+@Directive({
+	selector: '[brnFormField]',
+	standalone: true,
+})
+export class BrnFormFieldDirective {
+	public readonly hintChildren = contentChildren(BrnHintDirective);
+	public readonly errorChildren = contentChildren(BrnErrorDirective);
+	public readonly control = contentChild(BrnFormFieldControl);
+	public readonly input = contentChild(BrnInputDirective);
+
+	constructor() {
+		effect(() => {
+			if (this.input()) {
+				if (this.errorChildren()?.length && this.control()?.errorState()) {
+					const errorIds = this.errorChildren().map((error) => error.id());
+					this.input()!.setAriaDescribedBy(errorIds.join(' '));
+				} else if (this.hintChildren()?.length) {
+					const hintIds = this.hintChildren().map((hint) => hint.id());
+					this.input()!.setAriaDescribedBy(hintIds.join(' '));
+				}
+			}
+		});
+	}
+}

--- a/libs/brain/form-field/src/lib/brn-hint.directive.ts
+++ b/libs/brain/form-field/src/lib/brn-hint.directive.ts
@@ -1,0 +1,16 @@
+import { Directive, input } from '@angular/core';
+
+let uniqueId = 0;
+
+@Directive({
+	// eslint-disable-next-line @angular-eslint/directive-selector
+	selector: 'brn-hint',
+	standalone: true,
+	host: {
+		'[id]': 'id()',
+	},
+})
+export class BrnHintDirective {
+	/** The unique id for the header */
+	public readonly id = input(`brn-hint-${uniqueId++}`);
+}

--- a/libs/brain/input/README.md
+++ b/libs/brain/input/README.md
@@ -1,0 +1,3 @@
+# @spartan-ng/brain/input
+
+Secondary entry point of `@spartan-ng/brain`. It can be used by importing from `@spartan-ng/brain/input`.

--- a/libs/brain/input/ng-package.json
+++ b/libs/brain/input/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/brain/input/src/index.ts
+++ b/libs/brain/input/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/brn-input.directive';

--- a/libs/brain/input/src/lib/brn-input.directive.ts
+++ b/libs/brain/input/src/lib/brn-input.directive.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectorRef, Directive, inject } from '@angular/core';
+
+@Directive({
+	selector: '[brnInput]',
+	standalone: true,
+	host: {
+		'[attr.aria-describedby]': 'ariaDescribedBy || null',
+	},
+})
+export class BrnInputDirective {
+	private readonly _cdRef = inject(ChangeDetectorRef);
+
+	public ariaDescribedBy = '';
+
+	public setAriaDescribedBy(ids: string) {
+		this.ariaDescribedBy = ids;
+		this._cdRef.markForCheck();
+	}
+}

--- a/libs/ui/form-field/form-field.stories.ts
+++ b/libs/ui/form-field/form-field.stories.ts
@@ -1,8 +1,8 @@
 import { Component, type OnInit, inject } from '@angular/core';
 import { FormBuilder, FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ErrorStateMatcher, ShowOnDirtyErrorStateMatcher } from '@spartan-ng/brain/forms';
-import { BrnSelectImports } from '@spartan-ng/brain/select';
 import { type Meta, type StoryObj, moduleMetadata } from '@storybook/angular';
+import { BrnSelectImports } from '../../brain/select/src';
 import { HlmButtonDirective, HlmButtonModule } from '../button/helm/src';
 import { HlmInputDirective } from '../input/helm/src';
 import { HlmSelectImports, HlmSelectModule } from '../select/helm/src';
@@ -75,6 +75,21 @@ export const Hint: Story = {
 			<hlm-hint>This is your public display name.</hlm-hint>
 		</hlm-form-field>
 		`,
+	}),
+};
+
+export const HintAndError: Story = {
+	render: (args) => ({
+		props: {
+			...args,
+			username: new FormControl(null, { validators: Validators.required }),
+		},
+		template: `
+		<hlm-form-field>
+			<input aria-label='Your Name' class='w-80' hlmInput type='text' placeholder='shadcn' [formControl]="username"/>
+			<hlm-hint>This is your public display name.</hlm-hint>
+			<hlm-error>Username is required</hlm-error>
+		</hlm-form-field>`,
 	}),
 };
 

--- a/libs/ui/form-field/helm/src/lib/form-field.spec.ts
+++ b/libs/ui/form-field/helm/src/lib/form-field.spec.ts
@@ -133,4 +133,25 @@ describe('Hlm Form Field Component', () => {
 			expect(error()?.textContent?.trim()).toBe(TEXT_ERROR);
 		});
 	});
+
+	describe('Hlm Form Field Component ID Tests', () => {
+		it('should have an id that begins with "brn-hint-" on the hint directive', async () => {
+			const { hint } = await setupFormField();
+			expect(hint.getAttribute('id')).toBeDefined() // Check if the id attribute exists
+			expect(hint.getAttribute('id')).toMatch(/^brn-hint-/); // Assert that the id begins with "brn-hint-"
+		});
+
+		it('should have an id that begins with "brn-error-" on the error directive', async () => {
+			const { error, user, trigger } = await setupFormFieldWithErrorStateDirty();
+
+						await user.click(trigger);
+						await user.type(trigger, 'a');
+						await user.clear(trigger);
+
+						await user.click(document.body);
+
+			expect(error()?.getAttribute('id')).toBeDefined();  // Check if the id attribute exists
+			expect(error()?.getAttribute('id')).toMatch(/^brn-error-/); // Assert that the id begins with "brn-error-"
+		});
+	});
 });

--- a/libs/ui/form-field/helm/src/lib/hlm-error.directive.ts
+++ b/libs/ui/form-field/helm/src/lib/hlm-error.directive.ts
@@ -1,9 +1,11 @@
 import { Directive } from '@angular/core';
+import { BrnErrorDirective } from '@spartan-ng/brain/form-field';
 
 @Directive({
-	standalone: true,
 	// eslint-disable-next-line @angular-eslint/directive-selector
 	selector: 'hlm-error',
+	standalone: true,
+	hostDirectives: [BrnErrorDirective],
 	host: {
 		class: 'block text-destructive text-sm font-medium',
 	},

--- a/libs/ui/form-field/helm/src/lib/hlm-form-field.component.ts
+++ b/libs/ui/form-field/helm/src/lib/hlm-form-field.component.ts
@@ -1,5 +1,5 @@
 import { Component, computed, contentChild, contentChildren, effect } from '@angular/core';
-import { BrnFormFieldControl } from '@spartan-ng/brain/form-field';
+import { BrnFormFieldControl, BrnFormFieldDirective } from '@spartan-ng/brain/form-field';
 import { HlmErrorDirective } from './hlm-error.directive';
 
 @Component({
@@ -20,6 +20,7 @@ import { HlmErrorDirective } from './hlm-error.directive';
 	host: {
 		class: 'space-y-2 block',
 	},
+	hostDirectives: [BrnFormFieldDirective],
 })
 export class HlmFormFieldComponent {
 	public readonly control = contentChild(BrnFormFieldControl);

--- a/libs/ui/form-field/helm/src/lib/hlm-hint.directive.ts
+++ b/libs/ui/form-field/helm/src/lib/hlm-hint.directive.ts
@@ -1,9 +1,11 @@
 import { Directive } from '@angular/core';
+import { BrnHintDirective } from '@spartan-ng/brain/form-field';
 
 @Directive({
 	// eslint-disable-next-line @angular-eslint/directive-selector
 	selector: 'hlm-hint',
 	standalone: true,
+	hostDirectives: [BrnHintDirective],
 	host: {
 		class: 'block text-sm text-muted-foreground',
 	},

--- a/libs/ui/input/helm/src/lib/hlm-input.directive.ts
+++ b/libs/ui/input/helm/src/lib/hlm-input.directive.ts
@@ -3,6 +3,7 @@ import { FormGroupDirective, NgControl, NgForm } from '@angular/forms';
 import { hlm } from '@spartan-ng/brain/core';
 import { BrnFormFieldControl } from '@spartan-ng/brain/form-field';
 import { ErrorStateMatcher, ErrorStateTracker } from '@spartan-ng/brain/forms';
+import { BrnInputDirective } from '@spartan-ng/brain/input';
 
 import { type VariantProps, cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
@@ -35,6 +36,7 @@ type InputVariants = VariantProps<typeof inputVariants>;
 	host: {
 		'[class]': '_computedClass()',
 	},
+	hostDirectives: [BrnInputDirective],
 	providers: [
 		{
 			provide: BrnFormFieldControl,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -49,6 +49,7 @@
 			"@spartan-ng/brain/form-field": ["libs/brain/form-field/src/index.ts"],
 			"@spartan-ng/brain/forms": ["libs/brain/forms/src/index.ts"],
 			"@spartan-ng/brain/hover-card": ["libs/brain/hover-card/src/index.ts"],
+			"@spartan-ng/brain/input": ["libs/brain/input/src/index.ts"],
 			"@spartan-ng/brain/label": ["libs/brain/label/src/index.ts"],
 			"@spartan-ng/brain/menu": ["libs/brain/menu/src/index.ts"],
 			"@spartan-ng/brain/popover": ["libs/brain/popover/src/index.ts"],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [x] form-field
- [ ] hover-card
- [ ] icon
- [x] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Hints and errors are not semantically linked to the input so they are not read by a screenreader

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #591 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
