### PR TITLE
docs: fix additional call to api docs from loader

### DIFF
--- a/apps/app/src/app/core/models/ui-docs.model.ts
+++ b/apps/app/src/app/core/models/ui-docs.model.ts
@@ -2,23 +2,19 @@ export interface PropertyMetadata {
 	name: string;
 	type: string;
 	description: string;
-	defaultValue: string;
+	defaultValue?: string | null; // Made optional since outputs don't have defaultValue
 }
+
 export interface ComponentMetadata {
 	file: string;
 	inputs: PropertyMetadata[];
 	models: PropertyMetadata[];
 	outputs: PropertyMetadata[];
-	selector: string | null;
-	exportAs: string | null;
+	selector?: string | null;
+	exportAs?: string | null;
 }
 
-export type PrimitveComponent = Record<string, ComponentMetadata>;
-
-export type SubTypeRecord = 'brain' | 'helm';
-
-// Represents the subtype (e.g., "brain", "ui") containing components/directives
-export type PrimitiveSubTypes = Record<SubTypeRecord, PrimitveComponent>;
+export type LibraryComponents = Record<string, ComponentMetadata>;
 
 export type Primitives =
 	| 'accordion'
@@ -34,20 +30,16 @@ export type Primitives =
 	| 'carousel'
 	| 'checkbox'
 	| 'collapsible'
-	| 'combobox'
 	| 'command'
-	| 'context-menu'
-	| 'data-table'
 	| 'date-picker'
 	| 'dialog'
-	| 'dropdown-menu'
 	| 'form-field'
 	| 'hover-card'
 	| 'icon'
 	| 'input'
+	| 'input-otp'
 	| 'label'
-	| 'menubar'
-	| 'navigation-menu'
+	| 'menu'
 	| 'pagination'
 	| 'popover'
 	| 'progress'
@@ -63,10 +55,11 @@ export type Primitives =
 	| 'switch'
 	| 'table'
 	| 'tabs'
-	| 'textarea'
 	| 'toggle'
+	| 'toggle-group'
 	| 'tooltip'
 	| 'typography';
 
-// The root structure containing all components and subtypes
-export type ComponentApiData = Record<Primitives, PrimitiveSubTypes>;
+export type LibraryType = 'brain' | 'helm';
+
+export type ComponentApiData = Record<Primitives, Partial<Record<LibraryType, LibraryComponents>>>;

--- a/apps/app/src/app/pages/(components)/components.page.ts
+++ b/apps/app/src/app/pages/(components)/components.page.ts
@@ -11,7 +11,6 @@ import {
 	HlmAlertTitleDirective,
 } from '@spartan-ng/helm/alert';
 import { HlmIconDirective } from '@spartan-ng/helm/icon';
-import { ComponentApiData } from '../../core/models/ui-docs.model';
 import { ApiDocsService } from '../../core/services/api-docs.service';
 import { PageComponent } from '../../shared/layout/page.component';
 import { metaWith } from '../../shared/meta/meta.util';
@@ -61,6 +60,6 @@ export default class ComponentsPageComponent {
 	private readonly _apiDocsService = inject(ApiDocsService);
 
 	constructor() {
-		this._apiDocsService.setApiDocs(this._apiData() as ComponentApiData);
+		this._apiDocsService.setApiDocs(this._apiData());
 	}
 }

--- a/apps/app/src/app/pages/(components)/components.server.ts
+++ b/apps/app/src/app/pages/(components)/components.server.ts
@@ -1,5 +1,5 @@
-import { PageServerLoad } from '@analogjs/router';
+import docsData from '../../../public/data/ui-api.json';
 
-export const load = async ({ fetch }: PageServerLoad) => {
-	return await fetch('/api/primitive-api');
+export const load = async () => {
+	return docsData;
 };

--- a/apps/app/src/app/shared/layout/ui-docs-section/ui-docs-section.component.ts
+++ b/apps/app/src/app/shared/layout/ui-docs-section/ui-docs-section.component.ts
@@ -1,7 +1,7 @@
 import { Component, computed, inject, input } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
-import { SubTypeRecord } from '@spartan-ng/app/app/core/models/ui-docs.model';
+import { LibraryType } from '@spartan-ng/app/app/core/models/ui-docs.model';
 import { hlmCode, hlmH4 } from '@spartan-ng/helm/typography';
 import { map } from 'rxjs/operators';
 import { ApiDocsService } from '../../../core/services/api-docs.service';
@@ -69,11 +69,11 @@ import { UIApiDocsTableComponent } from '../ui-api-docs-table/ui-api-docs-table.
 export class UIApiDocsComponent {
 	private readonly _apiDocsService = inject(ApiDocsService);
 	private readonly _route = inject(ActivatedRoute);
-	protected primitive = toSignal(this._route.data.pipe(map((data) => data?.['api'])));
+	protected readonly primitive = toSignal(this._route.data.pipe(map((data) => data?.['api'])));
 
-	public docType = input.required<SubTypeRecord>();
+	public readonly docType = input.required<LibraryType>();
 
-	protected componentDocs = computed(() => this._apiDocsService.getComponentDocs(this.primitive())());
-	protected componentItems = computed(() => this.componentDocs()?.[this.docType()] ?? {});
-	protected componentEntries = computed(() => Object.keys(this.componentItems() ?? []));
+	protected readonly componentDocs = computed(() => this._apiDocsService.getComponentDocs(this.primitive())());
+	protected readonly componentItems = computed(() => this.componentDocs()?.[this.docType()] ?? {});
+	protected readonly componentEntries = computed(() => Object.keys(this.componentItems() ?? []));
 }

--- a/apps/app/src/server/routes/primitive-api.get.ts
+++ b/apps/app/src/server/routes/primitive-api.get.ts
@@ -1,6 +1,0 @@
-import { defineEventHandler } from 'h3';
-import docsData from '../../public/data/ui-api.json';
-
-export default defineEventHandler(() => {
-	return docsData;
-});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

additional fetch call to server endpoint was made
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

no additional call

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
