### PR TITLE
fix: respect @nx/angular:library config in nx.json

### DIFF
--- a/libs/cli/src/generators/base/lib/initialize-angular-library.ts
+++ b/libs/cli/src/generators/base/lib/initialize-angular-library.ts
@@ -1,4 +1,4 @@
-import { type Tree, joinPathFragments } from '@nx/devkit';
+import { type Tree, joinPathFragments, readNxJson } from '@nx/devkit';
 import type { HlmBaseGeneratorSchema } from '../schema';
 
 export async function initializeAngularLibrary(tree: Tree, options: HlmBaseGeneratorSchema) {
@@ -9,6 +9,7 @@ export async function initializeAngularLibrary(tree: Tree, options: HlmBaseGener
 			'@nx/angular/generators'
 		)
 	).libraryGenerator(tree, {
+		...(readNxJson(tree).generators?.['@nx/angular:library'] || {}),
 		name: options.publicName,
 		skipFormat: true,
 		simpleName: true,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

Currently generating ui libraries always uses jest as default unit test runner and eslint as linter among other defaults because the project configuration is not taken into account (@nx/angular:library).

Closes #

## What is the new behavior?

Configuration from nx.json is used as base for creating libraries (@nx/angular:library, if existent).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
