### PR TITLE
fix: radio migration also finds tags with linebreaks

### DIFF
--- a/libs/cli/src/generators/migrate-radio/generator.spec.ts
+++ b/libs/cli/src/generators/migrate-radio/generator.spec.ts
@@ -67,7 +67,6 @@ describe('migrate-radio generator', () => {
 				import { Component } from '@angular/core';
 				import { BrnRadioComponent } from '@spartan-ng/brain/radio-group';
 				import { HlmRadioDirective, HlmRadioGroupComponent } from '@spartan-ng/ui-radiogroup-helm';
-	
 				@Component({
 					imports: [BrnRadioComponent, HlmRadioDirective, HlmRadioGroupComponent],
 					template: \`
@@ -91,5 +90,43 @@ describe('migrate-radio generator', () => {
 		);
 		expect(content).toContain(`imports: [HlmRadioComponent, HlmRadioGroupComponent],`);
 		expect(content).toContain(`<hlm-radio value="16.1.4">`);
+	});
+	it('should replace BrnRadioComponent also if the hlm is not directly after the brn-radio tag (Standalone)', async () => {
+		tree.write(
+			'app/src/app/app.component.ts',
+			`
+				import { Component } from '@angular/core';
+				import { BrnRadioComponent } from '@spartan-ng/brain/radio-group';
+				import { HlmRadioDirective, HlmRadioGroupComponent } from '@spartan-ng/ui-radiogroup-helm';
+
+				@Component({
+					imports: [BrnRadioComponent, HlmRadioDirective, HlmRadioGroupComponent],
+					template: \`
+						<hlm-radio-group class="font-mono text-sm font-medium" [(ngModel)]="version">
+							<brn-radio
+			hlm
+value="16.1.5">
+								should be replaced 1
+							</brn-radio>
+							<brn-radio class="hlm" value="16.1.4">
+								should not be replaced
+							</brn-radio>
+							<brn-radio class="hlm replace-me" value="hlm" hlm>
+								should be replaced 2
+							</brn-radio>
+
+						</hlm-radio-group>
+					\`
+				})
+				export class AppModule {}
+				`,
+		);
+
+		await migrateRadioGenerator(tree, { skipFormat: true });
+
+		const content = tree.read('app/src/app/app.component.ts', 'utf-8');
+		expect(content).toContain(`<brn-radio class="hlm" value="16.1.4">`);
+		expect(content).toContain(`<hlm-radio class="hlm replace-me" value="hlm">`);
+		expect(content).toContain(`<hlm-radio value="16.1.5">`);
 	});
 });

--- a/libs/cli/src/generators/migrate-radio/generator.ts
+++ b/libs/cli/src/generators/migrate-radio/generator.ts
@@ -26,13 +26,44 @@ function replaceSelector(tree: Tree) {
 			return;
 		}
 
-		content = content.replace(/<brn-radio hlm/g, '<hlm-radio');
+		// <brn-radio hlm but between
+		content = replaceBrnRadioHlm(content);
 		content = content.replace(/<\/brn-radio>/g, '</hlm-radio>');
 
 		tree.write(path, content);
 	});
 }
 
+function replaceBrnRadioHlm(input) {
+	// Split input to handle multiple tags separately
+	return input
+		.split(/(?=<)/)
+		.map((tag) => {
+			// Skip if not a brn-radio tag
+			if (!tag.startsWith('<brn-radio')) {
+				return tag;
+			}
+
+			// Remove line breaks, tabs, and other whitespace within the tag
+			// Replace with a single space
+			tag = tag.replace(/\s+/g, ' ');
+
+			// Check if standalone hlm attribute exists
+			const hasHlm = / hlm(?=[\s>])/.test(tag);
+
+			if (hasHlm) {
+				// Remove the hlm attribute and convert to hlm-radio
+				return tag
+					.replace(/<brn-radio/, '<hlm-radio')
+					.replace(/ hlm(?=[\s>])/, '')
+					.replace(/\s+>/g, '>')
+					.replace(/\s+/g, ' ');
+			}
+
+			return tag;
+		})
+		.join('');
+}
 /**
  * Update imports remove BrnRadioComponent import and replace HlmRadioDirective with HlmRadioComponent
  */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Healthchecks

## Which package are you modifying?

health-check migrations

## What is the current behavior?

the migration for hlm-radio only replaces ``<brn-radio hlm`` occurrences.
If some codebases have different formatting and the ``hlm`` attribute is not directly after the ``brn-radio`` tag, the migration fails to find these.


## What is the new behavior?

also replaces 
```
<brn-radio 
hlm>

<brn-radio class="foo" hlm>
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
