### PR TITLE
feat(collapsible): adding expanded input and output

### DIFF
--- a/libs/brain/collapsible/src/lib/brn-collapsible-content.component.ts
+++ b/libs/brain/collapsible/src/lib/brn-collapsible-content.component.ts
@@ -1,71 +1,59 @@
-import {
-	type AfterContentInit,
-	Component,
-	ElementRef,
-	computed,
-	effect,
-	inject,
-	input,
-	signal,
-	untracked,
-} from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { Component, ElementRef, OnInit, PLATFORM_ID, effect, inject, input, signal, untracked } from '@angular/core';
 import { BrnCollapsibleComponent } from './brn-collapsible.component';
 
 @Component({
 	selector: 'brn-collapsible-content',
 	standalone: true,
 	host: {
-		'[hidden]': 'state() === "closed"',
-		'[attr.data-state]': 'state()',
-		'[style]': 'computedStyles()',
-		'[id]': 'contentId()',
+		'[hidden]': '!collapsible?.expanded()',
+		'[attr.data-state]': 'collapsible?.expanded() ? "open" : "closed"',
+		'[id]': 'collapsible?.contentId()',
+		'[style.--brn-collapsible-content-width.px]': 'width()',
+		'[style.--brn-collapsible-content-height.px]': 'height()',
 	},
 	template: `
 		<ng-content />
 	`,
 })
-export class BrnCollapsibleContentComponent implements AfterContentInit {
-	private readonly _collapsible = inject(BrnCollapsibleComponent, { optional: true });
-
-	private readonly _elementRef = inject(ElementRef);
-
-	private readonly _height = signal(0);
-
-	private readonly _width = signal(0);
-
-	public readonly contentId = computed(() => this._collapsible?.contentId());
-
-	public readonly state = computed(() => this._collapsible?.state?.() ?? 'closed');
-
-	public readonly computedStyles = computed(() => {
-		const height = this._height();
-		const width = this._width();
-		return {
-			'--radix-collapsible-content-height': height ? `${height}px` : undefined,
-			'--radix-collapsible-content-width': width ? `${width}px` : undefined,
-		};
-	});
-
+export class BrnCollapsibleContentComponent implements OnInit {
+	protected readonly collapsible = inject(BrnCollapsibleComponent, { optional: true });
+	private readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+	private readonly _platformId = inject(PLATFORM_ID);
+	/**
+	 * The id of the collapsible content element.
+	 */
 	public readonly id = input<string | null | undefined>();
+	protected readonly width = signal<number | null>(null);
+	protected readonly height = signal<number | null>(null);
 
 	constructor() {
-		if (!this._collapsible) {
+		if (!this.collapsible) {
 			throw Error('Collapsible trigger directive can only be used inside a brn-collapsible element.');
 		}
 
 		effect(() => {
 			const id = this.id();
-			const collapsible = this._collapsible;
+			const collapsible = this.collapsible;
 			if (!id || !collapsible) return;
 			untracked(() => collapsible.contentId.set(id));
 		});
 	}
 
-	ngAfterContentInit() {
-		if (typeof this._elementRef.nativeElement.getBoundingClientRect !== 'function') return;
-		const rect = this._elementRef.nativeElement.getBoundingClientRect();
-		if (!rect) return;
-		this._width.set(rect.width);
-		this._height.set(rect.height);
+	ngOnInit(): void {
+		if (isPlatformServer(this._platformId)) {
+			return;
+		}
+
+		// ensure the element is not hidden when measuring its size
+		this._elementRef.nativeElement.hidden = false;
+
+		const { width, height } = this._elementRef.nativeElement.getBoundingClientRect();
+		this.width.set(width);
+		this.height.set(height);
+
+		// we force the element to be hidden again if collapsed after measuring its size
+		// this is handled by the host binding, but it can cause a flicker if we don't do this here manually
+		this._elementRef.nativeElement.hidden = this.collapsible?.expanded() ?? false;
 	}
 }

--- a/libs/brain/collapsible/src/lib/brn-collapsible-trigger.directive.ts
+++ b/libs/brain/collapsible/src/lib/brn-collapsible-trigger.directive.ts
@@ -1,35 +1,27 @@
-import { Directive, computed, inject } from '@angular/core';
+import { Directive, inject } from '@angular/core';
 import { BrnCollapsibleComponent } from './brn-collapsible.component';
 
 @Directive({
 	selector: 'button[brnCollapsibleTrigger]',
 	standalone: true,
 	host: {
-		'[attr.data-state]': 'state()',
-		'[attr.disabled]': 'attrDisabled()',
-		'[attr.aria-expanded]': 'state() === "open"',
-		'[attr.aria-controls]': 'ariaControls()',
-		'(click)': 'toggleCollapsible()',
+		'[attr.data-state]': 'collapsible?.expanded() ? "open" : "closed"',
+		'[attr.disabled]': 'collapsible?.disabled() ? true : undefined',
+		'[attr.aria-expanded]': 'collapsible?.expanded()',
+		'[attr.aria-controls]': 'collapsible?.contentId()',
+		'(click)': 'toggle()',
 	},
 })
 export class BrnCollapsibleTriggerDirective {
-	private readonly _collapsible = inject(BrnCollapsibleComponent, { optional: true });
-
-	public readonly state = computed(() => this._collapsible?.state());
-
-	public readonly disabled = computed(() => this._collapsible?.disabled?.());
-
-	public readonly attrDisabled = computed(() => this._collapsible?.attrDisabled?.());
-
-	public readonly ariaControls = computed(() => this._collapsible?.contentId());
+	protected readonly collapsible = inject(BrnCollapsibleComponent, { optional: true });
 
 	constructor() {
-		if (!this._collapsible) {
+		if (!this.collapsible) {
 			throw Error('Collapsible trigger directive can only be used inside a brn-collapsible element.');
 		}
 	}
 
-	toggleCollapsible() {
-		this._collapsible?.toggle();
+	toggle(): void {
+		this.collapsible?.toggle();
 	}
 }

--- a/libs/brain/collapsible/src/lib/brn-collapsible.component.ts
+++ b/libs/brain/collapsible/src/lib/brn-collapsible.component.ts
@@ -1,39 +1,39 @@
-import {
-	ChangeDetectionStrategy,
-	Component,
-	ViewEncapsulation,
-	booleanAttribute,
-	computed,
-	input,
-	signal,
-} from '@angular/core';
+import { BooleanInput } from '@angular/cdk/coercion';
+import { ChangeDetectionStrategy, Component, booleanAttribute, input, model, signal } from '@angular/core';
 
 let collapsibleContentIdSequence = 0;
+
 export type BrnCollapsibleState = 'open' | 'closed';
 
 @Component({
 	selector: 'brn-collapsible',
 	standalone: true,
 	host: {
-		'[attr.data-state]': 'state()',
-		'[attr.disabled]': 'attrDisabled()',
+		'[attr.data-state]': 'expanded() ? "open" : "closed"',
+		'[attr.disabled]': 'disabled() ? true : undefined',
 	},
 	template: `
 		<ng-content />
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	encapsulation: ViewEncapsulation.None,
 })
 export class BrnCollapsibleComponent {
-	public readonly state = signal<BrnCollapsibleState>('closed');
-
 	public readonly contentId = signal(`brn-collapsible-content-${collapsibleContentIdSequence++}`);
 
-	public readonly disabled = input(false, { transform: booleanAttribute });
+	/**
+	 * The expanded or collapsed state of the collapsible component.
+	 */
+	public readonly expanded = model<boolean>(false);
 
-	public readonly attrDisabled = computed(() => (this.disabled() ? true : undefined));
+	/**
+	 * The disabled state of the collapsible component.
+	 */
+	public readonly disabled = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 
-	public toggle() {
-		this.state.set(this.state() === 'closed' ? 'open' : 'closed');
+	/**
+	 * Toggles the expanded state of the collapsible component.
+	 */
+	public toggle(): void {
+		this.expanded.update((expanded) => !expanded);
 	}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [X] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #668 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This PR technically renames the CSS variables for height and width which could be considered a breaking change - although they didn't work before so I doubt anyone would have been relying on them.