### PR TITLE
fix(tooltip): allow programmatic control of tooltipContentClasses

### DIFF
--- a/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
@@ -271,7 +271,7 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 			const ariaDescribedBy = this.ariaDescribedBy()();
 			this._ariaDescriber.removeDescription(
 				this._elementRef.nativeElement,
-				untracked(() => this.ariaDescribedByPrevious()),
+				untracked(() => this.ariaDescribedByPrevious()()),
 				'tooltip',
 			);
 

--- a/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
@@ -75,8 +75,8 @@ export const BRN_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER: Provider = {
 	deps: [Overlay],
 	useFactory:
 		(overlay: Overlay): (() => ScrollStrategy) =>
-			() =>
-				overlay.scrollStrategies.reposition({ scrollThrottle: SCROLL_THROTTLE_MS }),
+		() =>
+			overlay.scrollStrategies.reposition({ scrollThrottle: SCROLL_THROTTLE_MS }),
 };
 
 const PANEL_CLASS = 'tooltip-panel';
@@ -167,7 +167,9 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 
 	/** The default delay in ms before hiding the tooltip after hide is called */
 
-	public readonly _tooltipContentClasses = input<string>(this._defaultOptions?.tooltipContentClasses ?? '', { alias: 'tooltipContentClasses' });
+	public readonly _tooltipContentClasses = input<string>(this._defaultOptions?.tooltipContentClasses ?? '', {
+		alias: 'tooltipContentClasses',
+	});
 	public readonly tooltipContentClasses = computed(() => signal(this._tooltipContentClasses()));
 
 	/**

--- a/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
@@ -41,7 +41,6 @@ import {
 	InjectionToken,
 	input,
 	isDevMode,
-	linkedSignal,
 	NgZone,
 	numberAttribute,
 	type OnDestroy,

--- a/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-trigger.directive.ts
@@ -41,6 +41,7 @@ import {
 	InjectionToken,
 	input,
 	isDevMode,
+	linkedSignal,
 	NgZone,
 	numberAttribute,
 	type OnDestroy,
@@ -74,8 +75,8 @@ export const BRN_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER: Provider = {
 	deps: [Overlay],
 	useFactory:
 		(overlay: Overlay): (() => ScrollStrategy) =>
-		() =>
-			overlay.scrollStrategies.reposition({ scrollThrottle: SCROLL_THROTTLE_MS }),
+			() =>
+				overlay.scrollStrategies.reposition({ scrollThrottle: SCROLL_THROTTLE_MS }),
 };
 
 const PANEL_CLASS = 'tooltip-panel';
@@ -166,7 +167,8 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 
 	/** The default delay in ms before hiding the tooltip after hide is called */
 
-	public readonly tooltipContentClasses = input<string>(this._defaultOptions?.tooltipContentClasses ?? '');
+	public readonly _tooltipContentClasses = input<string>(this._defaultOptions?.tooltipContentClasses ?? '', { alias: 'tooltipContentClasses' });
+	public readonly tooltipContentClasses = linkedSignal(() => this._tooltipContentClasses());
 
 	/**
 	 * How touch gestures should be handled by the tooltip. On touch devices the tooltip directive
@@ -187,7 +189,8 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 
 	/** The message to be used to describe the aria in the tooltip */
 
-	public readonly ariaDescribedBy = input('', { alias: 'aria-describedby' });
+	public readonly _ariaDescribedBy = input('', { alias: 'aria-describedby' });
+	public readonly ariaDescribedBy = linkedSignal(() => this._ariaDescribedBy());
 	public readonly ariaDescribedByPrevious = computedPrevious(this.ariaDescribedBy);
 
 	/** The content to be displayed in the tooltip */
@@ -217,6 +220,12 @@ export class BrnTooltipTriggerDirective implements OnDestroy, AfterViewInit {
 		this._initBrnTooltipDisabledEffect();
 		this._initExitAnimationDurationEffect();
 		this._initHideDelayEffect();
+	}
+	setTooltipContentClasses(tooltipContentClasses: string) {
+		this.tooltipContentClasses.set(tooltipContentClasses);
+	}
+	setAriaDescribedBy(ariaDescribedBy: string) {
+		this.ariaDescribedBy.set(ariaDescribedBy);
 	}
 
 	private _initPositionEffect(): void {


### PR DESCRIPTION
### ✅ PR Checklist  
- [x] The commit message follows our [guidelines](https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines)  
- [ ] Tests for the changes have been added (not needed for this directive-level change)  
- [ ] Docs have been added / updated (not applicable)

---

### 🔧 PR Type  
What kind of change does this PR introduce?

- [x] Bugfix

---

### 📦 Which package are you modifying?

- [x] tooltip

---

### ❓ What is the current behavior?

When using `BrnTooltipTriggerDirective` as a `hostDirective`, it's not possible to programmatically set `tooltipContentClasses` since it is defined using `input()`, which is readonly in Angular's signal system.

---

### ✅ What is the new behavior?

This PR updates the `tooltipContentClasses` field in `BrnTooltipTriggerDirective` from an `input()` to a `model()`.

This allows:
- Two-way binding via the `Input`
- Programmatic updates using `.set()` — which is currently not possible with `input()`

---

### 💡 Example Use Case

```ts
@Directive({
  selector: '[myCustomTooltipTrigger]',
  standalone: true,
  hostDirectives: [{
    directive: BrnTooltipTriggerDirective,
    inputs: ['brnTooltipTrigger'],
  }]
})
export class MyCustomTooltipTriggerDirective {
  private readonly variant = input<'default' | 'dark'>('default');
  private readonly classes = computed(() => this.getClassesByVariant(this.variant()));
  private readonly _tooltipDirective = inject(BrnTooltipTriggerDirective, { self: true });

  constructor() {
    effect(() => {
      this._tooltipDirective.tooltipContentClasses.set(this.classes());
    });
  }
}
