### PR TITLE
fix(input): resolve error state persistence after form reset

### DIFF
--- a/libs/helm/input/src/lib/hlm-input.directive.ts
+++ b/libs/helm/input/src/lib/hlm-input.directive.ts
@@ -80,7 +80,8 @@ export class HlmInputDirective implements BrnFormFieldControl, DoCheck {
 			const error = this._errorStateTracker.errorState();
 			untracked(() => {
 				if (this.ngControl) {
-					this.setError(error);
+					const shouldShowError = error && this.ngControl.invalid && (this.ngControl.touched || this.ngControl.dirty);
+          this.setError(shouldShowError ? true : 'auto');
 				}
 			});
 		});


### PR DESCRIPTION
## 🐛 **Bug Fix**

### **Problem**
The `HlmInputDirective` was showing error borders that persisted after `form.reset()` due to the `ErrorStateTracker` not properly validating the form control's interaction state.

### **Root Cause**
The original `effect()` was directly using the boolean result from `ErrorStateTracker.errorState()` without checking if the form control was actually touched/dirty, causing error styling to persist even after successful form resets.

### **Solution**
Added validation to ensure error styling only appears when:
- ErrorStateTracker indicates an error AND
- Control is invalid AND  
- Control has been interacted with (touched OR dirty)

### **Changes**
- Modified the `effect()` in `HlmInputDirective` constructor
- Added proper form control state validation
- Follows Angular Material error state patterns

### **Testing**
- ✅ Error borders appear correctly on invalid touched fields
- ✅ Error borders disappear after `form.reset()`
- ✅ No regression in existing error display behavior
- ✅ All existing tests pass

### **Before/After**

**Before:**
```typescript
this.setError(error); // Always used ErrorStateTracker result