### PR TITLE
docs: fix hyrdation error message

### DIFF
--- a/apps/app/src/app/shared/layout/ui-api-docs-table/ui-api-docs-table.component.ts
+++ b/apps/app/src/app/shared/layout/ui-api-docs-table/ui-api-docs-table.component.ts
@@ -11,24 +11,28 @@ type Column = { label: string; key: string; class?: string };
 		<h4 class="mb-2 mt-6">{{ title() }}</h4>
 		<div class="w-full overflow-x-auto">
 			<table hlmTable class="w-fit min-w-full">
-				<tr hlmTr>
-					@for (col of columns(); track col.key) {
-						<th hlmTh [class]="col.class">{{ col.label }}</th>
-					}
-				</tr>
-				@for (row of rows(); track row.name + $index) {
+				<thead hlmTHead>
 					<tr hlmTr>
 						@for (col of columns(); track col.key) {
-							<td hlmTd [class]="col.class">
-								@if (row[col.key]) {
-									{{ row[col.key] }}
-								} @else {
-									<span class="sr-hidden">-</span>
-								}
-							</td>
+							<th hlmTh [class]="col.class">{{ col.label }}</th>
 						}
 					</tr>
-				}
+				</thead>
+				<tbody hlmTBody>
+					@for (row of rows(); track row.name + $index) {
+						<tr hlmTr>
+							@for (col of columns(); track col.key) {
+								<td hlmTd [class]="col.class">
+									@if (row[col.key]) {
+										{{ row[col.key] }}
+									} @else {
+										<span class="sr-hidden">-</span>
+									}
+								</td>
+							}
+						</tr>
+					}
+				</tbody>
 			</table>
 		</div>
 	`,

--- a/apps/app/src/app/shared/layout/ui-docs-section/ui-docs-section.component.ts
+++ b/apps/app/src/app/shared/layout/ui-docs-section/ui-docs-section.component.ts
@@ -33,7 +33,7 @@ import { UIApiDocsTableComponent } from '../ui-api-docs-table/ui-api-docs-table.
 							{ label: 'Prop', key: 'name', class: 'font-medium' },
 							{ label: 'Type', key: 'type' },
 							{ label: 'Default', key: 'defaultValue' },
-							{ label: 'Description', key: 'description' },
+							{ label: 'Description', key: 'description', class: 'whitespace-pre' },
 						]"
 					/>
 				}
@@ -46,7 +46,7 @@ import { UIApiDocsTableComponent } from '../ui-api-docs-table/ui-api-docs-table.
 							{ label: 'Prop', key: 'name', class: 'font-medium' },
 							{ label: 'Type', key: 'type' },
 							{ label: 'Default', key: 'defaultValue' },
-							{ label: 'Description', key: 'description' },
+							{ label: 'Description', key: 'description', class: 'whitespace-pre' },
 						]"
 					/>
 				}
@@ -58,7 +58,7 @@ import { UIApiDocsTableComponent } from '../ui-api-docs-table/ui-api-docs-table.
 						[columns]="[
 							{ label: 'Prop', key: 'name', class: 'font-medium' },
 							{ label: 'Type', key: 'type' },
-							{ label: 'Description', key: 'description' },
+							{ label: 'Description', key: 'description', class: 'whitespace-pre' },
 						]"
 					/>
 				}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix (documentation)
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<img width="1050" height="600" alt="image" src="https://github.com/user-attachments/assets/97d723a3-311e-409d-8211-4ee73f17fe9c" />

Closes #

## What is the new behavior?

The `thead` and `tbody` were added to the `ui-api-docs-table`, which solves the hydration error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Also added whitespace-pre fo the description on the api table.