### PR TITLE
fix(command): ngModel is recognized, NG0950 error fixed, focus up and…   … down fixed

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(command)/command.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(command)/command.preview.ts
@@ -10,14 +10,13 @@ import {
 	lucideWallet,
 } from '@ng-icons/lucide';
 import { BrnCommandImports } from '@spartan-ng/brain/command';
-import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
 import { HlmCommandImports } from '@spartan-ng/ui-command-helm';
 import { HlmIconDirective } from '@spartan-ng/ui-icon-helm';
 
 @Component({
 	selector: 'spartan-command-preview',
 	standalone: true,
-	imports: [BrnCommandImports, HlmCommandImports, NgIcon, HlmIconDirective, HlmButtonDirective],
+	imports: [BrnCommandImports, HlmCommandImports, NgIcon, HlmIconDirective],
 	providers: [
 		provideIcons({
 			lucideSearch,
@@ -90,7 +89,6 @@ import { Component } from '@angular/core';
 import { BrnCommandImports } from '@spartan-ng/brain/command';
 import { HlmCommandImports } from '@spartan-ng/ui-command-helm';
 import { HlmIconDirective } from '@spartan-ng/ui-icon-helm';
-import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
 import { provideIcons } from '@ng-icons/core';
 import {
   lucideCalendar,
@@ -105,7 +103,7 @@ import {
 @Component({
   selector: 'spartan-command-preview',
   standalone: true,
-  imports: [BrnCommandImports, HlmCommandImports, HlmIconDirective, HlmButtonDirective],
+  imports: [BrnCommandImports, HlmCommandImports, HlmIconDirective ],
   providers: [
     provideIcons({ lucideSearch, lucideCalendar, lucideSmile, lucidePlus, lucideUser, lucideWallet, lucideCog }),
   ],

--- a/apps/ui-storybook-e2e/src/integration/command/command--dynamic.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/command/command--dynamic.cy.ts
@@ -1,10 +1,10 @@
 describe('command', () => {
-	describe('dynamic', () => {
+	describe('dynamic with ngModel', () => {
 		beforeEach(() => {
 			cy.visit('/iframe.html?id=command--dynamic-options');
 			cy.injectAxe();
 		});
-		it(`should render items without error.`, () => {
+		it(`should show items based on input value without error.`, () => {
 			cy.checkA11y('#storybook-root', {
 				rules: {
 					'page-has-heading-one': { enabled: false },
@@ -28,6 +28,47 @@ describe('command', () => {
 			cy.get('input').type('t');
 			cy.get('button[hlm-command-item][data-selected]').should('have.length', 1);
 			cy.get('button[hlm-command-item][data-selected]').should('include.text', 'Settings');
+		});
+	});
+
+	describe('dynamic with reactive form', () => {
+		beforeEach(() => {
+			cy.visit('/iframe.html?id=command--reactive-form');
+			cy.injectAxe();
+		});
+		it(`should show items based on input value without error.`, () => {
+			cy.checkA11y('#storybook-root', {
+				rules: {
+					'page-has-heading-one': { enabled: false },
+					'landmark-one-main': { enabled: false },
+				},
+			});
+
+			/**       TEST initially it should only show Profile and Search Emoji    */
+			cy.get('button[hlm-command-item]:not([data-hidden])').should('have.length', 2);
+
+			cy.findByText('Profile').should('have.length', 1);
+			cy.findByText('Search Emoji').should('have.length', 1);
+		});
+	});
+
+	describe('dynamic with direct value binding', () => {
+		beforeEach(() => {
+			cy.visit('/iframe.html?id=command--bound-value');
+			cy.injectAxe();
+		});
+		it(`should show items based on input value without error.`, () => {
+			cy.checkA11y('#storybook-root', {
+				rules: {
+					'page-has-heading-one': { enabled: false },
+					'landmark-one-main': { enabled: false },
+				},
+			});
+
+			/**       TEST initially it should only show Search and Settings   */
+			cy.get('button[hlm-command-item]:not([data-hidden])').should('have.length', 2);
+			cy.findByText('Search Emoji').should('have.length', 1);
+			cy.findByText('Settings').should('have.length', 1);
 		});
 	});
 });

--- a/apps/ui-storybook-e2e/src/integration/command/command--dynamic.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/command/command--dynamic.cy.ts
@@ -4,9 +4,7 @@ describe('command', () => {
 			cy.visit('/iframe.html?id=command--dynamic-options');
 			cy.injectAxe();
 		});
-		it(`
-	  should render items without error.
-	  `, () => {
+		it(`should render items without error.`, () => {
 			cy.checkA11y('#storybook-root', {
 				rules: {
 					'page-has-heading-one': { enabled: false },
@@ -14,10 +12,22 @@ describe('command', () => {
 				},
 			});
 
-			cy.findByTestId('toggleButton').click();
+			/**       TEST initially it should only show Profiles   */
+			cy.get('button[hlm-command-item]:not([data-hidden])').should('have.length', 1);
+
+			/**       TEST after deleting search input it should show all items    */
 			cy.findByText('Profile').should('have.length', 1);
-			cy.findByText('Billing').should('have.length', 1);
-			cy.findByText('Settings').should('have.length', 1);
+			cy.get('input').type('{backspace}');
+			cy.get('button[hlm-command-item]:not([data-hidden])').should('have.length', 4);
+			cy.get('button[hlm-command-item][data-selected]').should('include.text', 'Profile');
+
+			/**       TEST Focusing first if selected item is not visible          */
+			cy.get('input').type('s');
+			cy.get('button[hlm-command-item][data-selected]').should('include.text', 'Search Emoji');
+			cy.get('input').type('e');
+			cy.get('input').type('t');
+			cy.get('button[hlm-command-item][data-selected]').should('have.length', 1);
+			cy.get('button[hlm-command-item][data-selected]').should('include.text', 'Settings');
 		});
 	});
 });

--- a/libs/brain/command/src/lib/brn-command-item.directive.ts
+++ b/libs/brain/command/src/lib/brn-command-item.directive.ts
@@ -73,15 +73,20 @@ export class BrnCommandItemDirective implements Highlightable, OnInit {
 
 	/** @internal Determine if this item is visible based on the current search query */
 	public readonly visible = computed(() => {
+		return this._command.filter()(this.safeValue(), this._command.search());
+	});
+
+	/** @internal Get the value of the item, with check if it has been initialized to avoid errors */
+	public safeValue = computed(() => {
 		if (!this._initialized()) {
-			return false;
+			return '';
 		}
-		return this._command.filter()(this.value(), this._command.search());
+		return this.value();
 	});
 
 	/** @internal Get the display value */
 	public getLabel(): string {
-		return this.value();
+		return this.safeValue();
 	}
 
 	/** @internal */

--- a/libs/brain/command/src/lib/brn-command-search-input.directive.ts
+++ b/libs/brain/command/src/lib/brn-command-search-input.directive.ts
@@ -1,5 +1,6 @@
-import { Directive, ElementRef, HostListener, inject, signal } from '@angular/core';
+import { Directive, ElementRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { NgModel } from '@angular/forms';
 import { startWith } from 'rxjs/operators';
 import { provideBrnCommandSearchInput } from './brn-command-search-input.token';
 import { injectBrnCommand } from './brn-command.token';
@@ -12,9 +13,12 @@ import { injectBrnCommand } from './brn-command.token';
 		role: 'combobox',
 		'aria-autocomplete': 'list',
 		'[attr.aria-activedescendant]': '_activeDescendant()',
+		'(keydown)': 'onKeyDown($event)',
+		'(input)': 'onInput()',
 	},
 })
 export class BrnCommandSearchInputDirective {
+	private readonly _ngModel = inject(NgModel, { optional: true });
 	private readonly _command = injectBrnCommand();
 	private readonly _elementRef = inject<ElementRef<HTMLInputElement>>(ElementRef);
 
@@ -28,16 +32,24 @@ export class BrnCommandSearchInputDirective {
 		this._command.keyManager.change
 			.pipe(startWith(this._command.keyManager.activeItemIndex), takeUntilDestroyed())
 			.subscribe(() => this._activeDescendant.set(this._command.keyManager.activeItem?.id()));
+
+		const ngModel = this._ngModel;
+		if (ngModel) {
+			ngModel.valueChanges?.pipe(takeUntilDestroyed()).subscribe((value) => {
+				this.value.set(value);
+			});
+		}
 	}
 
 	/** Listen for changes to the input value */
-	@HostListener('input')
 	protected onInput(): void {
+		if (this._ngModel) {
+			return;
+		}
 		this.value.set(this._elementRef.nativeElement.value);
 	}
 
 	/** Listen for keydown events */
-	@HostListener('keydown', ['$event'])
 	protected onKeyDown(event: KeyboardEvent): void {
 		this._command.keyManager.onKeydown(event);
 	}

--- a/libs/brain/command/src/lib/brn-command.directive.ts
+++ b/libs/brain/command/src/lib/brn-command.directive.ts
@@ -49,7 +49,7 @@ export class BrnCommandDirective implements AfterViewInit {
 	public readonly valueChange = output<string>();
 
 	/** @internal The search query */
-	public readonly search = computed(() => this._searchInput()?.value() ?? '');
+	public readonly search = computed(() => this._searchInput()?.valueState() ?? '');
 
 	/** Access the search input if present */
 	private readonly _searchInput = contentChild(BrnCommandSearchInputDirective, {

--- a/libs/brain/command/src/lib/brn-command.directive.ts
+++ b/libs/brain/command/src/lib/brn-command.directive.ts
@@ -13,6 +13,7 @@ import {
 	input,
 	output,
 	PLATFORM_ID,
+	untracked,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BrnCommandItemToken } from './brn-command-item.token';
@@ -68,22 +69,21 @@ export class BrnCommandDirective implements AfterViewInit {
 			.withVerticalOrientation()
 			.withHomeAndEnd()
 			.withWrap()
-			.withTypeAhead()
 			.skipPredicate((item) => item.disabled || !item.visible());
 
 		// When clearing the search input we also want to reset the active item to the first one
-		effect(
-			() => {
-				const searchInput = this._searchInput()?.value();
-				if (searchInput !== undefined && searchInput.length === 0) {
-					this.keyManager.setActiveItem(0);
+		effect(() => {
+			const searchInput = this.search();
+			untracked(() => {
+				const activeItemIsVisible = this.keyManager.activeItem?.visible();
+				if ((searchInput !== undefined && searchInput.length === 0) || !activeItemIsVisible) {
+					this.keyManager.setFirstItemActive();
 				}
-			},
-			{ allowSignalWrites: true },
-		);
+			});
+		});
 
 		this.keyManager.change.pipe(takeUntilDestroyed()).subscribe(() => {
-			const value = this.keyManager.activeItem?.value();
+			const value = this.keyManager.activeItem?.safeValue();
 			if (value) {
 				this.valueChange.emit(value);
 			}

--- a/libs/ui/command/command.stories.ts
+++ b/libs/ui/command/command.stories.ts
@@ -1,5 +1,5 @@
 import { Component, HostListener, signal } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import * as lucide from '@ng-icons/lucide';
 import { BrnCommandDirective, BrnCommandImports } from '@spartan-ng/brain/command';
@@ -214,11 +214,9 @@ export const Dialog: Story = {
 		BrnCommandImports,
 		HlmCommandImports,
 		BrnDialogImports,
-		HlmDialogOverlayDirective,
 		NgIcon,
 		HlmIconDirective,
 		HlmButtonDirective,
-		HlmCodeDirective,
 		FormsModule,
 	],
 	template: `
@@ -254,18 +252,6 @@ class CommandDynamicComponent {
 		{ label: 'Search Emoji', value: 'Search Emoji', icon: 'lucideSmile', shortcut: '⌘E' },
 		{ label: 'Settings', value: 'Settings', icon: 'lucideCog', shortcut: '⌘S' },
 	]);
-	public command = signal('');
-	public state = signal<'closed' | 'open'>('closed');
-	protected toggle = signal(false);
-
-	stateChanged(state: 'open' | 'closed') {
-		this.state.set(state);
-	}
-
-	commandSelected(selected: string) {
-		this.state.set('closed');
-		this.command.set(selected);
-	}
 }
 
 export const DynamicOptions: Story = {
@@ -276,5 +262,120 @@ export const DynamicOptions: Story = {
 	],
 	render: () => ({
 		template: '<command-dynamic-component/>',
+	}),
+};
+
+@Component({
+	selector: 'command-reactive-form-component',
+	standalone: true,
+	imports: [
+		BrnCommandImports,
+		HlmCommandImports,
+		NgIcon,
+		HlmIconDirective,
+		HlmButtonDirective,
+		FormsModule,
+		ReactiveFormsModule,
+	],
+	template: `
+		<hlm-command>
+			<hlm-command-search>
+				<ng-icon hlm name="lucideSearch" class="inline-flex" />
+
+				<input
+					type="text"
+					hlm-command-search-input
+					placeholder="Type a command or search..."
+					[formControl]="searchControl"
+				/>
+			</hlm-command-search>
+
+			<hlm-command-list>
+				<hlm-command-group>
+					<hlm-command-group-label>Suggestions</hlm-command-group-label>
+					@for (item of items(); track item.value) {
+						<button hlm-command-item [value]="item.value" data-testid="command-item">
+							<ng-icon hlm [name]="item.icon" hlmCommandIcon />
+							{{ item.label }}
+						</button>
+					}
+				</hlm-command-group>
+			</hlm-command-list>
+
+			<!-- Empty state -->
+			<div *brnCommandEmpty hlmCommandEmpty>No results found.</div>
+		</hlm-command>
+	`,
+})
+class CommandReactiveFormComponent {
+	searchControl = new FormControl('R');
+	protected readonly search = signal('P');
+	protected readonly items = signal<{ label: string; value: string; icon: string; shortcut: string }[]>([
+		{ label: 'Profile', value: 'Profile', icon: 'lucideUser', shortcut: '⌘P' },
+		{ label: 'Billing', value: 'Billing', icon: 'lucideWallet', shortcut: '⌘B' },
+		{ label: 'Search Emoji', value: 'Search Emoji', icon: 'lucideSmile', shortcut: '⌘E' },
+		{ label: 'Settings', value: 'Settings', icon: 'lucideCog', shortcut: '⌘S' },
+	]);
+	public state = signal<'closed' | 'open'>('closed');
+}
+
+export const ReactiveForm: Story = {
+	decorators: [
+		moduleMetadata({
+			imports: [CommandReactiveFormComponent],
+		}),
+	],
+	render: () => ({
+		template: '<command-reactive-form-component/>',
+	}),
+};
+
+@Component({
+	selector: 'command-bound-value-component',
+	standalone: true,
+	imports: [BrnCommandImports, HlmCommandImports, NgIcon, HlmIconDirective, HlmButtonDirective],
+	template: `
+		<hlm-command>
+			<hlm-command-search>
+				<ng-icon hlm name="lucideSearch" class="inline-flex" />
+
+				<input type="text" hlm-command-search-input placeholder="Type a command or search..." [value]="search()" />
+			</hlm-command-search>
+
+			<hlm-command-list>
+				<hlm-command-group>
+					<hlm-command-group-label>Suggestions</hlm-command-group-label>
+					@for (item of items(); track item.value) {
+						<button hlm-command-item [value]="item.value" data-testid="command-item">
+							<ng-icon hlm [name]="item.icon" hlmCommandIcon />
+							{{ item.label }}
+						</button>
+					}
+				</hlm-command-group>
+			</hlm-command-list>
+
+			<!-- Empty state -->
+			<div *brnCommandEmpty hlmCommandEmpty>No results found.</div>
+		</hlm-command>
+	`,
+})
+class CommandBoundValueComponent {
+	protected readonly search = signal('S');
+	protected readonly items = signal<{ label: string; value: string; icon: string; shortcut: string }[]>([
+		{ label: 'Profile', value: 'Profile', icon: 'lucideUser', shortcut: '⌘P' },
+		{ label: 'Billing', value: 'Billing', icon: 'lucideWallet', shortcut: '⌘B' },
+		{ label: 'Search Emoji', value: 'Search Emoji', icon: 'lucideSmile', shortcut: '⌘E' },
+		{ label: 'Settings', value: 'Settings', icon: 'lucideCog', shortcut: '⌘S' },
+	]);
+}
+
+export const BoundValue: Story = {
+	decorators: [
+		moduleMetadata({
+			imports: [CommandBoundValueComponent],
+		}),
+	],
+	render: () => ({
+		template: '<command-bound-value-component/>',
 	}),
 };

--- a/libs/ui/command/command.stories.ts
+++ b/libs/ui/command/command.stories.ts
@@ -1,4 +1,5 @@
 import { Component, HostListener, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import * as lucide from '@ng-icons/lucide';
 import { BrnCommandDirective, BrnCommandImports } from '@spartan-ng/brain/command';
@@ -218,40 +219,39 @@ export const Dialog: Story = {
 		HlmIconDirective,
 		HlmButtonDirective,
 		HlmCodeDirective,
+		FormsModule,
 	],
 	template: `
-		<!-- we need to add a toggle because the test would not fail if the command is visible from the beginning -->
-		<button hlm-button variant="outline" data-testid="toggleButton" (click)="toggle.set(!toggle())">Toggle</button>
-		@if (toggle()) {
-			<hlm-command>
-				<hlm-command-search>
-					<ng-icon hlm name="lucideSearch" class="inline-flex" />
+		<hlm-command>
+			<hlm-command-search>
+				<ng-icon hlm name="lucideSearch" class="inline-flex" />
 
-					<input type="text" hlm-command-search-input placeholder="Type a command or search..." />
-				</hlm-command-search>
+				<input type="text" hlm-command-search-input placeholder="Type a command or search..." [ngModel]="search()" />
+			</hlm-command-search>
 
-				<hlm-command-list>
-					<hlm-command-group>
-						<hlm-command-group-label>Suggestions</hlm-command-group-label>
-						@for (item of items(); track item.value) {
-							<button hlm-command-item [value]="item.value">
-								<ng-icon hlm [name]="item.icon" hlmCommandIcon />
-								{{ item.label }}
-							</button>
-						}
-					</hlm-command-group>
-				</hlm-command-list>
+			<hlm-command-list>
+				<hlm-command-group>
+					<hlm-command-group-label>Suggestions</hlm-command-group-label>
+					@for (item of items(); track item.value) {
+						<button hlm-command-item [value]="item.value" data-testid="command-item">
+							<ng-icon hlm [name]="item.icon" hlmCommandIcon />
+							{{ item.label }}
+						</button>
+					}
+				</hlm-command-group>
+			</hlm-command-list>
 
-				<!-- Empty state -->
-				<div *brnCommandEmpty hlmCommandEmpty>No results found.</div>
-			</hlm-command>
-		}
+			<!-- Empty state -->
+			<div *brnCommandEmpty hlmCommandEmpty>No results found.</div>
+		</hlm-command>
 	`,
 })
 class CommandDynamicComponent {
+	protected readonly search = signal('P');
 	protected readonly items = signal<{ label: string; value: string; icon: string; shortcut: string }[]>([
 		{ label: 'Profile', value: 'Profile', icon: 'lucideUser', shortcut: '⌘P' },
 		{ label: 'Billing', value: 'Billing', icon: 'lucideWallet', shortcut: '⌘B' },
+		{ label: 'Search Emoji', value: 'Search Emoji', icon: 'lucideSmile', shortcut: '⌘E' },
 		{ label: 'Settings', value: 'Settings', icon: 'lucideCog', shortcut: '⌘S' },
 	]);
 	public command = signal('');

--- a/libs/ui/command/helm/src/lib/hlm-command-group.component.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-group.component.ts
@@ -6,7 +6,12 @@ import { hlm } from '@spartan-ng/brain/core';
 	standalone: true,
 	selector: 'hlm-command-group',
 	template: '<ng-content />',
-	hostDirectives: [BrnCommandGroupDirective],
+	hostDirectives: [
+		{
+			directive: BrnCommandGroupDirective,
+			inputs: ['id'],
+		},
+	],
 	host: {
 		'[class]': '_computedClass()',
 	},

--- a/libs/ui/command/helm/src/lib/hlm-command-item.component.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-item.component.ts
@@ -12,7 +12,7 @@ import { hlm } from '@spartan-ng/brain/core';
 	hostDirectives: [
 		{
 			directive: BrnCommandItemDirective,
-			inputs: ['value', 'disabled'],
+			inputs: ['value', 'disabled', 'id'],
 			outputs: ['selected'],
 		},
 	],

--- a/libs/ui/command/helm/src/lib/hlm-command-list.component.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-list.component.ts
@@ -9,7 +9,12 @@ import { hlm } from '@spartan-ng/brain/core';
 	host: {
 		'[class]': '_computedClass()',
 	},
-	hostDirectives: [BrnCommandListDirective],
+	hostDirectives: [
+		{
+			directive: BrnCommandListDirective,
+			inputs: ['id'],
+		},
+	],
 })
 export class HlmCommandListComponent {
 	/** The user defined class  */

--- a/libs/ui/command/helm/src/lib/hlm-command-search-input.component.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command-search-input.component.ts
@@ -6,7 +6,7 @@ import { hlm } from '@spartan-ng/brain/core';
 	standalone: true,
 	selector: 'input[hlm-command-search-input]',
 	template: '',
-	hostDirectives: [BrnCommandSearchInputDirective],
+	hostDirectives: [{ directive: BrnCommandSearchInputDirective, inputs: ['value'] }],
 	host: {
 		'[class]': '_computedClass()',
 	},

--- a/libs/ui/command/helm/src/lib/hlm-command.component.ts
+++ b/libs/ui/command/helm/src/lib/hlm-command.component.ts
@@ -11,6 +11,7 @@ import { hlm } from '@spartan-ng/brain/core';
 	hostDirectives: [
 		{
 			directive: BrnCommandDirective,
+			inputs: ['id', 'filter'],
 			outputs: ['valueChange'],
 		},
 	],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [x] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Typeahead does not feel right and doesn't match shadcn behaviour. 
NG0950 Error can occur still.
Up and down Arrow is not working when searchtext is empty
Setting searchtext via ngModel does not work

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #593 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Sorry for adding so much additional fixes to this PR. 