### PR TITLE
fix(breadcrumb): breadcrumb separator icon style

### DIFF
--- a/libs/cli/src/generators/ui/libs/ui-breadcrumb-helm/files/lib/breadcrumb-separator.component.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-breadcrumb-helm/files/lib/breadcrumb-separator.component.ts.template
@@ -2,13 +2,12 @@ import { Component, computed, input } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideChevronRight } from '@ng-icons/lucide';
 import { hlm } from '@spartan-ng/brain/core';
-import { HlmIconDirective } from '@spartan-ng/ui-icon-helm';
 import type { ClassValue } from 'clsx';
 
 @Component({
 	// eslint-disable-next-line @angular-eslint/component-selector
 	selector: '[hlmBreadcrumbSeparator]',
-	imports: [NgIcon, HlmIconDirective],
+	imports: [NgIcon],
 	providers: [provideIcons({ lucideChevronRight })],
 	host: {
 		role: 'presentation',
@@ -17,7 +16,7 @@ import type { ClassValue } from 'clsx';
 	},
 	template: `
 		<ng-content>
-			<ng-icon size="sm" hlm name="lucideChevronRight" />
+			<ng-icon name="lucideChevronRight" />
 		</ng-content>
 	`,
 })
@@ -25,6 +24,6 @@ export class HlmBreadcrumbSeparatorComponent {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 
 	protected readonly _computedClass = computed(() =>
-		hlm('[&>ng-icon]:w-3.5 [&>ng-icon]:h-3.5 [&>ng-icon]:flex', this.userClass()),
+		hlm('[&>ng-icon]:text-[14px] [&>ng-icon]:flex!', this.userClass()),
 	);
 }

--- a/libs/ui/breadcrumb/helm/src/lib/breadcrumb-separator.component.ts
+++ b/libs/ui/breadcrumb/helm/src/lib/breadcrumb-separator.component.ts
@@ -2,13 +2,12 @@ import { Component, computed, input } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideChevronRight } from '@ng-icons/lucide';
 import { hlm } from '@spartan-ng/brain/core';
-import { HlmIconDirective } from '@spartan-ng/ui-icon-helm';
 import type { ClassValue } from 'clsx';
 
 @Component({
 	// eslint-disable-next-line @angular-eslint/component-selector
 	selector: '[hlmBreadcrumbSeparator]',
-	imports: [NgIcon, HlmIconDirective],
+	imports: [NgIcon],
 	providers: [provideIcons({ lucideChevronRight })],
 	host: {
 		role: 'presentation',
@@ -17,7 +16,7 @@ import type { ClassValue } from 'clsx';
 	},
 	template: `
 		<ng-content>
-			<ng-icon size="sm" hlm name="lucideChevronRight" />
+			<ng-icon name="lucideChevronRight" />
 		</ng-content>
 	`,
 })
@@ -25,6 +24,6 @@ export class HlmBreadcrumbSeparatorComponent {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 
 	protected readonly _computedClass = computed(() =>
-		hlm('[&>ng-icon]:w-3.5 [&>ng-icon]:h-3.5 [&>ng-icon]:flex', this.userClass()),
+		hlm('[&>ng-icon]:text-[14px] [&>ng-icon]:flex!', this.userClass()),
 	);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [x] breadcrumb
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Breadcrumb separator style have wrong style with tailwind v4 and ng-icon

Default icon size is 16px and align to top

![image](https://github.com/user-attachments/assets/76015e42-6988-4c9a-8805-29975c38fe26)

Closes #

## What is the new behavior?

Default icon is 14px and align center

![image](https://github.com/user-attachments/assets/5ee848d3-a2c9-4650-a32e-3c71e580c3ed)

Breadcrumb

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
