### PR TITLE
Implement setDisabledState on ControlValueAccessor in HlmSwitchComponent

### DIFF
--- a/libs/ui/switch/helm/src/lib/hlm-switch.component.ts
+++ b/libs/ui/switch/helm/src/lib/hlm-switch.component.ts
@@ -1,6 +1,6 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { Component, booleanAttribute, computed, forwardRef, input, model, output } from '@angular/core';
-import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { Component, booleanAttribute, computed, forwardRef, input, model, output, signal } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { hlm } from '@spartan-ng/brain/core';
 import { ChangeFn, TouchFn } from '@spartan-ng/brain/forms';
 import { BrnSwitchComponent, BrnSwitchThumbComponent } from '@spartan-ng/brain/switch';
@@ -40,7 +40,7 @@ export const HLM_SWITCH_VALUE_ACCESSOR = {
 	`,
 	providers: [HLM_SWITCH_VALUE_ACCESSOR],
 })
-export class HlmSwitchComponent {
+export class HlmSwitchComponent implements ControlValueAccessor {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
@@ -54,8 +54,9 @@ export class HlmSwitchComponent {
 	public readonly checked = model<boolean>(false);
 
 	/** The disabled state of the switch. */
-	public readonly disabled = input<boolean, BooleanInput>(false, {
+	public readonly disabledInput = input<boolean, BooleanInput>(false, {
 		transform: booleanAttribute,
+		alias: 'disabled',
 	});
 
 	/** Used to set the id on the underlying brn element. */
@@ -72,6 +73,10 @@ export class HlmSwitchComponent {
 
 	/** Emits when the checked state of the switch changes. */
 	public readonly changed = output<boolean>();
+
+	private readonly _writableDisabled = computed(() => signal(this.disabledInput()));
+
+	public readonly disabled = computed(() => this._writableDisabled()());
 
 	protected _onChange?: ChangeFn<boolean>;
 	protected _onTouched?: TouchFn;
@@ -94,5 +99,9 @@ export class HlmSwitchComponent {
 
 	registerOnTouched(fn: TouchFn): void {
 		this._onTouched = fn;
+	}
+
+	setDisabledState(isDisabled: boolean): void {
+		this._writableDisabled().set(isDisabled);
 	}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [x] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Currently, the HlmSwitchComponent does not implement the ControlValueAccessor interface, so the disabled state cannot be managed via Angular forms. This limits the integration and consistency of state management within form controls.

## What is the new behavior?

The HlmSwitchComponent now implements the ControlValueAccessor interface and includes the setDisabledState method. This enhancement enables the component to properly handle and reflect the disabled state when used within Angular forms, improving its interoperability with form APIs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
