### PR TITLE
fix(tabs): vertical styles and format tabs snippet

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(tabs)/tabs.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(tabs)/tabs.page.ts
@@ -3,6 +3,9 @@ import { Component } from '@angular/core';
 import { HlmAlertDescriptionDirective, HlmAlertDirective } from '@spartan-ng/helm/alert';
 import { hlmCode, hlmH4 } from '@spartan-ng/helm/typography';
 
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideCircleAlert } from '@ng-icons/lucide';
+import { HlmIconDirective } from '@spartan-ng/helm/icon';
 import { CodePreviewDirective } from '../../../../shared/code/code-preview.directive';
 import { CodeComponent } from '../../../../shared/code/code.component';
 import { MainSectionDirective } from '../../../../shared/layout/main-section.directive';
@@ -47,7 +50,10 @@ export const routeMeta: RouteMeta = {
 		TabsPaginatedPreviewComponent,
 		HlmAlertDescriptionDirective,
 		HlmAlertDirective,
+		NgIcon,
+		HlmIconDirective,
 	],
+	providers: [provideIcons({ lucideCircleAlert })],
 	template: `
 		<section spartanMainSection>
 			<spartan-section-intro
@@ -102,17 +108,20 @@ export const routeMeta: RouteMeta = {
 			</p>
 
 			<div hlmAlert class="my-2">
-				<p hlmAlertDesc>
-					<strong>Padding</strong>
-					styles, applied to the tab list (
-					<code class="${hlmCode}">listVariants</code>
-					), are
-					<strong>not</strong>
-					taken into account during
-					<strong>keyboard scrolling</strong>
-					. This affects the active tab's scrolling position and next/previous button remain enabled even when the
-					active tab is at the start or end of the tab list.
-				</p>
+				<ng-icon hlm hlmAlertIcon name="lucideCircleAlert" />
+				<div hlmAlertDesc>
+					<p>
+						<strong>Padding</strong>
+						styles, applied to the tab list (
+						<code class="${hlmCode}">listVariants</code>
+						), are
+						<strong>not</strong>
+						taken into account during
+						<strong>keyboard scrolling</strong>
+						. This affects the active tab's scrolling position and next/previous button remain enabled even when the
+						active tab is at the start or end of the tab list.
+					</p>
+				</div>
 			</div>
 
 			<spartan-tabs firstTab="Preview" secondTab="Code">

--- a/apps/app/src/app/pages/(components)/components/(tabs)/tabs.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(tabs)/tabs.preview.ts
@@ -100,15 +100,11 @@ import {
 `;
 export const defaultSkeleton = `
 <hlm-tabs tab="account" class="w-full">
-	<hlm-tabs-list class="grid w-full grid-cols-2" aria-label="tabs example">
-		<button hlmTabsTrigger="account">Account</button>
-		<button hlmTabsTrigger="password">Password</button>
-	</hlm-tabs-list>
-	<div hlmTabsContent="account">
-    	Make your account here
-  	</div>
-  	<div hlmTabsContent="password">
-    	Change your password here
-  	</div>
+  <hlm-tabs-list class="grid w-full grid-cols-2" aria-label="tabs example">
+    <button hlmTabsTrigger="account">Account</button>
+    <button hlmTabsTrigger="password">Password</button>
+  </hlm-tabs-list>
+  <div hlmTabsContent="account">Make your account here</div>
+  <div hlmTabsContent="password">Change your password here</div>
 </hlm-tabs>
 `;

--- a/libs/helm/tabs/src/lib/hlm-tabs-list.component.ts
+++ b/libs/helm/tabs/src/lib/hlm-tabs-list.component.ts
@@ -5,7 +5,7 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
 
 export const listVariants = cva(
-	'inline-flex items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+	'inline-flex h-9 w-fit items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground',
 	{
 		variants: {
 			orientation: {
@@ -32,9 +32,6 @@ type ListVariants = VariantProps<typeof listVariants>;
 export class HlmTabsListComponent {
 	public readonly orientation = input<ListVariants['orientation']>('horizontal');
 
-	public readonly userClass = input<ClassValue>(
-		'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
-		{ alias: 'class' },
-	);
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() => hlm(listVariants({ orientation: this.orientation() }), this.userClass()));
 }

--- a/libs/helm/tabs/src/lib/hlm-tabs.component.ts
+++ b/libs/helm/tabs/src/lib/hlm-tabs.component.ts
@@ -21,9 +21,6 @@ import { ClassValue } from 'clsx';
 export class HlmTabsComponent {
 	public readonly tab = input.required<string>();
 
-	public readonly userClass = input<ClassValue>(
-		'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
-		{ alias: 'class' },
-	);
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() => hlm('flex flex-col gap-2', this.userClass()));
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [x] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Styles for vertical orientation was not correctly applied. It should be `h-fit` but it is overridden by `h-9` from the `userClass`.

<img width="854" height="480" alt="CleanShot 2025-07-10 at 14 55 24" src="https://github.com/user-attachments/assets/d2da93d3-ec72-4735-9a52-1c872fbfb408" />

## What is the new behavior?

Update styles in `listVariants` and remove unnecessary `userClass` in `hlm-tabs` and `hlm-tabs-list`.

<img width="782" height="480" alt="CleanShot 2025-07-10 at 14 55 08" src="https://github.com/user-attachments/assets/39daf2c6-5c39-414c-8c5e-e0b7546f111e" />

Format usage code and update fix formatting issue with `hlmAlertDesc`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
