### PR TITLE
fix(docs): work break in api docs table

### DIFF
--- a/apps/app/src/app/shared/layout/ui-docs-section/ui-docs-section.component.ts
+++ b/apps/app/src/app/shared/layout/ui-docs-section/ui-docs-section.component.ts
@@ -30,10 +30,10 @@ import { UIApiDocsTableComponent } from '../ui-api-docs-table/ui-api-docs-table.
 						title="Inputs"
 						[rows]="componentItems()[entry].inputs"
 						[columns]="[
-							{ label: 'Prop', key: 'name', class: 'w-[200px] flex-1 font-medium' },
-							{ label: 'Type', key: 'type', class: 'w-[100px] flex-1 flex-wrap' },
-							{ label: 'Default', key: 'defaultValue', class: 'w-[100px] flex-1' },
-							{ label: 'Description', key: 'description', class: 'flex-1' },
+							{ label: 'Prop', key: 'name', class: 'w-[200px] flex-1 font-medium break-all' },
+							{ label: 'Type', key: 'type', class: 'w-[100px] flex-1 flex-wrap break-all' },
+							{ label: 'Default', key: 'defaultValue', class: 'w-[100px] flex-1 break-all' },
+							{ label: 'Description', key: 'description', class: 'flex-1 break-normal' },
 						]"
 					/>
 				}
@@ -43,10 +43,10 @@ import { UIApiDocsTableComponent } from '../ui-api-docs-table/ui-api-docs-table.
 						title="Models"
 						[rows]="componentItems()[entry].models"
 						[columns]="[
-							{ label: 'Prop', key: 'name', class: 'w-[200px] flex-1 font-medium' },
-							{ label: 'Type', key: 'type', class: 'w-[100px] flex-1 flex-wrap' },
-							{ label: 'Default', key: 'defaultValue', class: 'w-[100px] flex-1' },
-							{ label: 'Description', key: 'description', class: 'flex-1' },
+							{ label: 'Prop', key: 'name', class: 'w-[200px] flex-1 font-medium break-all' },
+							{ label: 'Type', key: 'type', class: 'w-[100px] flex-1 flex-wrap break-all' },
+							{ label: 'Default', key: 'defaultValue', class: 'w-[100px] flex-1 break-all' },
+							{ label: 'Description', key: 'description', class: 'flex-1 break-normal' },
 						]"
 					/>
 				}
@@ -56,9 +56,9 @@ import { UIApiDocsTableComponent } from '../ui-api-docs-table/ui-api-docs-table.
 						title="Outputs"
 						[rows]="componentItems()[entry].outputs"
 						[columns]="[
-							{ label: 'Prop', key: 'name', class: 'w-[200px] flex-1 font-medium' },
-							{ label: 'Type', key: 'type', class: 'w-[100px] flex-1 flex-wrap' },
-							{ label: 'Description', key: 'description', class: 'flex-1' },
+							{ label: 'Prop', key: 'name', class: 'w-[200px] flex-1 font-medium break-all' },
+							{ label: 'Type', key: 'type', class: 'w-[100px] flex-1 flex-wrap break-all' },
+							{ label: 'Description', key: 'description', class: 'flex-1 break-normal' },
 						]"
 					/>
 				}


### PR DESCRIPTION
add break-all class in each column of api docs table in order to prevent text overflow

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

The text in api table overflows as below.

<img width="917" alt="스크린샷 2025-06-18 오후 9 39 41" src="https://github.com/user-attachments/assets/7230094a-1287-43b8-9fc6-985d81497cca" />

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

<img width="946" alt="스크린샷 2025-06-18 오후 9 48 02" src="https://github.com/user-attachments/assets/dcefe78f-53a1-4b7c-8d35-bcdac4b5cab5" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
