### PR TITLE
fix(select): use compare with function

### DIFF
--- a/libs/brain/select/src/lib/brn-select-value.component.ts
+++ b/libs/brain/select/src/lib/brn-select-value.component.ts
@@ -58,7 +58,9 @@ export class BrnSelectValueComponent<T> {
 		}
 
 		// remove any selected values that are not in the options list
-		const existingOptions = value.filter((val) => this._select.options().some((option) => this._select.compareWith()(option.value(), val)));
+		const existingOptions = value.filter((val) =>
+			this._select.options().some((option) => this._select.compareWith()(option.value(), val)),
+		);
 		const selectedOption = existingOptions.map((val) =>
 			this._select.options().find((option) => this._select.compareWith()(option.value(), val)),
 		);
@@ -68,7 +70,7 @@ export class BrnSelectValueComponent<T> {
 		}
 
 		const selectedLabels = selectedOption.map((option) => option?.getLabel());
-		
+
 		if (this._select.dir() === 'rtl') {
 			selectedLabels.reverse();
 		}

--- a/libs/brain/select/src/lib/brn-select-value.component.ts
+++ b/libs/brain/select/src/lib/brn-select-value.component.ts
@@ -58,9 +58,9 @@ export class BrnSelectValueComponent<T> {
 		}
 
 		// remove any selected values that are not in the options list
-		const existingOptions = value.filter((val) => this._select.options().some((option) => option.value() === val));
+		const existingOptions = value.filter((val) => this._select.options().some((option) => this._select.compareWith()(option.value(), val)));
 		const selectedOption = existingOptions.map((val) =>
-			this._select.options().find((option) => option.value() === val),
+			this._select.options().find((option) => this._select.compareWith()(option.value(), val)),
 		);
 
 		if (selectedOption.length === 0) {
@@ -68,7 +68,7 @@ export class BrnSelectValueComponent<T> {
 		}
 
 		const selectedLabels = selectedOption.map((option) => option?.getLabel());
-
+		
 		if (this._select.dir() === 'rtl') {
 			selectedLabels.reverse();
 		}

--- a/libs/brain/select/src/lib/brn-select.component.ts
+++ b/libs/brain/select/src/lib/brn-select.component.ts
@@ -283,7 +283,7 @@ export class BrnSelectComponent<T = unknown>
 	deselectOption(value: T): void {
 		if (this.multiple()) {
 			const currentValue = this.value() as T[];
-			const newValue = currentValue.filter((val) => val !== value);
+			const newValue = currentValue.filter((val) => !this.compareWith()(val, value));
 			this.value.set(newValue);
 		} else {
 			this.value.set(null as T);


### PR DESCRIPTION
Ensure correct behavior on select value level when custom compare with function is provided to the select component

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [x] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

When a custom `compareWith` function is provided to the `SelectComponent` it's not used in the `BrnSelectValueComponent`. This leads to inconsistent behavior as the selected value isn't shown in the `BrnSelectValueComponent` because the comparison returns false.
The comparison in the `BrnSelectValueComponent` is fixed to reference equality and doesn't account for the custom compare function.

## What is the new behavior?

Always use the custom compare function which falls back to comparing reference equality.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
