### PR TITLE
fix(calendar): hover active styles in light mode

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(calendar)/calendar.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(calendar)/calendar.preview.ts
@@ -29,12 +29,5 @@ import {
 `;
 
 export const defaultSkeleton = `
-<hlm-calendar
-	[(date)]="selectedDate"
-	[min]="minDate"
-	[max]="maxDate"
-	[disabled]="false"
-	[dateDisabled]="(date) => false"
-	[weekStartsOn]="0"
-/>
+<hlm-calendar [(date)]="selectedDate" [min]="minDate" [max]="maxDate" />
 `;

--- a/libs/helm/calendar/src/lib/hlm-calendar.component.ts
+++ b/libs/helm/calendar/src/lib/hlm-calendar.component.ts
@@ -170,7 +170,7 @@ export class HlmCalendarComponent<T> {
 		'size-8 p-0 font-normal aria-selected:opacity-100',
 		'data-[outside]:text-muted-foreground data-[outside]:opacity-50 data-[outside]:aria-selected:bg-accent/50 data-[outside]:aria-selected:text-muted-foreground data-[outside]:aria-selected:opacity-30',
 		'data-[today]:bg-accent data-[today]:text-accent-foreground',
-		'data-[selected]:bg-primary data-[selected]:text-primary-foreground data-[selected]:hover:bg-primary data-[selected]:hover:text-accent-foreground data-[selected]:focus:bg-primary data-[selected]:focus:text-primary-foreground',
+		'data-[selected]:bg-primary data-[selected]:text-primary-foreground data-[selected]:hover:bg-primary dark:hover:text-accent-foreground data-[selected]:focus:bg-primary data-[selected]:focus:text-primary-foreground',
 		'data-[disabled]:text-muted-foreground data-[disabled]:opacity-50',
 	);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [x] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Hover active date and the text is not readable in light mode

<img width="276" height="307" alt="CleanShot 2025-07-10 at 15 33 45" src="https://github.com/user-attachments/assets/1401bad7-29d7-4061-a310-5e5d6b12b197" />

## What is the new behavior?

Hover active date and the text is readable in light mode

<img width="272" height="307" alt="CleanShot 2025-07-10 at 15 35 14" src="https://github.com/user-attachments/assets/749b3b88-ebc3-4590-ab7a-443c29150800" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
