### PR TITLE
feat(table): add go to first and last page with the brn-paginator #684

### DIFF
--- a/libs/brain/table/src/lib/brn-paginator.directive.ts
+++ b/libs/brain/table/src/lib/brn-paginator.directive.ts
@@ -29,6 +29,8 @@ export type PaginatorContext = {
 		decrementable: Signal<boolean>;
 		increment: () => void;
 		decrement: () => void;
+		goToFirstPage: () => void;
+		goToLastPage: () => void;
 	};
 };
 
@@ -95,6 +97,8 @@ export class BrnPaginatorDirective implements OnInit {
 				decrement: () => this.decrementPage(),
 				incrementable: this._incrementable,
 				decrementable: this._decrementable,
+				goToFirstPage: () => this.reset(),
+				goToLastPage: () => this.goToLastPage(),
 			},
 		});
 	}
@@ -104,6 +108,10 @@ export class BrnPaginatorDirective implements OnInit {
 		if (0 < currentPage) {
 			this.calculateNewState({ newPage: currentPage - 1 });
 		}
+	}
+
+	public goToLastPage(): void {
+		this.currentPage = this._state().totalPages;
 	}
 
 	public incrementPage(): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [x] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Currently, it's not possible to go to the last page when you use the BrnPaginator directive programmatically. 

Closes #684

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
