### PR TITLE
fix(select): Use toggle select for multi and set as null when empty a…

### DIFF
--- a/libs/brain/select/src/lib/brn-select-option.directive.ts
+++ b/libs/brain/select/src/lib/brn-select-option.directive.ts
@@ -1,6 +1,6 @@
 import type { Highlightable } from '@angular/cdk/a11y';
 import { BooleanInput } from '@angular/cdk/coercion';
-import { Directive, ElementRef, booleanAttribute, computed, inject, input, signal } from '@angular/core';
+import { booleanAttribute, computed, Directive, ElementRef, inject, input, signal } from '@angular/core';
 import { injectBrnSelectContent } from './brn-select-content.token';
 import { injectBrnSelect } from './brn-select.token';
 
@@ -45,6 +45,11 @@ export class BrnSelectOptionDirective<T> implements Highlightable {
 
 	public select(): void {
 		if (this._disabled()) {
+			return;
+		}
+
+		if (this._select.multiple()) {
+			this._select.toggleSelect(this.value());
 			return;
 		}
 

--- a/libs/brain/select/src/lib/brn-select.component.ts
+++ b/libs/brain/select/src/lib/brn-select.component.ts
@@ -282,7 +282,8 @@ export class BrnSelectComponent<T = unknown>
 	deselectOption(value: T): void {
 		if (this.multiple()) {
 			const currentValue = this.value() as T[];
-			const newValue = currentValue.filter((val) => !this.compareWith()(val, value));
+			const newSelectedValues = currentValue.filter((val) => !this.compareWith()(val, value));
+			const newValue = !newSelectedValues.length ? (null as T) : newSelectedValues;
 			this.value.set(newValue);
 		} else {
 			this.value.set(null as T);

--- a/libs/brain/select/src/lib/tests/select-multi-mode.spec.ts
+++ b/libs/brain/select/src/lib/tests/select-multi-mode.spec.ts
@@ -722,4 +722,27 @@ describe('Brn Select Component in multi-mode', () => {
 			expect(getFormValidationClasses(trigger)).toStrictEqual(afterValuePatchExpected);
 		});
 	});
+
+	describe('deselect option - multi mode', () => {
+		it('should reflect correct form control status with no initial value', async () => {
+			const { fixture, trigger, user } = await setupWithFormValidationMulti();
+			const cmpInstance = fixture.componentInstance as SelectMultiValueTestComponent;
+
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+
+			// open select
+			await user.click(trigger);
+
+			const options = await screen.getAllByRole('option');
+			await user.click(options[1]);
+
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual(['banana']);
+			expect(screen.getByTestId('brn-select-value').textContent?.trim()).toBe('Banana');
+
+			await user.click(options[1]);
+
+			expect(trigger).toHaveTextContent('Select a Fruit');
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+		});
+	});
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [X] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Multi Select does not allow items to be deselected.
Multi Select returns an empty array when there are no items selected.

Closes #645

## What is the new behavior?

Multi Select uses toggle to deselect/select items.
Multi Select now returns null when there are not items selected

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
