### PR TITLE
fix(dialog): fixed TS2698 in HlmDialogService

### DIFF
--- a/libs/helm/dialog/src/lib/hlm-dialog.service.ts
+++ b/libs/helm/dialog/src/lib/hlm-dialog.service.ts
@@ -26,7 +26,7 @@ export class HlmDialogService {
 
 			...(options ?? {}),
 			backdropClass: cssClassesToArray(`${hlmDialogOverlayClass} ${options?.backdropClass ?? ''}`),
-			context: { ...(options?.context ?? {}), $component: component, $dynamicComponentClass: options?.contentClass },
+			context: { ...(options?.context && typeof options.context === 'object' ? options.context : {}), $component: component, $dynamicComponentClass: options?.contentClass },
 		};
 
 		return this._brnDialogService.open(HlmDialogContentComponent, undefined, mergedOptions.context, mergedOptions);


### PR DESCRIPTION
Ensures options.context is an object before spreading its properties. This prevents potential type errors and ensures that the dialog service correctly handles context objects when opening dialogs.

fixes  spartan-ng/spartan#749


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [x] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The spread operator causes TS2698 when options.context is of type `unknown`. 

Closes #749 

## What is the new behavior?

There is now a type check `typeof options.context === 'object'` before the spread operator to prevent error. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
