### PR TITLE
fix(cli): make sure to use the right separator regardless of OS

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -19,6 +19,7 @@ module.exports = {
 				'card',
 				'carousel',
 				'checkbox',
+				'cli',
 				'collapsible',
 				'combobox',
 				'command',

--- a/libs/cli/src/generators/base/generator.ts
+++ b/libs/cli/src/generators/base/generator.ts
@@ -30,7 +30,9 @@ export async function hlmBaseGenerator(tree: Tree, options: HlmBaseGeneratorSche
 	}
 
 	if (options.angularCli) {
-		addTsConfigPath(tree, tsConfigAliasToUse, [`.${path.sep}${joinPathFragments(targetLibDir, 'src', 'index.ts')}`]);
+		addTsConfigPath(tree, tsConfigAliasToUse, [
+			`./${joinPathFragments(targetLibDir, 'src', 'index.ts').replace(/\\/g, '/')}`,
+		]);
 	} else {
 		tasks.push(await initializeAngularLibrary(tree, options));
 	}


### PR DESCRIPTION
closes #723

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

We get the wrong separator in the tsconfig if running on windows

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #723

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
