### PR TITLE
feat(tabs): add unregister functionality to BrnTabsDirective (#710)

### DIFF
--- a/libs/brain/tabs/src/lib/brn-tabs-content.directive.ts
+++ b/libs/brain/tabs/src/lib/brn-tabs-content.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, effect, ElementRef, inject, input, untracked } from '@angular/core';
+import {computed, Directive, effect, ElementRef, inject, input, OnDestroy, untracked} from '@angular/core';
 import { BrnTabsDirective } from './brn-tabs.directive';
 
 @Directive({
@@ -13,7 +13,7 @@ import { BrnTabsDirective } from './brn-tabs.directive';
 	},
 	exportAs: 'brnTabsContent',
 })
-export class BrnTabsContentDirective {
+export class BrnTabsContentDirective implements OnDestroy {
 	private readonly _root = inject(BrnTabsDirective);
 	private readonly _elementRef = inject(ElementRef);
 
@@ -31,5 +31,9 @@ export class BrnTabsContentDirective {
 
 	public focus() {
 		this._elementRef.nativeElement.focus();
+	}
+
+	ngOnDestroy(): void {
+		this._root.unregisterContent(this.contentFor())
 	}
 }

--- a/libs/brain/tabs/src/lib/brn-tabs-content.directive.ts
+++ b/libs/brain/tabs/src/lib/brn-tabs-content.directive.ts
@@ -1,4 +1,4 @@
-import {computed, Directive, effect, ElementRef, inject, input, OnDestroy, untracked} from '@angular/core';
+import { computed, Directive, effect, ElementRef, inject, input, OnDestroy, untracked } from '@angular/core';
 import { BrnTabsDirective } from './brn-tabs.directive';
 
 @Directive({
@@ -34,6 +34,6 @@ export class BrnTabsContentDirective implements OnDestroy {
 	}
 
 	ngOnDestroy(): void {
-		this._root.unregisterContent(this.contentFor())
+		this._root.unregisterContent(this.contentFor());
 	}
 }

--- a/libs/brain/tabs/src/lib/brn-tabs-trigger.directive.ts
+++ b/libs/brain/tabs/src/lib/brn-tabs-trigger.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, ElementRef, Input, computed, effect, inject, input, untracked, OnDestroy} from '@angular/core';
+import { Directive, ElementRef, Input, OnDestroy, computed, effect, inject, input, untracked } from '@angular/core';
 import { BrnTabsDirective } from './brn-tabs.directive';
 
 @Directive({

--- a/libs/brain/tabs/src/lib/brn-tabs-trigger.directive.ts
+++ b/libs/brain/tabs/src/lib/brn-tabs-trigger.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Input, computed, effect, inject, input, untracked } from '@angular/core';
+import {Directive, ElementRef, Input, computed, effect, inject, input, untracked, OnDestroy} from '@angular/core';
 import { BrnTabsDirective } from './brn-tabs.directive';
 
 @Directive({
@@ -18,7 +18,7 @@ import { BrnTabsDirective } from './brn-tabs.directive';
 	},
 	exportAs: 'brnTabsTrigger',
 })
-export class BrnTabsTriggerDirective {
+export class BrnTabsTriggerDirective implements OnDestroy {
 	public readonly elementRef = inject(ElementRef);
 
 	private readonly _root = inject(BrnTabsDirective);
@@ -56,5 +56,9 @@ export class BrnTabsTriggerDirective {
 
 	public get key(): string | undefined {
 		return this.triggerFor();
+	}
+
+	ngOnDestroy(): void {
+		this._root.unregisterTrigger(this.triggerFor());
 	}
 }

--- a/libs/brain/tabs/src/lib/brn-tabs.directive.spec.ts
+++ b/libs/brain/tabs/src/lib/brn-tabs.directive.spec.ts
@@ -1,0 +1,75 @@
+import { ChangeDetectionStrategy, Component, input, viewChild } from '@angular/core';
+import { render, RenderResult } from '@testing-library/angular';
+import { BrnTabsContentDirective } from './brn-tabs-content.directive';
+import { BrnTabsTriggerDirective } from './brn-tabs-trigger.directive';
+import { BrnTabsDirective } from './brn-tabs.directive';
+
+@Component({
+	standalone: true,
+	imports: [BrnTabsDirective, BrnTabsTriggerDirective, BrnTabsContentDirective],
+	template: `
+		<div brnTabs="tab1" #tabs="brnTabs">
+			@if (showTrigger()) {
+				<button brnTabsTrigger [brnTabsTrigger]="'tab1'" data-testid="trigger">Tab Trigger</button>
+			}
+			@if (showContent()) {
+				<div brnTabsContent [brnTabsContent]="'tab1'" data-testid="content">Tab Content</div>
+			}
+		</div>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class BrnTabsDirectiveSpecComponent {
+	public tabsDir = viewChild.required<BrnTabsDirective>('tabs');
+
+	public showTrigger = input(true);
+	public showContent = input(true);
+}
+
+describe('BrnTabsDirective', () => {
+	let renderResult: RenderResult<BrnTabsDirectiveSpecComponent>;
+
+	beforeEach(async () => {
+		renderResult = await render(BrnTabsDirectiveSpecComponent, {});
+	});
+
+	it('should register trigger and content on init', () => {
+		const tabs = renderResult.fixture.componentInstance.tabsDir().$tabs();
+		expect(Object.keys(tabs)).toContain('tab1');
+		expect(tabs['tab1'].trigger).toBeInstanceOf(BrnTabsTriggerDirective);
+		expect(tabs['tab1'].content).toBeInstanceOf(BrnTabsContentDirective);
+	});
+
+	it('should unregister only the trigger when it is removed', async () => {
+		renderResult.fixture.componentRef.setInput('showTrigger', false);
+		renderResult.fixture.detectChanges();
+		const tabsAfter = renderResult.fixture.componentInstance.tabsDir().$tabs();
+		expect(tabsAfter['tab1']).toBeDefined();
+		expect(tabsAfter['tab1'].trigger).toBeUndefined();
+		expect(tabsAfter['tab1'].content).toBeInstanceOf(BrnTabsContentDirective);
+	});
+
+	it('should unregister only the content when it is removed', async () => {
+		renderResult.fixture.componentRef.setInput('showContent', false);
+		renderResult.fixture.detectChanges();
+		const tabsAfter = renderResult.fixture.componentInstance.tabsDir().$tabs();
+		expect(tabsAfter['tab1']).toBeDefined();
+		expect(tabsAfter['tab1'].content).toBeUndefined();
+		expect(tabsAfter['tab1'].trigger).toBeInstanceOf(BrnTabsTriggerDirective);
+	});
+
+	it('should remove the entire tab entry when both trigger and content are gone', async () => {
+		renderResult.fixture.componentRef.setInput('showContent', false);
+		renderResult.fixture.componentRef.setInput('showTrigger', false);
+		renderResult.fixture.detectChanges();
+		const tabsAfter = renderResult.fixture.componentInstance.tabsDir().$tabs();
+		expect(tabsAfter['tab1']).toBeUndefined();
+	});
+
+	it('should remove active tab when trigger was removed', async () => {
+		expect(renderResult.fixture.componentInstance.tabsDir().$activeTab()).toBe('tab1');
+		renderResult.fixture.componentRef.setInput('showTrigger', false);
+		renderResult.fixture.detectChanges();
+		expect(renderResult.fixture.componentInstance.tabsDir().$activeTab()).toBeUndefined();
+	});
+});

--- a/libs/brain/tabs/src/lib/brn-tabs.directive.ts
+++ b/libs/brain/tabs/src/lib/brn-tabs.directive.ts
@@ -48,7 +48,9 @@ export class BrnTabsDirective {
 
 	public unregisterTrigger(key: string) {
 		this.updateEntry(key, { trigger: undefined });
-		this._activeTab.set(undefined);
+		if (this._activeTab() === key) {
+			this._activeTab.set(undefined);
+		}
 	}
 
 	public unregisterContent(key: string): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [x] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #710 

## What is the new behavior?

The brnTabsTrigger and brnTabsContent unregisters onDestroy. Active tab is set as undefined when trigger is removed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I'm not sure if an event with active tab to undefined should be emitted after destroying a card. I can image situation where we want to destroy tab but user should stay at actived content. On the other hand it seems logical. I ran unit tests the tests but not all pass (eg. test for tools) on my local env even without my changes. I compared output and seems the same. Also wondered if there should be a common function for those methods but decided to go that way. I hope everything is in line with the contributing guidelines.

