### PR TITLE
Dialog trigger should update aria-expanded to reflect open state

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/dialog/dialog.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/dialog/dialog.cy.ts
@@ -14,9 +14,13 @@ describe('dialog--default', () => {
 			});
 
 			cy.findByText(/edit profile/i).should('have.attr', 'aria-haspopup', 'dialog');
+			cy.findByText(/edit profile/i).should('have.attr', 'aria-expanded', 'false');
 			cy.findByText(/edit profile/i).click();
 
 			cy.findAllByText(/edit profile/i).should('have.length', 2);
+			cy.findAllByText(/edit profile/i)
+				.first()
+				.should('have.attr', 'aria-expanded', 'true');
 			cy.findByRole('dialog');
 			cy.findByRole('dialog').should('have.attr', 'aria-labelledby', 'brn-dialog-title-0');
 			cy.findByRole('dialog').should('have.attr', 'aria-labelledby', 'brn-dialog-title-0');

--- a/libs/brain/dialog/src/lib/brn-dialog-trigger.directive.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog-trigger.directive.ts
@@ -1,4 +1,4 @@
-import { computed, Directive, effect, inject, input, type Signal, signal } from '@angular/core';
+import { computed, Directive, effect, inject, input, signal } from '@angular/core';
 import { BrnDialogRef } from './brn-dialog-ref';
 import type { BrnDialogState } from './brn-dialog-state';
 import { BrnDialogComponent } from './brn-dialog.component';
@@ -23,7 +23,26 @@ export class BrnDialogTriggerDirective {
 
 	public readonly id = input(`brn-dialog-trigger-${idSequence++}`);
 
-	public readonly state: Signal<BrnDialogState> = this._brnDialogRef?.state ?? signal('closed');
+	public readonly state = computed<BrnDialogState>(() => {
+		// If we have a dialog component from the input, use its state (the highest priority)
+		const dialogFromInput = this.brnDialogTriggerForState();
+		if (dialogFromInput) {
+			return dialogFromInput.stateComputed();
+		}
+
+		// If we have a dialog component, use its state
+		if (this._brnDialog) {
+			return this._brnDialog.stateComputed();
+		}
+
+		// If we have a dialog ref, use its state
+		if (this._brnDialogRef) {
+			return this._brnDialogRef.state();
+		}
+
+		return 'closed';
+	});
+
 	public readonly dialogId = `brn-dialog-${this._brnDialogRef?.dialogId ?? idSequence++}`;
 
 	public readonly brnDialogTriggerFor = input<BrnDialogComponent | undefined>(undefined, {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [x] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

When a dialog (or any primitive using brnDialogTrigger, such as popover, alert-dialog, or combobox) is toggled open or closed, the trigger element's aria-expanded attribute incorrectly remains false, causing accessibility inconsistencies.

Closes #739 

## What is the new behavior?

The aria-expanded attribute on the trigger element now reflects the actual open/closed state of the dialog. The BrnDialogTriggerDirective's state property has been converted to a computed signal that dynamically tracks dialog state from the correct source (input, injected component, or ref). This also improves support for nested dialogs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The change also includes a Cypress test asserting the correct state of aria-expanded before and after toggling a dialog.