### PR TITLE
fix(docs): generate helm api

### DIFF
--- a/apps/app/project.json
+++ b/apps/app/project.json
@@ -78,7 +78,7 @@
 				"outputDir": "apps/app/src/public/data",
 				"outputFile": "ui-api.json",
 				"brainDir": "libs/brain",
-				"uiDir": "libs/ui"
+				"helmDir": "libs/helm"
 			}
 		}
 	}

--- a/apps/app/src/app/core/models/ui-docs.model.ts
+++ b/apps/app/src/app/core/models/ui-docs.model.ts
@@ -15,7 +15,7 @@ export interface ComponentMetadata {
 
 export type PrimitveComponent = Record<string, ComponentMetadata>;
 
-export type SubTypeRecord = 'brain' | 'ui';
+export type SubTypeRecord = 'brain' | 'helm';
 
 // Represents the subtype (e.g., "brain", "ui") containing components/directives
 export type PrimitiveSubTypes = Record<SubTypeRecord, PrimitveComponent>;

--- a/apps/app/src/app/core/services/api-docs.service.ts
+++ b/apps/app/src/app/core/services/api-docs.service.ts
@@ -28,8 +28,8 @@ export class ApiDocsService {
 				}))
 			: [];
 
-		const helmHeaders = docs.ui
-			? Object.keys(docs.ui).map((name) => ({
+		const helmHeaders = docs.helm
+			? Object.keys(docs.helm).map((name) => ({
 					id: name.toLowerCase(),
 					label: name,
 					type: 'helm' as const,

--- a/apps/app/src/app/pages/(components)/components/(accordion)/accordion.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(accordion)/accordion.page.ts
@@ -75,7 +75,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__multiple_opened" class="${hlmH4} mb-2 mt-6">Multiple and Opened</h3>

--- a/apps/app/src/app/pages/(components)/components/(alert)/alert.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(alert)/alert.page.ts
@@ -65,7 +65,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>

--- a/apps/app/src/app/pages/(components)/components/(alert-dialog)/alert-dialog.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(alert-dialog)/alert-dialog.page.ts
@@ -71,7 +71,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="aspect-ratio" label="Aspect Ratio" />

--- a/apps/app/src/app/pages/(components)/components/(aspect-ratio)/aspect-ratio.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(aspect-ratio)/aspect-ratio.page.ts
@@ -62,7 +62,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="avatar" label="Avatar" />

--- a/apps/app/src/app/pages/(components)/components/(avatar)/avatar.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(avatar)/avatar.page.ts
@@ -65,7 +65,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="badge" label="Badge" />

--- a/apps/app/src/app/pages/(components)/components/(badge)/badge.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(badge)/badge.page.ts
@@ -69,7 +69,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>

--- a/apps/app/src/app/pages/(components)/components/(breadcrumb)/breadcrumb.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(breadcrumb)/breadcrumb.page.ts
@@ -77,7 +77,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__custom-separator" class="${hlmH4} mt-6">Custom separator</h3>

--- a/apps/app/src/app/pages/(components)/components/(button)/button.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(button)/button.page.ts
@@ -81,7 +81,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>

--- a/apps/app/src/app/pages/(components)/components/(calendar)/calendar.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(calendar)/calendar.page.ts
@@ -63,7 +63,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__multiple_selection" class="${hlmH4} mb-2 mt-6">Multiple Selection</h3>

--- a/apps/app/src/app/pages/(components)/components/(card)/card.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(card)/card.page.ts
@@ -60,7 +60,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<spartan-tabs firstTab="Preview" secondTab="Code">

--- a/apps/app/src/app/pages/(components)/components/(carousel)/carousel.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(carousel)/carousel.page.ts
@@ -72,7 +72,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__sizes" class="${hlmH4} mb-2 mt-6">Sizes</h3>

--- a/apps/app/src/app/pages/(components)/components/(checkbox)/checkbox.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(checkbox)/checkbox.page.ts
@@ -66,7 +66,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="collapsible" label="Collapsible" />

--- a/apps/app/src/app/pages/(components)/components/(command)/command.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(command)/command.page.ts
@@ -72,7 +72,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__dialog" class="${hlmH4} mb-2 mt-6">Dialog</h3>

--- a/apps/app/src/app/pages/(components)/components/(context-menu)/context-menu.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(context-menu)/context-menu.page.ts
@@ -74,7 +74,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<h3 id="examples__stateful" class="${hlmH4} mb-2 mt-6">Stateful</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">

--- a/apps/app/src/app/pages/(components)/components/(date-picker)/date-picker.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(date-picker)/date-picker.page.ts
@@ -82,7 +82,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__custom_config" class="${hlmH4} mb-2 mt-6">Custom Configs</h3>

--- a/apps/app/src/app/pages/(components)/components/(dialog)/dialog.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(dialog)/dialog.page.ts
@@ -95,7 +95,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="declarative-usage">Declarative Usage</spartan-section-sub-heading>
 			<p class="${hlmP} mb-6">

--- a/apps/app/src/app/pages/(components)/components/(dropdown-menu)/dropdown-menu.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(dropdown-menu)/dropdown-menu.page.ts
@@ -71,7 +71,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__stateful" class="${hlmH4} mb-2 mt-6">Stateful</h3>

--- a/apps/app/src/app/pages/(components)/components/(form-field)/form-field.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(form-field)/form-field.page.ts
@@ -74,7 +74,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>

--- a/apps/app/src/app/pages/(components)/components/(hover-card)/hover-card.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(hover-card)/hover-card.page.ts
@@ -65,7 +65,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="icon" label="Icon" />

--- a/apps/app/src/app/pages/(components)/components/(icon)/icon.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(icon)/icon.page.ts
@@ -69,7 +69,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="input" label="Input" />

--- a/apps/app/src/app/pages/(components)/components/(input)/input.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(input)/input.page.ts
@@ -75,7 +75,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp.page.ts
@@ -66,7 +66,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 

--- a/apps/app/src/app/pages/(components)/components/(label)/label.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(label)/label.page.ts
@@ -63,7 +63,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="menubar" label="Menubar" />

--- a/apps/app/src/app/pages/(components)/components/(menubar)/menubar.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(menubar)/menubar.page.ts
@@ -65,7 +65,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="pagination" label="Pagination" />

--- a/apps/app/src/app/pages/(components)/components/(pagination)/pagination.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(pagination)/pagination.page.ts
@@ -68,7 +68,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__query_params" class="${hlmH4} mb-2 mt-6">Query Params</h3>

--- a/apps/app/src/app/pages/(components)/components/(popover)/popover.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(popover)/popover.page.ts
@@ -63,7 +63,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="progress" label="Progress" />

--- a/apps/app/src/app/pages/(components)/components/(progress)/progress.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(progress)/progress.page.ts
@@ -72,7 +72,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>

--- a/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group.page.ts
@@ -73,7 +73,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Card Layout</h3>

--- a/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area.page.ts
@@ -67,7 +67,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="select" label="Select" />

--- a/apps/app/src/app/pages/(components)/components/(select)/select.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(select)/select.page.ts
@@ -71,7 +71,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__multiple" class="${hlmH4} mb-2 mt-6">Multiple</h3>

--- a/apps/app/src/app/pages/(components)/components/(separator)/separator.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(separator)/separator.page.ts
@@ -63,7 +63,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="sheet" label="Sheet" />

--- a/apps/app/src/app/pages/(components)/components/(sheet)/sheet.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(sheet)/sheet.page.ts
@@ -74,7 +74,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__sides" class="${hlmH4} mb-2 mt-6">Sides</h3>

--- a/apps/app/src/app/pages/(components)/components/(skeleton)/skeleton.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(skeleton)/skeleton.page.ts
@@ -60,7 +60,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="slider" label="Slider" />

--- a/apps/app/src/app/pages/(components)/components/(sonner)/sonner.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(sonner)/sonner.page.ts
@@ -82,7 +82,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="table" label="Table" />

--- a/apps/app/src/app/pages/(components)/components/(spinner)/spinner.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(spinner)/spinner.page.ts
@@ -67,7 +67,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="variants">Variants</spartan-section-sub-heading>
 			The spinner component has the following variants:

--- a/apps/app/src/app/pages/(components)/components/(switch)/switch.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(switch)/switch.page.ts
@@ -66,7 +66,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="table" label="Table" />

--- a/apps/app/src/app/pages/(components)/components/(table)/table.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(table)/table.page.ts
@@ -66,7 +66,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="data-table">Data Table</spartan-section-sub-heading>
 			<p class="${hlmP}">

--- a/apps/app/src/app/pages/(components)/components/(tabs)/tabs.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(tabs)/tabs.page.ts
@@ -74,7 +74,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>

--- a/apps/app/src/app/pages/(components)/components/(textarea)/textarea.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(textarea)/textarea.page.ts
@@ -74,7 +74,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="toggle" label="Toggle" />

--- a/apps/app/src/app/pages/(components)/components/(toggle)/toggle.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(toggle)/toggle.page.ts
@@ -75,7 +75,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>

--- a/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
@@ -74,7 +74,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="brain" />
 
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
-			<spartan-ui-api-docs docType="ui" />
+			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 			<h3 id="examples__default" class="${hlmH4} mb-2 mt-6">Default</h3>

--- a/apps/app/src/app/shared/layout/ui-docs-section/ui-docs-section.component.ts
+++ b/apps/app/src/app/shared/layout/ui-docs-section/ui-docs-section.component.ts
@@ -1,6 +1,7 @@
 import { Component, computed, inject, input } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
+import { SubTypeRecord } from '@spartan-ng/app/app/core/models/ui-docs.model';
 import { hlmCode, hlmH4 } from '@spartan-ng/helm/typography';
 import { map } from 'rxjs/operators';
 import { ApiDocsService } from '../../../core/services/api-docs.service';
@@ -71,7 +72,7 @@ export class UIApiDocsComponent {
 	private readonly _route = inject(ActivatedRoute);
 	protected primitive = toSignal(this._route.data.pipe(map((data) => data?.['api'])));
 
-	public docType = input.required<'brain' | 'ui'>();
+	public docType = input.required<SubTypeRecord>();
 
 	protected componentDocs = computed(() => this._apiDocsService.getComponentDocs(this.primitive())());
 	protected componentItems = computed(() => this.componentDocs()?.[this.docType()] ?? {});

--- a/libs/tools/src/executors/docs/generate-ui-docs/executor.spec.ts
+++ b/libs/tools/src/executors/docs/generate-ui-docs/executor.spec.ts
@@ -169,7 +169,7 @@ describe('GenerateUiDocs Executor', () => {
 			outputDir: 'dist/extracted-metadata',
 			outputFile: 'ui-api.json',
 			brainDir: 'libs/brain',
-			uiDir: 'libs/ui',
+			helmDir: 'libs/helm',
 		};
 
 		// Setup mock classes and decorators

--- a/libs/tools/src/executors/docs/generate-ui-docs/executor.ts
+++ b/libs/tools/src/executors/docs/generate-ui-docs/executor.ts
@@ -7,7 +7,7 @@ import { GenerateUiDocsExecutorSchema } from './schema';
 export default async function runExecutor(options: GenerateUiDocsExecutorSchema, context: ExecutorContext) {
 	// Convert relative paths to absolute paths using workspace root
 	const brainDir = path.join(context.root, options.brainDir);
-	const uiDir = path.join(context.root, options.uiDir);
+	const helmDir = path.join(context.root, options.helmDir);
 	const outputDir = path.join(context.root, options.outputDir);
 
 	if (!fs.existsSync(outputDir)) {
@@ -18,8 +18,8 @@ export default async function runExecutor(options: GenerateUiDocsExecutorSchema,
 	project.addSourceFilesAtPaths([
 		`${brainDir}/**/*.component.ts`,
 		`${brainDir}/**/*.directive.ts`,
-		`${uiDir}/**/*.component.ts`,
-		`${uiDir}/**/*.directive.ts`,
+		`${helmDir}/**/*.component.ts`,
+		`${helmDir}/**/*.directive.ts`,
 	]);
 
 	const extractedData = extractInputsOutputs(project, context.root);

--- a/libs/tools/src/executors/docs/generate-ui-docs/schema.d.ts
+++ b/libs/tools/src/executors/docs/generate-ui-docs/schema.d.ts
@@ -2,5 +2,5 @@ export interface GenerateUiDocsExecutorSchema {
 	outputDir: string;
 	outputFile: string;
 	brainDir: string;
-	uiDir: string;
+	helmDir: string;
 }

--- a/libs/tools/src/executors/docs/generate-ui-docs/schema.json
+++ b/libs/tools/src/executors/docs/generate-ui-docs/schema.json
@@ -17,10 +17,10 @@
 			"type": "string",
 			"description": "Directory containing brain components, relative to workspace root"
 		},
-		"uiDir": {
+		"helmDir": {
 			"type": "string",
-			"description": "Directory containing UI components, relative to workspace root"
+			"description": "Directory containing helm components, relative to workspace root"
 		}
 	},
-	"required": ["outputDir", "outputFile", "brainDir", "uiDir"]
+	"required": ["outputDir", "outputFile", "brainDir", "helmDir"]
 }

--- a/project.json
+++ b/project.json
@@ -15,7 +15,7 @@
 				"outputDir": "apps/app/src/public/data",
 				"outputFile": "ui-api.json",
 				"brainDir": "libs/brain",
-				"uiDir": "libs/ui"
+				"helmDir": "libs/helm"
 			},
 			"outputs": ["{options.outputDir}/{options.outputFile}"]
 		}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The "Helm API" section for components are currently empty, since the move from ui to helm directory #696.

![CleanShot 2025-06-10 at 15 28 50](https://github.com/user-attachments/assets/719d9a7a-9785-42bd-8548-7cfc3d405fc5)


## What is the new behavior?

Renames ui to helm for the generator and when displaying the docs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
