### PR TITLE
docs: fix alert usage and polish alert preview/imports

### DIFF
--- a/apps/app/src/app/pages/(components)/components.page.ts
+++ b/apps/app/src/app/pages/(components)/components.page.ts
@@ -46,11 +46,13 @@ export const routeMeta: RouteMeta = {
 		>
 			<ng-icon hlm hlmAlertIcon name="lucideRocket" class="!text-primary-foreground" />
 			<h2 hlmAlertTitle>Spartans get ready! v1 is coming!</h2>
-			<p hlmAlertDesc>
-				We are very close to our first stable release. Expect more announcements in the coming weeks. v1 was made
-				possible by
-				<a class="underline" target="_blank" href="https://zerops.io">our partner Zerops.</a>
-			</p>
+			<div hlmAlertDescription>
+				<p>
+					We are very close to our first stable release. Expect more announcements in the coming weeks. v1 was made
+					possible by
+					<a class="underline" target="_blank" href="https://zerops.io">our partner Zerops.</a>
+				</p>
+			</div>
 		</div>
 		<spartan-page />
 	`,

--- a/apps/app/src/app/pages/(components)/components/(alert)/alert--destructive.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(alert)/alert--destructive.example.ts
@@ -1,12 +1,24 @@
 import { Component } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideTriangleAlert } from '@ng-icons/lucide';
-import { HlmAlertImports } from '@spartan-ng/helm/alert';
+import {
+	HlmAlertDescriptionDirective,
+	HlmAlertDirective,
+	HlmAlertIconDirective,
+	HlmAlertTitleDirective,
+} from '@spartan-ng/helm/alert';
 import { HlmIconDirective } from '@spartan-ng/helm/icon';
 
 @Component({
 	selector: 'spartan-alert-destructive',
-	imports: [HlmAlertImports, NgIcon, HlmIconDirective],
+	imports: [
+		HlmAlertDescriptionDirective,
+		HlmAlertDirective,
+		HlmAlertIconDirective,
+		HlmAlertTitleDirective,
+		NgIcon,
+		HlmIconDirective,
+	],
 	providers: [provideIcons({ lucideTriangleAlert })],
 	template: `
 		<div hlmAlert variant="destructive">

--- a/apps/app/src/app/pages/(components)/components/(alert)/alert.generated.ts
+++ b/apps/app/src/app/pages/(components)/components/(alert)/alert.generated.ts
@@ -33,12 +33,24 @@ export const defaultCode = `
 import { Component } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideCircleCheck } from '@ng-icons/lucide';
-import { HlmAlertImports } from '@spartan-ng/helm/alert';
+import {
+	HlmAlertDescriptionDirective,
+	HlmAlertDirective,
+	HlmAlertIconDirective,
+	HlmAlertTitleDirective,
+} from '@spartan-ng/helm/alert';
 import { HlmIconDirective } from '@spartan-ng/helm/icon';
 
 @Component({
 	selector: 'spartan-alert-preview',
-	imports: [HlmAlertImports, NgIcon, HlmIconDirective],
+	imports: [
+		HlmAlertDescriptionDirective,
+		HlmAlertDirective,
+		HlmAlertIconDirective,
+		HlmAlertTitleDirective,
+		NgIcon,
+		HlmIconDirective,
+	],
 	providers: [provideIcons({ lucideCircleCheck })],
 	template: \`
 		<div hlmAlert>

--- a/apps/app/src/app/pages/(components)/components/(alert)/alert.generated.ts
+++ b/apps/app/src/app/pages/(components)/components/(alert)/alert.generated.ts
@@ -11,12 +11,24 @@ export const alertDestructiveCode = `
 import { Component } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideTriangleAlert } from '@ng-icons/lucide';
-import { HlmAlertImports } from '@spartan-ng/helm/alert';
+import {
+	HlmAlertDescriptionDirective,
+	HlmAlertDirective,
+	HlmAlertIconDirective,
+	HlmAlertTitleDirective,
+} from '@spartan-ng/helm/alert';
 import { HlmIconDirective } from '@spartan-ng/helm/icon';
 
 @Component({
 	selector: 'spartan-alert-destructive',
-	imports: [HlmAlertImports, NgIcon, HlmIconDirective],
+	imports: [
+		HlmAlertDescriptionDirective,
+		HlmAlertDirective,
+		HlmAlertIconDirective,
+		HlmAlertTitleDirective,
+		NgIcon,
+		HlmIconDirective,
+	],
 	providers: [provideIcons({ lucideTriangleAlert })],
 	template: \`
 		<div hlmAlert variant="destructive">

--- a/apps/app/src/app/pages/(components)/components/(alert)/alert.generated.ts
+++ b/apps/app/src/app/pages/(components)/components/(alert)/alert.generated.ts
@@ -44,7 +44,7 @@ export class AlertDestructiveComponent {}
 export const defaultCode = `
 import { Component } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { lucideCircleCheck } from '@ng-icons/lucide';
+import { lucideCircleAlert, lucideCircleCheck, lucidePopcorn } from '@ng-icons/lucide';
 import {
 	HlmAlertDescriptionDirective,
 	HlmAlertDirective,
@@ -63,12 +63,30 @@ import { HlmIconDirective } from '@spartan-ng/helm/icon';
 		NgIcon,
 		HlmIconDirective,
 	],
-	providers: [provideIcons({ lucideCircleCheck })],
+	providers: [provideIcons({ lucideCircleCheck, lucidePopcorn, lucideCircleAlert })],
 	template: \`
-		<div hlmAlert>
-			<ng-icon hlm hlmAlertIcon name="lucideCircleCheck" />
-			<h4 hlmAlertTitle>Success! Your changes have been saved</h4>
-			<p hlmAlertDescription>This is an alert with icon, title and description.</p>
+		<div class="grid w-full max-w-xl items-start gap-4">
+			<div hlmAlert>
+				<ng-icon hlm hlmAlertIcon name="lucideCircleCheck" />
+				<h4 hlmAlertTitle>Success! Your changes have been saved</h4>
+				<p hlmAlertDescription>This is an alert with icon, title and description.</p>
+			</div>
+			<div hlmAlert>
+				<ng-icon hlm hlmAlertIcon name="lucidePopcorn" />
+				<h4 hlmAlertTitle>This Alert has a title and an icon. No description.</h4>
+			</div>
+			<div hlmAlert variant="destructive">
+				<ng-icon hlm hlmAlertIcon name="lucideCircleAlert" />
+				<h4 hlmAlertTitle>Unable to process your payment.</h4>
+				<div hlmAlertDescription>
+					<p>Please verify your billing information and try again.</p>
+					<ul class="list-inside list-disc text-sm">
+						<li>Check your card details</li>
+						<li>Ensure sufficient funds</li>
+						<li>Verify billing address</li>
+					</ul>
+				</div>
+			</div>
 		</div>
 	\`,
 })

--- a/apps/app/src/app/pages/(components)/components/(alert)/alert.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(alert)/alert.preview.ts
@@ -1,12 +1,24 @@
 import { Component } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideCircleCheck } from '@ng-icons/lucide';
-import { HlmAlertImports } from '@spartan-ng/helm/alert';
+import {
+	HlmAlertDescriptionDirective,
+	HlmAlertDirective,
+	HlmAlertIconDirective,
+	HlmAlertTitleDirective,
+} from '@spartan-ng/helm/alert';
 import { HlmIconDirective } from '@spartan-ng/helm/icon';
 
 @Component({
 	selector: 'spartan-alert-preview',
-	imports: [HlmAlertImports, NgIcon, HlmIconDirective],
+	imports: [
+		HlmAlertDescriptionDirective,
+		HlmAlertDirective,
+		HlmAlertIconDirective,
+		HlmAlertTitleDirective,
+		NgIcon,
+		HlmIconDirective,
+	],
 	providers: [provideIcons({ lucideCircleCheck })],
 	template: `
 		<div hlmAlert>
@@ -27,11 +39,10 @@ import {
 } from '@spartan-ng/helm/alert';
 `;
 
-export const defaultSkeleton = `<div hlmAlert>
-	<ng-icon hlm hlmAlertIcon name="lucideBox" />
-	<h4 hlmAlertTitle>Introducing spartan/ui!</h4>
-	<p hlmAlertDesc>
-		spartan/ui is made up of unstyled UI providers, the spartan/ui/brain.<br />
-		On top we add spartan/ui/helm(et) with shadcn-like styles.
-	</p>
-</div>`;
+export const defaultSkeleton = `
+<div hlmAlert>
+  <ng-icon hlm hlmAlertIcon name="lucideCircleCheck" />
+  <h4 hlmAlertTitle>Success! Your changes have been saved</h4>
+  <div hlmAlertDescription>This is an alert with icon, title and description.</div>
+</div>
+`;

--- a/apps/app/src/app/pages/(components)/components/(alert)/alert.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(alert)/alert.preview.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { lucideCircleCheck } from '@ng-icons/lucide';
+import { lucideCircleAlert, lucideCircleCheck, lucidePopcorn } from '@ng-icons/lucide';
 import {
 	HlmAlertDescriptionDirective,
 	HlmAlertDirective,
@@ -19,12 +19,30 @@ import { HlmIconDirective } from '@spartan-ng/helm/icon';
 		NgIcon,
 		HlmIconDirective,
 	],
-	providers: [provideIcons({ lucideCircleCheck })],
+	providers: [provideIcons({ lucideCircleCheck, lucidePopcorn, lucideCircleAlert })],
 	template: `
-		<div hlmAlert>
-			<ng-icon hlm hlmAlertIcon name="lucideCircleCheck" />
-			<h4 hlmAlertTitle>Success! Your changes have been saved</h4>
-			<p hlmAlertDescription>This is an alert with icon, title and description.</p>
+		<div class="grid w-full max-w-xl items-start gap-4">
+			<div hlmAlert>
+				<ng-icon hlm hlmAlertIcon name="lucideCircleCheck" />
+				<h4 hlmAlertTitle>Success! Your changes have been saved</h4>
+				<p hlmAlertDescription>This is an alert with icon, title and description.</p>
+			</div>
+			<div hlmAlert>
+				<ng-icon hlm hlmAlertIcon name="lucidePopcorn" />
+				<h4 hlmAlertTitle>This Alert has a title and an icon. No description.</h4>
+			</div>
+			<div hlmAlert variant="destructive">
+				<ng-icon hlm hlmAlertIcon name="lucideCircleAlert" />
+				<h4 hlmAlertTitle>Unable to process your payment.</h4>
+				<div hlmAlertDescription>
+					<p>Please verify your billing information and try again.</p>
+					<ul class="list-inside list-disc text-sm">
+						<li>Check your card details</li>
+						<li>Ensure sufficient funds</li>
+						<li>Verify billing address</li>
+					</ul>
+				</div>
+			</div>
 		</div>
 	`,
 })
@@ -40,7 +58,7 @@ import {
 `;
 
 export const defaultSkeleton = `
-<div hlmAlert>
+<div hlmAlert variant="default | destructive">
   <ng-icon hlm hlmAlertIcon name="lucideCircleCheck" />
   <h4 hlmAlertTitle>Success! Your changes have been saved</h4>
   <div hlmAlertDescription>This is an alert with icon, title and description.</div>

--- a/apps/app/src/app/pages/(components)/components/(tabs)/tabs.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(tabs)/tabs.page.ts
@@ -109,7 +109,7 @@ export const routeMeta: RouteMeta = {
 
 			<div hlmAlert class="my-2">
 				<ng-icon hlm hlmAlertIcon name="lucideCircleAlert" />
-				<div hlmAlertDesc>
+				<div hlmAlertDescription>
 					<p>
 						<strong>Padding</strong>
 						styles, applied to the tab list (

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/theming.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/theming.page.ts
@@ -8,7 +8,7 @@ import { PageNavComponent } from '@spartan-ng/app/app/shared/layout/page-nav/pag
 import { SectionIntroComponent } from '@spartan-ng/app/app/shared/layout/section-intro.component';
 import { SectionSubHeadingComponent } from '@spartan-ng/app/app/shared/layout/section-sub-heading.component';
 import { metaWith } from '@spartan-ng/app/app/shared/meta/meta.util';
-import { HlmAlertDirective } from '@spartan-ng/helm/alert';
+import { HlmAlertDescriptionDirective, HlmAlertDirective } from '@spartan-ng/helm/alert';
 import { hlmCode, hlmH4, hlmP, hlmSmall } from '@spartan-ng/helm/typography';
 
 export const routeMeta: RouteMeta = {
@@ -28,6 +28,7 @@ export const routeMeta: RouteMeta = {
 		SectionSubHeadingComponent,
 		CodeComponent,
 		HlmAlertDirective,
+		HlmAlertDescriptionDirective,
 	],
 	template: `
 		<section spartanMainSection>
@@ -53,9 +54,13 @@ export const routeMeta: RouteMeta = {
 					variable is used for the text color.
 				</p>
 				<div class="mt-4" hlmAlert>
-					The
-					<code class="${hlmCode}">background</code>
-					suffix is omitted when the variable is used for the background color of the component.
+					<div hlmAlertDescription>
+						<p>
+							The
+							<code class="${hlmCode}">background</code>
+							suffix is omitted when the variable is used for the background color of the component.
+						</p>
+					</div>
 				</div>
 				<p class="${hlmP}">Given the following CSS variables:</p>
 				<spartan-code
@@ -78,18 +83,20 @@ export const routeMeta: RouteMeta = {
 				</p>
 				<spartan-code class="mt-4" code='<div class="bg-primary text-primary-foreground">Hello</div>' />
 				<div class="mt-4 text-sm" hlmAlert>
-					<p>
-						<span class="font-semibold">CSS variables must be defined without color space function.</span>
-						See the
-						<a
-							class="font-medium underline"
-							href="https://tailwindcss.com/docs/customizing-colors#using-css-variables"
-							target="_blank"
-						>
-							Tailwind CSS documentation
-						</a>
-						for more information.
-					</p>
+					<div hlmAlertDescription>
+						<p>
+							<span class="font-semibold">CSS variables must be defined without color space function.</span>
+							See the
+							<a
+								class="font-medium underline"
+								href="https://tailwindcss.com/docs/customizing-colors#using-css-variables"
+								target="_blank"
+							>
+								Tailwind CSS documentation
+							</a>
+							for more information.
+						</p>
+					</div>
 				</div>
 			</section>
 

--- a/apps/app/src/app/pages/(stack)/stack/installation.page.ts
+++ b/apps/app/src/app/pages/(stack)/stack/installation.page.ts
@@ -110,15 +110,17 @@ export const routeMeta: RouteMeta = {
 			<div class="mb-6 mt-4" hlmAlert>
 				<ng-icon hlm hlmAlertIcon name="lucideTriangleAlert" />
 				<h4 hlmAlertTitle>Dealing with postgres & CommonJs</h4>
-				<p hlmAlertDesc>
-					<code class="${hlmCode}">postgres</code>
-					is a CommonJs package, which directly exposes an augmented function. Therefore, we need to adjust our
-					<code class="${hlmCode}">[YOUR_APP_NAME]/tsconfig.json</code>
-					file to tell the TS compiler how to deal with it properly. Add the following line to
-					<code class="${hlmCode}">compilerOptions</code>
-					:
-				</p>
-				<spartan-code class="mt-3" language="sh" code='"allowSyntheticDefaultImports": true' />
+				<div hlmAlertDescription>
+					<p>
+						<code class="${hlmCode}">postgres</code>
+						is a CommonJs package, which directly exposes an augmented function. Therefore, we need to adjust our
+						<code class="${hlmCode}">[YOUR_APP_NAME]/tsconfig.json</code>
+						file to tell the TS compiler how to deal with it properly. Add the following line to
+						<code class="${hlmCode}">compilerOptions</code>
+						:
+					</p>
+					<spartan-code class="mt-3" language="sh" code='"allowSyntheticDefaultImports": true' />
+				</div>
 			</div>
 
 			<p class="${hlmP}">
@@ -253,14 +255,16 @@ export const noteRouter = router({
 					<div class="mt-4" hlmAlert>
 						<ng-icon hlm name="lucideTriangleAlert" hlmAlertIcon />
 						<p hlmAlertTitle>Make sure to add .env to your .gitignore file.</p>
-						<p hlmAlertDescription>
-							You do not want to accidentally commit your secrets to GitHub. To exclude the file from git add a new line
-							to the
-							<code class="${hlmCode}">.gitignore</code>
-							-file and add
-							<code class="${hlmCode}">.env</code>
-							on a new line.
-						</p>
+						<div hlmAlertDescription>
+							<p>
+								You do not want to accidentally commit your secrets to GitHub. To exclude the file from git add a new
+								line to the
+								<code class="${hlmCode}">.gitignore</code>
+								-file and add
+								<code class="${hlmCode}">.env</code>
+								on a new line.
+							</p>
+						</div>
 					</div>
 				</div>
 
@@ -306,7 +310,7 @@ git init"
 					<div class="mt-8" hlmAlert variant="destructive">
 						<ng-icon hlm hlmAlertIcon name="lucideTriangleAlert" />
 						<h4 hlmAlertTitle>Important: Make sure Docker is running</h4>
-						<p hlmAlertDesc>
+						<p hlmAlertDescription>
 							Make sure Docker is running and configured correctly! I had Docker already installed and running. However,
 							my setup is not compatible with the config Supabase expects by default.
 						</p>

--- a/apps/ui-storybook/stories/alert.stories.ts
+++ b/apps/ui-storybook/stories/alert.stories.ts
@@ -29,7 +29,7 @@ const meta: Meta<HlmAlertDirective> = {
      <div class='max-w-xl' hlmAlert ${argsToTemplate(args)}>
       <ng-icon hlm name='lucideInfo' hlmAlertIcon />
       <h4 hlmAlertTitle>Introducing SPARTAN helm & brain</h4>
-      <p hlmAlertDesc>
+      <p hlmAlertDescription>
         The components used on this page are also the intial building blocks of a new UI library. It is made up of
         headless UI providers, the brain components/directives, which add ARIA compliant markup and interactions. On top
         of the brain we add helm(et) directives, which add shadcn-like styles to
@@ -59,7 +59,7 @@ export const Destructive: Story = {
      <div hlmAlert class='max-w-xl' ${argsToTemplate(args)}>
       <ng-icon hlm name='lucideCircleAlert' hlmAlertIcon />
       <h4 hlmAlertTitle>Something went wrong...</h4>
-      <p hlmAlertDesc>
+      <p hlmAlertDescription>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam aperiam at autem culpa debitis eius eveniet exercitationem, facilis illo magni mollitia, necessitatibus nesciunt quam quos recusandae tempore ullam velit veniam!
       </p>
      </div>

--- a/libs/cli/src/generators/ui/libs/ui-alert-helm/files/lib/hlm-alert.directive.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-alert-helm/files/lib/hlm-alert.directive.ts.template
@@ -4,7 +4,7 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
 
 const alertVariants = cva(
-	'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>[hlmAlertIcon]]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>[hlmAlertIcon]]:gap-x-3 gap-y-0.5 items-start [&>[hlmAlertIcon]]:size-4 [&>[hlmAlertIcon]]:translate-y-0.5 [&>[hlmAlertIcon]]:text-current',
+	'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>[hlmAlertIcon]]:grid-cols-[calc(theme(spacing.1)*4)_1fr] grid-cols-[0_1fr] has-[>[hlmAlertIcon]]:gap-x-3 gap-y-0.5 items-start [&>[hlmAlertIcon]]:size-4 [&>[hlmAlertIcon]]:translate-y-0.5 [&>[hlmAlertIcon]]:text-current',
 	{
 		variants: {
 			variant: {

--- a/libs/helm/alert/src/lib/hlm-alert.directive.ts
+++ b/libs/helm/alert/src/lib/hlm-alert.directive.ts
@@ -4,7 +4,7 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
 
 const alertVariants = cva(
-	'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>[hlmAlertIcon]]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>[hlmAlertIcon]]:gap-x-3 gap-y-0.5 items-start [&>[hlmAlertIcon]]:size-4 [&>[hlmAlertIcon]]:translate-y-0.5 [&>[hlmAlertIcon]]:text-current',
+	'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>[hlmAlertIcon]]:grid-cols-[calc(theme(spacing.1)*4)_1fr] grid-cols-[0_1fr] has-[>[hlmAlertIcon]]:gap-x-3 gap-y-0.5 items-start [&>[hlmAlertIcon]]:size-4 [&>[hlmAlertIcon]]:translate-y-0.5 [&>[hlmAlertIcon]]:text-current',
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [x] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Alert usage needs to be updated for the new-york styles

<img width="882" height="369" alt="CleanShot 2025-07-14 at 17 50 40" src="https://github.com/user-attachments/assets/f255f150-ce9d-43ad-bee2-485ee2d4ddf5" />

## What is the new behavior?

<img width="675" height="82" alt="CleanShot 2025-07-14 at 17 51 33" src="https://github.com/user-attachments/assets/5942f078-ac90-4c00-8cf8-771e3204247a" />

Use `theme(spacing.1)` instead of `var(--spacing)` in `hlmAlert` styles. `var(--spacing)` is only supported in Tailwind v4.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
