### PR TITLE
fix(command,select,slider,input): use forward refs when providing inj…

### DIFF
--- a/libs/brain/command/src/lib/brn-command-search-input.directive.ts
+++ b/libs/brain/command/src/lib/brn-command-search-input.directive.ts
@@ -1,4 +1,15 @@
-import { computed, Directive, effect, ElementRef, Inject, input, Optional, Renderer2, signal } from '@angular/core';
+import {
+	computed,
+	Directive,
+	effect,
+	ElementRef,
+	forwardRef,
+	Inject,
+	input,
+	Optional,
+	Renderer2,
+	signal,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { COMPOSITION_BUFFER_MODE, DefaultValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { startWith } from 'rxjs/operators';
@@ -11,7 +22,7 @@ import { injectBrnCommand } from './brn-command.token';
 		provideBrnCommandSearchInput(BrnCommandSearchInputDirective),
 		{
 			provide: NG_VALUE_ACCESSOR,
-			useExisting: BrnCommandSearchInputDirective,
+			useExisting: forwardRef(() => BrnCommandSearchInputDirective),
 			multi: true,
 		},
 	],

--- a/libs/brain/select/src/lib/brn-select.component.ts
+++ b/libs/brain/select/src/lib/brn-select.component.ts
@@ -17,6 +17,7 @@ import {
 	computed,
 	contentChild,
 	contentChildren,
+	forwardRef,
 	inject,
 	input,
 	model,
@@ -56,7 +57,7 @@ let nextId = 0;
 		provideBrnSelect(BrnSelectComponent),
 		{
 			provide: BrnFormFieldControl,
-			useExisting: BrnSelectComponent,
+			useExisting: forwardRef(() => BrnSelectComponent),
 		},
 	],
 	template: `

--- a/libs/brain/slider/src/lib/brn-slider.directive.ts
+++ b/libs/brain/slider/src/lib/brn-slider.directive.ts
@@ -5,6 +5,7 @@ import {
 	computed,
 	Directive,
 	ElementRef,
+	forwardRef,
 	inject,
 	input,
 	linkedSignal,
@@ -25,7 +26,7 @@ import { provideBrnSlider } from './brn-slider.token';
 		provideBrnSlider(BrnSliderDirective),
 		{
 			provide: NG_VALUE_ACCESSOR,
-			useExisting: BrnSliderDirective,
+			useExisting: forwardRef(() => BrnSliderDirective),
 			multi: true,
 		},
 	],

--- a/libs/helm/input/src/lib/hlm-input.directive.ts
+++ b/libs/helm/input/src/lib/hlm-input.directive.ts
@@ -1,4 +1,15 @@
-import { Directive, type DoCheck, Injector, computed, effect, inject, input, signal, untracked } from '@angular/core';
+import {
+	Directive,
+	type DoCheck,
+	Injector,
+	computed,
+	effect,
+	forwardRef,
+	inject,
+	input,
+	signal,
+	untracked,
+} from '@angular/core';
 import { FormGroupDirective, NgControl, NgForm } from '@angular/forms';
 import { hlm } from '@spartan-ng/brain/core';
 import { BrnFormFieldControl } from '@spartan-ng/brain/form-field';
@@ -37,7 +48,7 @@ type InputVariants = VariantProps<typeof inputVariants>;
 	providers: [
 		{
 			provide: BrnFormFieldControl,
-			useExisting: HlmInputDirective,
+			useExisting: forwardRef(() => HlmInputDirective),
 		},
 	],
 })


### PR DESCRIPTION
…ection token

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [x] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [x] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [x] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [x] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?
we do not use forward refs
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #725

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
