### PR TITLE
Feat/tabs disabled support

### DIFF
--- a/apps/ui-storybook/stories/tabs.stories.ts
+++ b/apps/ui-storybook/stories/tabs.stories.ts
@@ -6,7 +6,8 @@ import { HlmLabelDirective } from '@spartan-ng/helm/label';
 import { HlmTabsImports } from '@spartan-ng/helm/tabs';
 import { type Meta, type StoryObj, argsToTemplate, moduleMetadata } from '@storybook/angular';
 
-const meta: Meta<BrnTabsDirective> = {
+const meta: Meta<BrnTabsDirective & { disabled: boolean }
+> = {
 	title: 'Tabs',
 	component: BrnTabsDirective,
 	tags: ['autodocs'],
@@ -15,6 +16,11 @@ const meta: Meta<BrnTabsDirective> = {
 			options: ['manual', 'automatic'],
 			control: {
 				type: 'select',
+			},
+		},
+		disabled: {
+			control: {
+				type: 'boolean',
 			},
 		},
 	},
@@ -33,15 +39,15 @@ const meta: Meta<BrnTabsDirective> = {
 };
 
 export default meta;
-type Story = StoryObj<BrnTabsDirective>;
+type Story = StoryObj<BrnTabsDirective & { disabled: boolean }>;
 export const Default: Story = {
 	render: ({ ...args }) => ({
 		props: args,
 		template: /* HTML */ `
 			<hlm-tabs tab="account" ${argsToTemplate(args)} class="mx-auto block max-w-3xl">
 				<hlm-tabs-list class="grid w-full grid-cols-2" aria-label="tabs example">
-					<button hlmTabsTrigger="account">Account</button>
-					<button hlmTabsTrigger="password">Password</button>
+					<button [disabled]="disabled" hlmTabsTrigger="account">Account</button>
+					<button [disabled]="disabled" hlmTabsTrigger="password">Password</button>
 				</hlm-tabs-list>
 				<div hlmTabsContent="account">
 					<section hlmCard>
@@ -91,14 +97,14 @@ export const Default: Story = {
 };
 
 export const Vertical: Story = {
-	render: ({ activationMode }) => ({
-		props: { activationMode },
+	render: ({ activationMode, disabled }) => ({
+		props: { activationMode, disabled },
 		template: /* HTML */ `
 			<hlm-tabs tab="account" class="mx-auto flex max-w-3xl flex-row space-x-2" orientation="vertical">
 				<hlm-tabs-list orientation="vertical" aria-label="tabs example">
-					<button class="w-full" hlmTabsTrigger="account">Account</button>
-					<button class="w-full" hlmTabsTrigger="password">Password</button>
-					<button class="w-full" hlmTabsTrigger="danger">Danger Zone</button>
+					<button [disabled]="disabled" class="w-full" hlmTabsTrigger="account">Account</button>
+					<button [disabled]="disabled" class="w-full" hlmTabsTrigger="password">Password</button>
+					<button [disabled]="disabled" class="w-full" hlmTabsTrigger="danger">Danger Zone</button>
 				</hlm-tabs-list>
 				<div hlmTabsContent="account">
 					<section hlmCard>
@@ -159,30 +165,31 @@ export const Vertical: Story = {
 };
 
 export const Paginated: Story = {
-	render: () => ({
+	render: ({ disabled }) => ({
+		props: { disabled },
 		template: /* HTML */ `
 			<hlm-tabs tab="1" class="mx-auto block max-w-3xl">
 				<hlm-paginated-tabs-list>
-					<button hlmTabsTrigger="1">Tab 1</button>
-					<button hlmTabsTrigger="2">Tab 2</button>
-					<button hlmTabsTrigger="3">Tab 3</button>
-					<button hlmTabsTrigger="4">Tab 4</button>
-					<button hlmTabsTrigger="5">Tab 5</button>
-					<button hlmTabsTrigger="6">Tab 6</button>
-					<button hlmTabsTrigger="7">Tab 7</button>
-					<button hlmTabsTrigger="8">Tab 8</button>
-					<button hlmTabsTrigger="9">Tab 9</button>
-					<button hlmTabsTrigger="10">Tab 10</button>
-					<button hlmTabsTrigger="11">Tab 11</button>
-					<button hlmTabsTrigger="12">Tab 12</button>
-					<button hlmTabsTrigger="13">Tab 13</button>
-					<button hlmTabsTrigger="14">Tab 14</button>
-					<button hlmTabsTrigger="15">Tab 15</button>
-					<button hlmTabsTrigger="16">Tab 16</button>
-					<button hlmTabsTrigger="17">Tab 17</button>
-					<button hlmTabsTrigger="18">Tab 18</button>
-					<button hlmTabsTrigger="19">Tab 19</button>
-					<button hlmTabsTrigger="20">Tab 20</button>
+					<button [disabled]="disabled" hlmTabsTrigger="1">Tab 1</button>
+					<button [disabled]="disabled" hlmTabsTrigger="2">Tab 2</button>
+					<button [disabled]="disabled" hlmTabsTrigger="3">Tab 3</button>
+					<button [disabled]="disabled" hlmTabsTrigger="4">Tab 4</button>
+					<button [disabled]="disabled" hlmTabsTrigger="5">Tab 5</button>
+					<button [disabled]="disabled" hlmTabsTrigger="6">Tab 6</button>
+					<button [disabled]="disabled" hlmTabsTrigger="7">Tab 7</button>
+					<button [disabled]="disabled" hlmTabsTrigger="8">Tab 8</button>
+					<button [disabled]="disabled" hlmTabsTrigger="9">Tab 9</button>
+					<button [disabled]="disabled" hlmTabsTrigger="10">Tab 10</button>
+					<button [disabled]="disabled" hlmTabsTrigger="11">Tab 11</button>
+					<button [disabled]="disabled" hlmTabsTrigger="12">Tab 12</button>
+					<button [disabled]="disabled" hlmTabsTrigger="13">Tab 13</button>
+					<button [disabled]="disabled" hlmTabsTrigger="14">Tab 14</button>
+					<button [disabled]="disabled" hlmTabsTrigger="15">Tab 15</button>
+					<button [disabled]="disabled" hlmTabsTrigger="16">Tab 16</button>
+					<button [disabled]="disabled" hlmTabsTrigger="17">Tab 17</button>
+					<button [disabled]="disabled" hlmTabsTrigger="18">Tab 18</button>
+					<button [disabled]="disabled" hlmTabsTrigger="19">Tab 19</button>
+					<button [disabled]="disabled" hlmTabsTrigger="20">Tab 20</button>
 				</hlm-paginated-tabs-list>
 				<div hlmTabsContent="1">Tab 1</div>
 				<div hlmTabsContent="2">Tab 2</div>
@@ -215,8 +222,8 @@ export const BrnOnly: Story = {
 		template: /* HTML */ `
 			<div brnTabs="account" [activationMode]="activationMode" class="mx-auto block max-w-3xl">
 				<div brnTabsList class="grid w-full grid-cols-2" [attr.aria-label]="'tabs example'">
-					<button brnTabsTrigger="account">Account</button>
-					<button brnTabsTrigger="password">Password</button>
+					<button [disabled]="disabled" brnTabsTrigger="account">Account</button>
+					<button [disabled]="disabled" brnTabsTrigger="password">Password</button>
 				</div>
 				<div brnTabsContent="account">Account content</div>
 				<div brnTabsContent="password">Password content</div>
@@ -224,3 +231,18 @@ export const BrnOnly: Story = {
 		`,
 	}),
 };
+
+export const Disabled: Story = {
+	render: ({ disabled }) => ({
+		props: { disabled },
+		template: /* HTML */ `
+			<hlm-tabs tab="account" class="mx-auto block max-w-3xl">
+				<hlm-tabs-list class="grid w-full grid-cols-2" aria-label="tabs example">
+					<button [disabled]="disabled" hlmTabsTrigger="account">Account</button>
+					<button [disabled]="disabled" hlmTabsTrigger="password">Password</button>
+				</hlm-tabs-list>
+			</hlm-tabs>
+		`,
+	}),
+};
+

--- a/libs/helm/tabs/src/lib/hlm-tabs-trigger.directive.ts
+++ b/libs/helm/tabs/src/lib/hlm-tabs-trigger.directive.ts
@@ -8,7 +8,7 @@ import type { ClassValue } from 'clsx';
 	hostDirectives: [{ directive: BrnTabsTriggerDirective, inputs: ['brnTabsTrigger: hlmTabsTrigger', 'disabled'] }],
 	host: {
 		'[class]': '_computedClass()',
-		'[attr.disabled]': 'disabled()',
+		'[disabled]': 'disabled()',
 		'[attr.data-disabled]': 'disabled()',
 
 	},

--- a/libs/helm/tabs/src/lib/hlm-tabs-trigger.directive.ts
+++ b/libs/helm/tabs/src/lib/hlm-tabs-trigger.directive.ts
@@ -8,10 +8,14 @@ import type { ClassValue } from 'clsx';
 	hostDirectives: [{ directive: BrnTabsTriggerDirective, inputs: ['brnTabsTrigger: hlmTabsTrigger', 'disabled'] }],
 	host: {
 		'[class]': '_computedClass()',
+		'[attr.disabled]': 'disabled()',
+		'[attr.data-disabled]': 'disabled()',
+
 	},
 })
 export class HlmTabsTriggerDirective {
 	public readonly triggerFor = input.required<string>({ alias: 'hlmTabsTrigger' });
+	public readonly disabled = input<boolean>(false);
 
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() =>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [x] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `HlmTabsTriggerDirective` has a `disabled` input property but it wasn't properly preventing tab activation when disabled. Disabled tabs could still be clicked and activated, and the disabled state wasn't properly reflected in the host bindings for proper styling and accessibility.

Closes #

## What is the new behavior?

Enhanced the `HlmTabsTriggerDirective` to properly handle disabled state:

- Added `[disabled]` host binding to set the native disabled attribute on the button element
- Added `[attr.data-disabled]` host binding for consistent styling hooks
- Updated Storybook stories to showcase the disabled functionality with interactive controls

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This enhancement improves accessibility and user experience by ensuring disabled tab triggers behave correctly - they cannot be activated, have proper ARIA attributes, and provide the necessary styling hooks for visual disabled states. The Storybook updates demonstrate this functionality to help developers understand how to use the disabled feature.