### PR TITLE
fix(checkbox): bring checkIconName back

### DIFF
--- a/libs/cli/src/generators/ui/libs/ui-checkbox-helm/files/lib/hlm-checkbox.component.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-checkbox-helm/files/lib/hlm-checkbox.component.ts.template
@@ -31,7 +31,7 @@ export const HLM_CHECKBOX_VALUE_ACCESSOR = {
 			(changed)="_handleChange()"
 			(touched)="_onTouched?.()"
 		>
-			<ng-icon [class]="_computedIconClass()" hlm size="sm" name="lucideCheck" />
+			<ng-icon hlm size="sm" [class]="_computedIconClass()" [name]="checkIconName()" />
 		</brn-checkbox>
 	`,
 	host: {
@@ -74,6 +74,9 @@ export class HlmCheckboxComponent {
 
 	/** The checked state of the checkbox. */
 	public readonly checked = model<CheckboxValue>(false);
+
+	/** Used to set the icon is displayed when checkbox is checked. Default is 'lucideCheck' */
+	public readonly checkIconName = input<string>('lucideCheck');
 
 	/** The name attribute of the checkbox. */
 	public readonly name = input<string | null>(null);

--- a/libs/ui/checkbox/helm/src/lib/hlm-checkbox.component.ts
+++ b/libs/ui/checkbox/helm/src/lib/hlm-checkbox.component.ts
@@ -31,7 +31,7 @@ export const HLM_CHECKBOX_VALUE_ACCESSOR = {
 			(changed)="_handleChange()"
 			(touched)="_onTouched?.()"
 		>
-			<ng-icon [class]="_computedIconClass()" hlm size="sm" name="lucideCheck" />
+			<ng-icon hlm size="sm" [class]="_computedIconClass()" [name]="checkIconName()" />
 		</brn-checkbox>
 	`,
 	host: {
@@ -74,6 +74,9 @@ export class HlmCheckboxComponent {
 
 	/** The checked state of the checkbox. */
 	public readonly checked = model<CheckboxValue>(false);
+
+	/** Used to set the icon is displayed when checkbox is checked. Default is 'lucideCheck' */
+	public readonly checkIconName = input<string>('lucideCheck');
 
 	/** The name attribute of the checkbox. */
 	public readonly name = input<string | null>(null);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [x] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

For now, we can't add custom checked icon. And the own icon example always show lucideCheckIcon

<img width="839" alt="image" src="https://github.com/user-attachments/assets/a6161821-6f86-4f46-825e-70df36b391ba" />

## What is the new behavior?

Bring the option `checkIconName` back, so we can override default icon

<img width="846" alt="image" src="https://github.com/user-attachments/assets/507098c3-eb8a-4fc2-9dfc-39f3c0e86802" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
