### PR TITLE
fix(radio-group): id for container is set, disabled state is displayed

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/radio-group/radio-group.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/radio-group/radio-group.cy.ts
@@ -36,6 +36,9 @@ describe('radio-group', () => {
 			cy.findByTestId('currentVersion').should('have.text', '15.8.0');
 			//5
 			cy.findByText('v15.2.0').realClick();
+
+			cy.findByTestId('disabledLabel').should('have.css', 'cursor', 'not-allowed');
+
 			cy.findByLabelText('v15.2.0').should('not.be.checked');
 			cy.findByLabelText('v16.0.0').should('not.be.checked');
 			cy.findByLabelText('v15.8.0').should('be.checked');
@@ -91,6 +94,26 @@ describe('radio-group', () => {
 			cy.findByLabelText('v15.2.0').should('not.have.focus');
 			cy.findByLabelText('v16.1.4').should('have.focus');
 			cy.findByLabelText('v16.1.4').should('be.checked');
+		});
+		describe('labelFor', () => {
+			beforeEach(() => {
+				cy.visit('/iframe.html?id=radio-group--label-for');
+				cy.injectAxe();
+			});
+
+			it('should check the option when clicking the label', () => {
+				cy.get('#brn-label-0').realClick();
+				cy.get('#default-radio').realClick();
+				cy.findByLabelText('Default').should('be.checked');
+				cy.get('#brn-label-1').realClick();
+				cy.get('#comfortable-radio').realClick();
+				cy.findByLabelText('Comfortable').should('be.checked');
+				cy.get('#brn-label-2').realClick();
+				cy.get('#compact-radio').realClick();
+				cy.findByLabelText('Compact').should('be.checked');
+				cy.findByLabelText('Comfortable').should('not.be.checked');
+				cy.findByLabelText('Default').should('not.be.checked');
+			});
 		});
 	});
 });

--- a/apps/ui-storybook/stories/radio-group.stories.ts
+++ b/apps/ui-storybook/stories/radio-group.stories.ts
@@ -38,7 +38,7 @@ import { type Meta, type StoryObj, moduleMetadata } from '@storybook/angular';
 				</hlm-radio>
 				v15.8.0
 			</label>
-			<label class="flex items-center" hlmLabel>
+			<label class="flex items-center" hlmLabel data-testid="disabledLabel">
 				<hlm-radio disabled value="15.2.0">
 					<hlm-radio-indicator indicator />
 				</hlm-radio>
@@ -65,7 +65,15 @@ const meta: Meta<BrnRadioGroupDirective> = {
 	tags: ['autodocs'],
 	decorators: [
 		moduleMetadata({
-			imports: [RadioGroupExampleComponent],
+			imports: [
+				RadioGroupExampleComponent,
+				HlmRadioGroupImports,
+				FormsModule,
+				HlmButtonDirective,
+				HlmCodeDirective,
+				HlmSmallDirective,
+				HlmLabelDirective,
+			],
 			providers: [],
 		}),
 	],
@@ -77,5 +85,46 @@ type Story = StoryObj<BrnRadioGroupDirective>;
 export const Default: Story = {
 	render: () => ({
 		template: '<radio-group-example/>',
+	}),
+};
+
+export const LabelFor: Story = {
+	render: () => ({
+		template: `
+		<hlm-radio-group class="text-sm font-medium" >
+			<div class="flex items-center gap-3">
+				<hlm-radio value="default" id="default">
+					<hlm-radio-indicator indicator />
+				</hlm-radio>
+				<label hlmLabel for="default" >
+					Default
+				</label>
+			</div>
+			<div class="flex items-center gap-3">
+				<hlm-radio value="comfortable" id="comfortable">
+					<hlm-radio-indicator indicator />
+				</hlm-radio>
+				<label hlmLabel for="comfortable" >
+					Comfortable
+				</label>
+			</div>
+			<div class="flex items-center gap-3">
+				<hlm-radio value="compact" id="compact">
+					<hlm-radio-indicator indicator />
+				</hlm-radio>
+				<label hlmLabel for="compact" >
+					Compact
+				</label>
+			</div>
+			<div class="flex items-center gap-3">
+				<hlm-radio class="peer group" disabled=true value="disabled" id="disabled">
+					<hlm-radio-indicator indicator />
+				</hlm-radio>
+				<label hlmLabel for="disabled" >
+					Disabled
+				</label>
+			</div>
+		</hlm-radio-group>
+`,
 	}),
 };

--- a/libs/brain/radio-group/src/lib/brn-radio.component.ts
+++ b/libs/brain/radio-group/src/lib/brn-radio.component.ts
@@ -22,6 +22,8 @@ export class BrnRadioChange<T> {
 	) {}
 }
 
+const CONTAINER_POST_FIX = '-radio';
+
 @Component({
 	selector: 'brn-radio',
 	host: {
@@ -143,9 +145,9 @@ export class BrnRadioComponent<T = unknown> implements OnDestroy {
 	 */
 	public readonly change = output<BrnRadioChange<T>>();
 
-	protected readonly hostId = computed(() =>
-		this.id() ? this.id() : `brn-radio-${++BrnRadioComponent._nextUniqueId}`,
-	);
+	protected readonly hostId = computed(() => {
+		return this.id() ? this.id() + CONTAINER_POST_FIX : `brn-radio-${++BrnRadioComponent._nextUniqueId}`;
+	});
 
 	protected readonly inputElement = viewChild.required<ElementRef<HTMLInputElement>>('input');
 

--- a/libs/helm/label/src/lib/hlm-label.directive.ts
+++ b/libs/helm/label/src/lib/hlm-label.directive.ts
@@ -20,7 +20,7 @@ export class HlmLabelDirective {
 
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 peer-data-[disabled]:cursor-not-allowed peer-data-[disabled]:opacity-50',
+			'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 peer-data-[disabled]:cursor-not-allowed peer-data-[disabled]:opacity-50 has-[[disabled]]:cursor-not-allowed has-[[disabled]]:opacity-50',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/radio-group/src/lib/hlm-radio.component.ts
+++ b/libs/helm/radio-group/src/lib/hlm-radio.component.ts
@@ -37,6 +37,13 @@ import { ClassValue } from 'clsx';
 		</brn-radio>
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		'[attr.id]': 'null',
+		'[attr.aria-label]': 'null',
+		'[attr.aria-labelledby]': 'null',
+		'[attr.aria-describedby]': 'null',
+		'[attr.data-disabled]': 'state().disabled() ? "" : null',
+	},
 })
 export class HlmRadioComponent<T = unknown> {
 	private readonly _document = inject(DOCUMENT);
@@ -45,7 +52,13 @@ export class HlmRadioComponent<T = unknown> {
 	private readonly _isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() => hlm('group flex items-center gap-x-3', this.userClass()));
+	protected readonly _computedClass = computed(() =>
+		hlm(
+			'group flex items-center gap-x-3',
+			this.userClass(),
+			this.state().disabled() ? 'cursor-not-allowed opacity-50' : '',
+		),
+	);
 
 	/** Used to set the id on the underlying brn element. */
 	public readonly id = input<string | undefined>(undefined);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [x] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

When using the label side by side with the radio box and use "label for" the same way like with the checkbox, clicking on the label does not check the radio item.
While testing this PR i saw that the disabled state is not displayed.  
 
Closes #779 

## What is the new behavior?

It also checks the radio when using the label for method.

### disabled state
Cursor not allowed and opacity are set to the indicator directly, (same way as checkbox)
``has-[[disabled]]:cursor-not-allowed has-[[disabled]]:opacity-50`` was added to the label, show the disabled state of the label, if there are disabled elements inside the content of a label. (like in the storybook default example) 

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
