### PR TITLE
fix(select): multi select defaults to empty array

### DIFF
--- a/libs/brain/select/src/lib/brn-select.component.ts
+++ b/libs/brain/select/src/lib/brn-select.component.ts
@@ -282,9 +282,7 @@ export class BrnSelectComponent<T = unknown>
 	deselectOption(value: T): void {
 		if (this.multiple()) {
 			const currentValue = this.value() as T[];
-			const newSelectedValues = currentValue.filter((val) => !this.compareWith()(val, value));
-			const newValue = !newSelectedValues.length ? (null as T) : newSelectedValues;
-			this.value.set(newValue);
+			this.value.set(currentValue.filter((val) => !this.compareWith()(val, value)));
 		} else {
 			this.value.set(null as T);
 		}

--- a/libs/brain/select/src/lib/tests/select-multi-mode.spec.ts
+++ b/libs/brain/select/src/lib/tests/select-multi-mode.spec.ts
@@ -70,7 +70,7 @@ describe('Brn Select Component in multi-mode', () => {
 			expect(getFormControlStatus(cmpInstance.form?.get('fruit'))).toStrictEqual(expected);
 			expect(getFormValidationClasses(trigger)).toStrictEqual(expected);
 
-			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual([]);
 
 			// open
 			await user.click(trigger);
@@ -115,7 +115,7 @@ describe('Brn Select Component in multi-mode', () => {
 			expect(getFormValidationClasses(trigger)).toStrictEqual(expected);
 
 			expect(value.textContent?.trim()).toBe(DEFAULT_LABEL);
-			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual([]);
 		});
 
 		it('should reflect correct form control status with initial value', async () => {
@@ -154,7 +154,7 @@ describe('Brn Select Component in multi-mode', () => {
 			expect(getFormControlStatus(cmpInstance.form?.get('fruit'))).toStrictEqual(expected);
 			expect(getFormValidationClasses(trigger)).toStrictEqual(expected);
 
-			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual([]);
 
 			// open select
 			await user.click(trigger);
@@ -211,7 +211,7 @@ describe('Brn Select Component in multi-mode', () => {
 			expect(getFormControlStatus(cmpInstance.form?.get('fruit'))).toStrictEqual(expected);
 			expect(getFormValidationClasses(trigger)).toStrictEqual(expected);
 
-			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual([]);
 
 			expect(cmpInstance.form?.get('fruit')?.patchValue(['apple', 'banana', 'blueberry']));
 
@@ -247,7 +247,7 @@ describe('Brn Select Component in multi-mode', () => {
 			expect(getFormControlStatus(cmpInstance.form?.get('fruit'))).toStrictEqual(expected);
 			expect(getFormValidationClasses(trigger)).toStrictEqual(expected);
 
-			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual([]);
 
 			// open select
 			await user.click(trigger);
@@ -304,7 +304,7 @@ describe('Brn Select Component in multi-mode', () => {
 			expect(getFormControlStatus(cmpInstance.form?.get('fruit'))).toStrictEqual(expected);
 			expect(getFormValidationClasses(trigger)).toStrictEqual(expected);
 
-			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual([]);
 
 			expect(cmpInstance.form?.get('fruit')?.patchValue(['apple', 'banana', 'blueberry']));
 
@@ -407,7 +407,7 @@ describe('Brn Select Component in multi-mode', () => {
 			expect(getFormValidationClasses(trigger)).toStrictEqual(expected);
 
 			expect(value.textContent?.trim()).toBe(DEFAULT_LABEL);
-			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual([]);
 		});
 
 		/**
@@ -461,7 +461,7 @@ describe('Brn Select Component in multi-mode', () => {
 			expect(getFormControlStatus(cmpInstance.form?.get('fruit'))).toStrictEqual(expected);
 			expect(getFormValidationClasses(trigger)).toStrictEqual(expected);
 
-			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual([]);
 
 			// open select
 			await user.click(trigger);
@@ -657,7 +657,7 @@ describe('Brn Select Component in multi-mode', () => {
 			expect(getFormControlStatus(cmpInstance.form?.get('fruit'))).toStrictEqual(expected);
 			expect(getFormValidationClasses(trigger)).toStrictEqual(expected);
 
-			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual([]);
 
 			expect(cmpInstance.form?.get('fruit')?.patchValue(['apple', 'banana', 'blueberry']));
 
@@ -728,7 +728,7 @@ describe('Brn Select Component in multi-mode', () => {
 			const { fixture, trigger, user } = await setupWithFormValidationMulti();
 			const cmpInstance = fixture.componentInstance as SelectMultiValueTestComponent;
 
-			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual([]);
 
 			// open select
 			await user.click(trigger);
@@ -742,7 +742,7 @@ describe('Brn Select Component in multi-mode', () => {
 			await user.click(options[1]);
 
 			expect(trigger).toHaveTextContent('Select a Fruit');
-			expect(cmpInstance.form?.get('fruit')?.value).toEqual(null);
+			expect(cmpInstance.form?.get('fruit')?.value).toEqual([]);
 		});
 	});
 });

--- a/libs/brain/select/src/lib/tests/select-reactive-form.ts
+++ b/libs/brain/select/src/lib/tests/select-reactive-form.ts
@@ -156,7 +156,7 @@ export class SelectSingleValueWithInitialValueWithAsyncUpdateTestComponent {
 	`,
 })
 export class SelectMultiValueTestComponent {
-	public form = new FormGroup({ fruit: new FormControl<string | Array<string> | null>(null) });
+	public form = new FormGroup({ fruit: new FormControl<string[]>([]) });
 }
 
 @Component({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [X] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #666

## What is the new behavior?

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

When in multi select mode it makes more sense for a select to return an empty array rather than null. This simplifies things as it avoids having to deal multiple data types.

This is potentially a breaking change, but probably a better default that could help prevent bugs in apps.
