### PR TITLE
feat: add spartan hlm update function

### DIFF
--- a/libs/cli/generators.json
+++ b/libs/cli/generators.json
@@ -44,6 +44,11 @@
 			"factory": "./src/generators/healthcheck/generator",
 			"schema": "./src/generators/healthcheck/schema.json",
 			"description": "Run a healthcheck on the project to identify any potential issues or outdated code."
+		},
+		"update-hlm": {
+			"factory": "./src/generators/update-hlm/generator",
+			"schema": "./src/generators/update-hlm/schema.json",
+			"description": "Update hlm packages to the latest version."
 		}
 	},
 	"schematics": {
@@ -91,6 +96,11 @@
 			"factory": "./src/generators/healthcheck/compat",
 			"schema": "./src/generators/healthcheck/schema.json",
 			"description": "Run a healthcheck on the project to identify any potential issues or outdated code."
+		},
+		"update-hlm": {
+			"factory": "./src/generators/update-hlm/compat",
+			"schema": "./src/generators/update-hlm/schema.json",
+			"description": "Update hlm packages to the latest version."
 		}
 	}
 }

--- a/libs/cli/src/generators/base/schema.d.ts
+++ b/libs/cli/src/generators/base/schema.d.ts
@@ -7,4 +7,5 @@ export interface HlmBaseGeneratorSchema {
 	tags?: string;
 	peerDependencies?: Record<string, string>;
 	angularCli?: boolean;
+	update?: boolean;
 }

--- a/libs/cli/src/generators/ui/generator.ts
+++ b/libs/cli/src/generators/ui/generator.ts
@@ -44,12 +44,13 @@ async function createPrimitiveLibraries(
 ) {
 	const allPrimitivesSelected = response.primitives.includes('all');
 	const primitivesToCreate = allPrimitivesSelected ? availablePrimitiveNames : response.primitives;
+	const silent = allPrimitivesSelected || options.update;
 	const tasks: GeneratorCallback[] = [];
 
-	if (!response.primitives.includes('all')) {
+	if (!silent) {
 		await addDependentPrimitives(primitivesToCreate);
 	}
-	await replaceContextAndMenuBar(primitivesToCreate, allPrimitivesSelected);
+	await replaceContextAndMenuBar(primitivesToCreate, silent);
 
 	if (primitivesToCreate.length === 1 && primitivesToCreate[0] === 'collapsible') {
 		return tasks;
@@ -76,6 +77,7 @@ async function createPrimitiveLibraries(
 				tags: options.tags,
 				rootProject: options.rootProject,
 				angularCli: options.angularCli,
+				update: options.update,
 			});
 		}),
 	);

--- a/libs/cli/src/generators/ui/schema.d.ts
+++ b/libs/cli/src/generators/ui/schema.d.ts
@@ -3,4 +3,5 @@ export interface HlmUIGeneratorSchema {
 	directory?: string;
 	rootProject?: boolean;
 	tags?: string;
+	update?: boolean;
 }

--- a/libs/cli/src/generators/update-hlm/compat.ts
+++ b/libs/cli/src/generators/update-hlm/compat.ts
@@ -1,0 +1,4 @@
+import { convertNxGenerator } from '@nx/devkit';
+import { spartanUpdaterGenerator } from './generator';
+
+export default convertNxGenerator(spartanUpdaterGenerator);

--- a/libs/cli/src/generators/update-hlm/generator.ts
+++ b/libs/cli/src/generators/update-hlm/generator.ts
@@ -1,0 +1,48 @@
+import { formatFiles, GeneratorCallback, runTasksInSerial, Tree } from '@nx/devkit';
+import { getRootTsConfigPathInTree, readTsConfigPaths } from '@nx/js';
+import { prompt } from 'enquirer';
+import { default as hlmUIGenerator } from '../../generators/ui/generator';
+import { HlmUIGeneratorSchema } from '../ui/schema';
+
+export async function spartanUpdaterGenerator(
+	tree: Tree,
+	options: HlmUIGeneratorSchema & { angularCli?: boolean; skipFormat?: boolean },
+) {
+	const existingPathsByAlias = readTsConfigPaths(getRootTsConfigPathInTree(tree)) ?? {};
+
+	/** get all spartan packages from tsconfigPaths, to only prompt for the ones that are installed */
+	const spartanPackages = Object.keys(existingPathsByAlias).filter((path) => path.startsWith('@spartan-ng/ui-'));
+	const primitiveNames = spartanPackages.map((pkg) => pkg.replace('@spartan-ng/ui-', '').replace('-helm', ''));
+
+	/** prompt which packages to update */
+	const packagesToUpdate: { primitives: string[] } = await prompt({
+		type: 'multiselect',
+		required: true,
+		name: 'primitives',
+		message: 'Choose which packages you want to update',
+		choices: ['all', ...primitiveNames.sort()],
+	});
+	let primitivesToUpdate = packagesToUpdate.primitives;
+	if (primitivesToUpdate.includes('all')) {
+		primitivesToUpdate = primitiveNames;
+	}
+
+	const tasks: GeneratorCallback[] = [];
+
+	for (const packageName of primitivesToUpdate) {
+		tasks.push(
+			await hlmUIGenerator(tree, {
+				...options,
+				name: packageName,
+				update: true,
+			}),
+		);
+	}
+	await runTasksInSerial(...tasks)();
+
+	if (!options.skipFormat) {
+		await formatFiles(tree);
+	}
+}
+
+export default spartanUpdaterGenerator;

--- a/libs/cli/src/generators/update-hlm/schema.json
+++ b/libs/cli/src/generators/update-hlm/schema.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"$id": "UpdateHlm",
+	"title": "",
+	"type": "object",
+	"properties": {
+		"skipFormat": {
+			"type": "boolean",
+			"default": false,
+			"description": "Skip formatting files"
+		}
+	},
+	"required": []
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

There is no easy way to update hlm components.
The recommended approach is to delete spartan from tsconfig and delete all hlm directories.

Closes #

## What is the new behavior?

Add the possibility to the existing generator to update a primitive. 
e.g. ``npx nx g @spartan-ng/cli:ui accordion --update `` 
If the generator is started in update mode, we delete the src directory before regenerating the component. 
This makes sure, that if files were deleted they are also deleted from users source.
nx takes care of the comparison and the detection of the real changes.

Additionally a generator is added that lets you choose the primitives you want to update. 
``npx nx g @spartan-ng/cli:update-hlm``. 
This lists all installed spartan primitives that are detected from tsconfig. 




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Documentation is missing, but i wait for your feedback ;)