### PR TITLE
fix: ensure BrnLuxonDateAdapter#getDay() returns a value between 0 and 6

### DIFF
--- a/libs/brain/date-time-luxon/src/lib/date-adapter.spec.ts
+++ b/libs/brain/date-time-luxon/src/lib/date-adapter.spec.ts
@@ -1,0 +1,198 @@
+import {BrnLuxonDateAdapter} from './date-adapter';
+import {DateTime} from 'luxon';
+
+describe('BrnLuxonDateAdapter', () => {
+	const adapter = new BrnLuxonDateAdapter();
+
+	test('now() should return the current time', () => {
+		const actual = adapter.now();
+		const expected = DateTime.now();
+		expect(actual.toMillis()).toBeCloseTo(expected.toMillis(), -2);
+	});
+
+	test('set() should update specified date properties', () => {
+		const date = DateTime.utc(2023, 10, 10, 10, 0, 0);
+		const result = adapter.set(date, {hour: 15, minute: 45});
+		expect(result.hour).toBe(15);
+		expect(result.minute).toBe(45);
+	});
+
+	test('add() should add duration to a date', () => {
+		const date = DateTime.utc(2023, 10, 10);
+		const result = adapter.add(date, {days: 2, hours: 5});
+		expect(result.toISO()).toBe(DateTime.utc(2023, 10, 12, 5).toISO());
+	});
+
+	test('subtract() should subtract duration from a date', () => {
+		const date = DateTime.utc(2023, 10, 10);
+		const result = adapter.subtract(date, {days: 1, hours: 2});
+		expect(result.toISO()).toBe(DateTime.utc(2023, 10, 8, 22).toISO());
+	});
+
+	test('compare() should compare two dates', () => {
+		const dateA = DateTime.utc(2023, 10, 10);
+		const dateB = DateTime.utc(2023, 10, 12);
+		expect(adapter.compare(dateA, dateB)).toBe(-1);
+		expect(adapter.compare(dateB, dateA)).toBe(1);
+		expect(adapter.compare(dateA, dateA)).toBe(0);
+	});
+
+	test('isEqual() should check if two dates are equal', () => {
+		const dateA = DateTime.utc(2023, 10, 10);
+		const dateB = DateTime.utc(2023, 10, 10);
+		const dateC = DateTime.local(2023, 10, 10);
+		expect(adapter.isEqual(dateA, dateB)).toBe(true);
+		expect(adapter.isEqual(dateA, dateC)).toBe(false);
+	});
+
+	test('isBefore() should check if a date is before another', () => {
+		const dateA = DateTime.utc(2023, 10, 10);
+		const dateB = DateTime.utc(2023, 10, 11);
+		expect(adapter.isBefore(dateA, dateB)).toBe(true);
+		expect(adapter.isBefore(dateB, dateA)).toBe(false);
+	});
+
+	test('isAfter() should check if a date is after another', () => {
+		const dateA = DateTime.utc(2023, 10, 10);
+		const dateB = DateTime.utc(2023, 10, 9);
+		expect(adapter.isAfter(dateA, dateB)).toBe(true);
+		expect(adapter.isAfter(dateB, dateA)).toBe(false);
+	});
+
+	test('isSameDay() should check if two dates are on the same day', () => {
+		const dateA = DateTime.utc(2023, 10, 10, 5);
+		const dateB = DateTime.utc(2023, 10, 10, 22);
+		const dateC = DateTime.utc(2023, 10, 11);
+		expect(adapter.isSameDay(dateA, dateB)).toBe(true);
+		expect(adapter.isSameDay(dateA, dateC)).toBe(false);
+	});
+
+	test('isSameMonth() should check if two dates are in the same month', () => {
+		const dateA = DateTime.utc(2023, 10, 10);
+		const dateB = DateTime.utc(2023, 10, 15);
+		const dateC = DateTime.utc(2023, 11, 1);
+		expect(adapter.isSameMonth(dateA, dateB)).toBe(true);
+		expect(adapter.isSameMonth(dateA, dateC)).toBe(false);
+	});
+
+	test('isSameYear() should check if two dates are in the same year', () => {
+		const dateA = DateTime.utc(2023, 10, 10);
+		const dateB = DateTime.utc(2023, 11, 1);
+		const dateC = DateTime.utc(2024, 1, 1);
+		expect(adapter.isSameYear(dateA, dateB)).toBe(true);
+		expect(adapter.isSameYear(dateA, dateC)).toBe(false);
+	});
+
+	test('getYear() should return the year of a date', () => {
+		const date = DateTime.utc(2023, 10, 10);
+		expect(adapter.getYear(date)).toBe(2023);
+	});
+
+	test('getMonth() should return the month of a date', () => {
+		const date = DateTime.utc(2023, 10, 10);
+		expect(adapter.getMonth(date)).toBe(10);
+	});
+
+	test('getDate() should return the day of the month of a date', () => {
+		const date = DateTime.utc(2023, 10, 10);
+		expect(adapter.getDate(date)).toBe(10);
+	});
+
+	describe('getDay() should return the day of the week (0-based, Sunday as 0)', () => {
+		test('should return 0 for Sunday', () => {
+			const date = DateTime.fromObject({
+				weekday: 7
+			}); // Sunday
+			expect(adapter.getDay(date)).toBe(0);
+		});
+
+		test('should return 1 for Monday', () => {
+			const date = DateTime.fromObject({weekday: 1}); // Monday
+			expect(adapter.getDay(date)).toBe(1);
+		});
+
+		test('should return 2 for Tuesday', () => {
+			const date = DateTime.fromObject({weekday: 2}) // Tuesday
+			expect(adapter.getDay(date)).toBe(2);
+		});
+
+		test('should return 3 for Wednesday', () => {
+			const date = DateTime.fromObject({weekday: 3}) // Wednesday
+			expect(adapter.getDay(date)).toBe(3);
+		});
+
+		test('should return 4 for Thursday', () => {
+			const date = DateTime.fromObject({weekday: 4}) // Thursday
+			expect(adapter.getDay(date)).toBe(4);
+		});
+
+		test('should return 5 for Friday', () => {
+			const date = DateTime.fromObject({weekday: 5}); // Friday
+			expect(adapter.getDay(date)).toBe(5);
+		});
+
+		test('should return 6 for Saturday', () => {
+			const date = DateTime.fromObject({weekday: 6}) // Saturday
+			expect(adapter.getDay(date)).toBe(6);
+		});
+	});
+
+	test('getHours() should return the hour of the given datetime', () => {
+		const date = DateTime.utc(2023, 10, 10, 14, 30);
+		expect(adapter.getHours(date)).toBe(14);
+	});
+
+	test('getMinutes() should return the minute of the given datetime', () => {
+		const date = DateTime.utc(2023, 10, 10, 14, 45);
+		expect(adapter.getMinutes(date)).toBe(45);
+	});
+
+	test('getSeconds() should return the seconds of the given datetime', () => {
+		const date = DateTime.utc(2023, 10, 10, 14, 45, 30);
+		expect(adapter.getSeconds(date)).toBe(30);
+	});
+
+	test('getMilliseconds() should return the milliseconds of the given datetime', () => {
+		const date = DateTime.utc(2023, 10, 10, 14, 45, 30, 123);
+		expect(adapter.getMilliseconds(date)).toBe(123);
+	});
+
+	test('getTime() should return the timestamp of a date', () => {
+		const date = DateTime.utc(2023, 10, 10, 12);
+		expect(adapter.getTime(date)).toBe(date.toMillis());
+	});
+
+	test('startOfMonth() should return the start of the month', () => {
+		const date = DateTime.utc(2023, 10, 10, 12);
+		expect(adapter.startOfMonth(date)).toEqual(DateTime.utc(2023, 10, 1));
+	});
+
+	test('endOfMonth() should return the end of the month', () => {
+		const date = DateTime.utc(2023, 10, 10, 12);
+		expect(adapter.endOfMonth(date)).toEqual(DateTime.utc(2023, 10, 31, 23, 59, 59, 999));
+	});
+
+	test('startOfDay() should return the start of the given day', () => {
+		const date = DateTime.utc(2023, 10, 10, 14, 45, 30, 123);
+		expect(adapter.startOfDay(date)).toEqual(DateTime.utc(2023, 10, 10).startOf('day'));
+	});
+
+	test('endOfDay() should return the end of the given day', () => {
+		const date = DateTime.utc(2023, 10, 10, 14, 45, 30, 123);
+		expect(adapter.endOfDay(date)).toEqual(DateTime.utc(2023, 10, 10).endOf('day'));
+	});
+
+	test('create() should create a new date from values', () => {
+		const values = {
+			year: 2023,
+			month: 10,
+			day: 10,
+			hour: 12,
+			minute: 30,
+			second: 0,
+			millisecond: 0
+		};
+		const date = adapter.create(values);
+		expect(date).toEqual(DateTime.fromObject(values));
+	});
+});

--- a/libs/brain/date-time-luxon/src/lib/date-adapter.spec.ts
+++ b/libs/brain/date-time-luxon/src/lib/date-adapter.spec.ts
@@ -1,5 +1,5 @@
-import {BrnLuxonDateAdapter} from './date-adapter';
-import {DateTime} from 'luxon';
+import { DateTime } from 'luxon';
+import { BrnLuxonDateAdapter } from './date-adapter';
 
 describe('BrnLuxonDateAdapter', () => {
 	const adapter = new BrnLuxonDateAdapter();
@@ -12,20 +12,20 @@ describe('BrnLuxonDateAdapter', () => {
 
 	test('set() should update specified date properties', () => {
 		const date = DateTime.utc(2023, 10, 10, 10, 0, 0);
-		const result = adapter.set(date, {hour: 15, minute: 45});
+		const result = adapter.set(date, { hour: 15, minute: 45 });
 		expect(result.hour).toBe(15);
 		expect(result.minute).toBe(45);
 	});
 
 	test('add() should add duration to a date', () => {
 		const date = DateTime.utc(2023, 10, 10);
-		const result = adapter.add(date, {days: 2, hours: 5});
+		const result = adapter.add(date, { days: 2, hours: 5 });
 		expect(result.toISO()).toBe(DateTime.utc(2023, 10, 12, 5).toISO());
 	});
 
 	test('subtract() should subtract duration from a date', () => {
 		const date = DateTime.utc(2023, 10, 10);
-		const result = adapter.subtract(date, {days: 1, hours: 2});
+		const result = adapter.subtract(date, { days: 1, hours: 2 });
 		expect(result.toISO()).toBe(DateTime.utc(2023, 10, 8, 22).toISO());
 	});
 
@@ -101,38 +101,38 @@ describe('BrnLuxonDateAdapter', () => {
 	describe('getDay() should return the day of the week (0-based, Sunday as 0)', () => {
 		test('should return 0 for Sunday', () => {
 			const date = DateTime.fromObject({
-				weekday: 7
+				weekday: 7,
 			}); // Sunday
 			expect(adapter.getDay(date)).toBe(0);
 		});
 
 		test('should return 1 for Monday', () => {
-			const date = DateTime.fromObject({weekday: 1}); // Monday
+			const date = DateTime.fromObject({ weekday: 1 }); // Monday
 			expect(adapter.getDay(date)).toBe(1);
 		});
 
 		test('should return 2 for Tuesday', () => {
-			const date = DateTime.fromObject({weekday: 2}) // Tuesday
+			const date = DateTime.fromObject({ weekday: 2 }); // Tuesday
 			expect(adapter.getDay(date)).toBe(2);
 		});
 
 		test('should return 3 for Wednesday', () => {
-			const date = DateTime.fromObject({weekday: 3}) // Wednesday
+			const date = DateTime.fromObject({ weekday: 3 }); // Wednesday
 			expect(adapter.getDay(date)).toBe(3);
 		});
 
 		test('should return 4 for Thursday', () => {
-			const date = DateTime.fromObject({weekday: 4}) // Thursday
+			const date = DateTime.fromObject({ weekday: 4 }); // Thursday
 			expect(adapter.getDay(date)).toBe(4);
 		});
 
 		test('should return 5 for Friday', () => {
-			const date = DateTime.fromObject({weekday: 5}); // Friday
+			const date = DateTime.fromObject({ weekday: 5 }); // Friday
 			expect(adapter.getDay(date)).toBe(5);
 		});
 
 		test('should return 6 for Saturday', () => {
-			const date = DateTime.fromObject({weekday: 6}) // Saturday
+			const date = DateTime.fromObject({ weekday: 6 }); // Saturday
 			expect(adapter.getDay(date)).toBe(6);
 		});
 	});
@@ -190,7 +190,7 @@ describe('BrnLuxonDateAdapter', () => {
 			hour: 12,
 			minute: 30,
 			second: 0,
-			millisecond: 0
+			millisecond: 0,
 		};
 		const date = adapter.create(values);
 		expect(date).toEqual(DateTime.fromObject(values));

--- a/libs/brain/date-time-luxon/src/lib/date-adapter.ts
+++ b/libs/brain/date-time-luxon/src/lib/date-adapter.ts
@@ -69,7 +69,7 @@ export class BrnLuxonDateAdapter implements BrnDateAdapter<DateTime> {
 	getDay(date: DateTime): number {
 		// Adjust the range, Luxon calculates week days starting with Monday 1 to Sunday 7
 		// , and we should return Sunday 0 to Saturday 6
-		return date.weekday % 7
+		return date.weekday % 7;
 	}
 
 	getHours(date: DateTime): number {

--- a/libs/brain/date-time-luxon/src/lib/date-adapter.ts
+++ b/libs/brain/date-time-luxon/src/lib/date-adapter.ts
@@ -67,7 +67,9 @@ export class BrnLuxonDateAdapter implements BrnDateAdapter<DateTime> {
 	}
 
 	getDay(date: DateTime): number {
-		return date.weekday;
+		// Adjust the range, Luxon calculates week days starting with Monday 1 to Sunday 7
+		// , and we should return Sunday 0 to Saturday 6
+		return date.weekday % 7
 	}
 
 	getHours(date: DateTime): number {

--- a/libs/brain/date-time/src/lib/date-adapter.ts
+++ b/libs/brain/date-time/src/lib/date-adapter.ts
@@ -82,7 +82,9 @@ export interface BrnDateAdapter<T> {
 	getDate(date: T): number;
 
 	/**
-	 * Get the day.
+	 * Get the day of the week.
+	 *
+	 * Returns a value between 0 and 6 where 0 is Sunday
 	 */
 	getDay(date: T): number;
 

--- a/libs/brain/date-time/src/lib/native-date-adapter.spec.ts
+++ b/libs/brain/date-time/src/lib/native-date-adapter.spec.ts
@@ -11,20 +11,20 @@ describe('BrnNativeDateAdapter', () => {
 
 	test('set() should update specified date properties', () => {
 		const date = new Date(2023, 9, 10, 10, 0, 0);
-		const result = adapter.set(date, {hour: 15, minute: 45});
+		const result = adapter.set(date, { hour: 15, minute: 45 });
 		expect(result.getHours()).toBe(15);
 		expect(result.getMinutes()).toBe(45);
 	});
 
 	test('add() should add duration to a date', () => {
 		const date = new Date(2023, 9, 10);
-		const result = adapter.add(date, {days: 2, hours: 5});
+		const result = adapter.add(date, { days: 2, hours: 5 });
 		expect(result).toEqual(new Date(2023, 9, 12, 5));
 	});
 
 	test('subtract() should subtract duration from a date', () => {
 		const date = new Date(2023, 9, 10);
-		const result = adapter.subtract(date, {days: 1, hours: 2});
+		const result = adapter.subtract(date, { days: 1, hours: 2 });
 		expect(result).toEqual(new Date(2023, 9, 8, 22));
 	});
 
@@ -122,7 +122,6 @@ describe('BrnNativeDateAdapter', () => {
 		expect(adapter.getDay(new Date(2024, 2, 23))).toBe(6);
 	});
 
-
 	test('getHours() should return the hours of a date', () => {
 		const date = new Date(2023, 9, 10, 15, 30);
 		expect(adapter.getHours(date)).toBe(15);
@@ -154,7 +153,7 @@ describe('BrnNativeDateAdapter', () => {
 	});
 
 	test('create() should create a new date from values', () => {
-		const values = {year: 2023, month: 9, day: 10, hour: 12, minute: 30, second: 0, millisecond: 0};
+		const values = { year: 2023, month: 9, day: 10, hour: 12, minute: 30, second: 0, millisecond: 0 };
 		const date = adapter.create(values);
 		expect(date).toEqual(new Date(2023, 9, 10, 12, 30));
 	});

--- a/libs/brain/date-time/src/lib/native-date-adapter.spec.ts
+++ b/libs/brain/date-time/src/lib/native-date-adapter.spec.ts
@@ -1,0 +1,161 @@
+import { BrnNativeDateAdapter } from './native-date-adapter';
+
+describe('BrnNativeDateAdapter', () => {
+	const adapter = new BrnNativeDateAdapter();
+
+	test('now() should return the current time', () => {
+		const actual = adapter.now();
+		const expected = new Date();
+		expect(actual.getTime()).toBeCloseTo(expected.getTime(), -2);
+	});
+
+	test('set() should update specified date properties', () => {
+		const date = new Date(2023, 9, 10, 10, 0, 0);
+		const result = adapter.set(date, {hour: 15, minute: 45});
+		expect(result.getHours()).toBe(15);
+		expect(result.getMinutes()).toBe(45);
+	});
+
+	test('add() should add duration to a date', () => {
+		const date = new Date(2023, 9, 10);
+		const result = adapter.add(date, {days: 2, hours: 5});
+		expect(result).toEqual(new Date(2023, 9, 12, 5));
+	});
+
+	test('subtract() should subtract duration from a date', () => {
+		const date = new Date(2023, 9, 10);
+		const result = adapter.subtract(date, {days: 1, hours: 2});
+		expect(result).toEqual(new Date(2023, 9, 8, 22));
+	});
+
+	test('compare() should compare two dates', () => {
+		const dateA = new Date(2023, 9, 10);
+		const dateB = new Date(2023, 9, 12);
+		expect(adapter.compare(dateA, dateB)).toBe(-1);
+		expect(adapter.compare(dateB, dateA)).toBe(1);
+		expect(adapter.compare(dateA, dateA)).toBe(0);
+	});
+
+	test('isEqual() should check if two dates are equal', () => {
+		const dateA = new Date(2023, 9, 10);
+		const dateB = new Date(2023, 9, 10);
+		const dateC = new Date(2023, 9, 11);
+		expect(adapter.isEqual(dateA, dateB)).toBe(true);
+		expect(adapter.isEqual(dateA, dateC)).toBe(false);
+	});
+
+	test('isBefore() should check if a date is before another', () => {
+		const dateA = new Date(2023, 9, 10);
+		const dateB = new Date(2023, 9, 11);
+		expect(adapter.isBefore(dateA, dateB)).toBe(true);
+		expect(adapter.isBefore(dateB, dateA)).toBe(false);
+	});
+
+	test('isAfter() should check if a date is after another', () => {
+		const dateA = new Date(2023, 9, 10);
+		const dateB = new Date(2023, 9, 9);
+		expect(adapter.isAfter(dateA, dateB)).toBe(true);
+		expect(adapter.isAfter(dateB, dateA)).toBe(false);
+	});
+
+	test('isSameDay() should check if two dates are on the same day', () => {
+		const dateA = new Date(2023, 9, 10, 5);
+		const dateB = new Date(2023, 9, 10, 22);
+		const dateC = new Date(2023, 9, 11);
+		expect(adapter.isSameDay(dateA, dateB)).toBe(true);
+		expect(adapter.isSameDay(dateA, dateC)).toBe(false);
+	});
+
+	test('getYear() should return the year of a date', () => {
+		const date = new Date(2023, 9, 10);
+		expect(adapter.getYear(date)).toBe(2023);
+	});
+
+	test('getMonth() should return the month of a date', () => {
+		const date = new Date(2023, 9, 10);
+		expect(adapter.getMonth(date)).toBe(9); // JavaScript months are 0-based
+	});
+
+	test('getDate() should return the day of the month of a date', () => {
+		const date = new Date(2023, 9, 10);
+		expect(adapter.getDate(date)).toBe(10);
+	});
+
+	test('getTime() should return the timestamp of a date', () => {
+		const date = new Date(2023, 9, 10, 12);
+		expect(adapter.getTime(date)).toBe(date.getTime());
+	});
+
+	test('startOfMonth() should return the start of the month', () => {
+		const date = new Date(2023, 9, 10, 12);
+		expect(adapter.startOfMonth(date)).toEqual(new Date(2023, 9, 1));
+	});
+
+	test('endOfMonth() should return the end of the month', () => {
+		const date = new Date(2023, 9, 10, 12);
+		expect(adapter.endOfMonth(date)).toEqual(new Date(2023, 9, 31));
+	});
+
+	test('isSameMonth() should check if two dates are in the same month', () => {
+		const dateA = new Date(2023, 9, 10);
+		const dateB = new Date(2023, 9, 15);
+		const dateC = new Date(2023, 10, 10);
+		expect(adapter.isSameMonth(dateA, dateB)).toBe(true);
+		expect(adapter.isSameMonth(dateA, dateC)).toBe(false);
+	});
+
+	test('isSameYear() should check if two dates are in the same year', () => {
+		const dateA = new Date(2023, 9, 10);
+		const dateB = new Date(2023, 11, 15);
+		const dateC = new Date(2024, 9, 10);
+		expect(adapter.isSameYear(dateA, dateB)).toBe(true);
+		expect(adapter.isSameYear(dateA, dateC)).toBe(false);
+	});
+
+	test('getDay() should return the day of week', () => {
+		expect(adapter.getDay(new Date(2024, 2, 17))).toBe(0);
+		expect(adapter.getDay(new Date(2024, 2, 18))).toBe(1);
+		expect(adapter.getDay(new Date(2024, 2, 19))).toBe(2);
+		expect(adapter.getDay(new Date(2024, 2, 20))).toBe(3);
+		expect(adapter.getDay(new Date(2024, 2, 21))).toBe(4);
+		expect(adapter.getDay(new Date(2024, 2, 22))).toBe(5);
+		expect(adapter.getDay(new Date(2024, 2, 23))).toBe(6);
+	});
+
+
+	test('getHours() should return the hours of a date', () => {
+		const date = new Date(2023, 9, 10, 15, 30);
+		expect(adapter.getHours(date)).toBe(15);
+	});
+
+	test('getMinutes() should return the minutes of a date', () => {
+		const date = new Date(2023, 9, 10, 15, 30);
+		expect(adapter.getMinutes(date)).toBe(30);
+	});
+
+	test('getSeconds() should return the seconds of a date', () => {
+		const date = new Date(2023, 9, 10, 15, 30, 45);
+		expect(adapter.getSeconds(date)).toBe(45);
+	});
+
+	test('getMilliseconds() should return the milliseconds of a date', () => {
+		const date = new Date(2023, 9, 10, 15, 30, 45, 500);
+		expect(adapter.getMilliseconds(date)).toBe(500);
+	});
+
+	test('startOfDay() should return the start of the day', () => {
+		const date = new Date(2023, 9, 10, 15, 30, 45);
+		expect(adapter.startOfDay(date)).toEqual(new Date(2023, 9, 10, 0, 0, 0, 0));
+	});
+
+	test('endOfDay() should return the end of the day', () => {
+		const date = new Date(2023, 9, 10, 15, 30, 45);
+		expect(adapter.endOfDay(date)).toEqual(new Date(2023, 9, 10, 23, 59, 59, 999));
+	});
+
+	test('create() should create a new date from values', () => {
+		const values = {year: 2023, month: 9, day: 10, hour: 12, minute: 30, second: 0, millisecond: 0};
+		const date = adapter.create(values);
+		expect(date).toEqual(new Date(2023, 9, 10, 12, 30));
+	});
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] Other... Please describe:
Added tests

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [x] date-time (seems to be missing?)
- [ ] dialog
- [ ] dropdown-menu
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`getDay()` in `BrnLuxonDateAdapter` returns a value between 1-7 whereas a value between 0-6 is expected.

Closes #675 

## What is the new behavior?

Adapt the `BrnLuxonDateAdapter` to return a value in the range 0-6.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
