### PR TITLE
feat(cli): add config flag for non-buildable libs #805

### DIFF
--- a/apps/app/src/app/pages/(documentation)/documentation/components-json.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/components-json.page.ts
@@ -49,15 +49,21 @@ export const routeMeta: RouteMeta = {
 
 			<spartan-section-sub-heading id="configuration">Configuration</spartan-section-sub-heading>
 
-			<h3 id="componentsPath" class="${hlmH4} mt-12">componentsPath</h3>
+			<h3 id="componentsPath" class="${hlmH4} mt-8">componentsPath</h3>
 
 			<p class="${hlmP}">The base path where your components will be generated.</p>
+
+			<h3 id="buildable" class="${hlmH4} mt-8">buildable</h3>
+
+			<p class="${hlmP}">Determines whether the generated library is buildable or not.</p>
+
 			<spartan-code
 				class="mt-3"
 				language="js"
 				code='
 {
 	"componentsPath": "libs/ui"
+	"buildable": true
 }'
 			/>
 

--- a/libs/cli/src/generators/base/generator.spec.ts
+++ b/libs/cli/src/generators/base/generator.spec.ts
@@ -63,6 +63,7 @@ describe('base generator', () => {
 			internalName: 'ui-button-helm',
 			publicName: 'ui-button-helm',
 			directory: 'libs/test-ui',
+			buildable: true,
 		};
 
 		await hlmBaseGenerator(tree, options);

--- a/libs/cli/src/generators/base/lib/initialize-angular-library.ts
+++ b/libs/cli/src/generators/base/lib/initialize-angular-library.ts
@@ -14,7 +14,7 @@ export async function initializeAngularLibrary(tree: Tree, options: HlmBaseGener
 		name: options.publicName,
 		skipFormat: true,
 		simpleName: true,
-		buildable: true,
+		buildable: options.buildable,
 		importPath: `@spartan-ng/helm/${options.primitiveName}`,
 		prefix: 'hlm',
 		skipModule: true,

--- a/libs/cli/src/generators/base/schema.d.ts
+++ b/libs/cli/src/generators/base/schema.d.ts
@@ -7,4 +7,5 @@ export interface HlmBaseGeneratorSchema {
 	tags?: string;
 	peerDependencies?: Record<string, string>;
 	angularCli?: boolean;
+	buildable: boolean;
 }

--- a/libs/cli/src/generators/ui/generator.ts
+++ b/libs/cli/src/generators/ui/generator.ts
@@ -47,7 +47,7 @@ export async function createPrimitiveLibraries(
 	availablePrimitiveNames: Primitive[],
 	availablePrimitives: PrimitiveDefinitions,
 	tree: Tree,
-	options: HlmUIGeneratorSchema & { angularCli?: boolean; installPeerDependencies?: boolean },
+	options: HlmUIGeneratorSchema & { angularCli?: boolean; installPeerDependencies?: boolean; buildable?: boolean },
 	config: Config,
 ) {
 	const allPrimitivesSelected = response.primitives.includes('all');
@@ -84,6 +84,7 @@ export async function createPrimitiveLibraries(
 				tags: options.tags,
 				rootProject: options.rootProject,
 				angularCli: options.angularCli,
+				buildable: options.buildable ?? config.buildable,
 			});
 		}),
 	);

--- a/libs/cli/src/utils/config.ts
+++ b/libs/cli/src/utils/config.ts
@@ -5,6 +5,7 @@ const configPath = 'components.json';
 
 export type Config = {
 	componentsPath: string;
+	buildable: boolean;
 };
 
 export async function getOrCreateConfig(tree: Tree, defaults?: Partial<Config>): Promise<Config> {
@@ -14,7 +15,7 @@ export async function getOrCreateConfig(tree: Tree, defaults?: Partial<Config>):
 
 	console.log('Configuration file not found, creating a new one...');
 
-	const { componentsPath } = (await prompt([
+	const { componentsPath, buildable } = (await prompt([
 		{
 			type: 'input',
 			required: true,
@@ -23,9 +24,16 @@ export async function getOrCreateConfig(tree: Tree, defaults?: Partial<Config>):
 			initial: defaults?.componentsPath ?? 'libs/ui',
 			skip: !!defaults?.componentsPath,
 		},
-	])) as { componentsPath: string };
+		{
+			type: 'confirm',
+			name: 'buildable',
+			message: 'Should the libraries be buildable?',
+			initial: defaults?.buildable ?? true,
+			skip: typeof defaults?.buildable === 'boolean',
+		},
+	])) as { componentsPath: string; buildable: boolean };
 
-	const config = { componentsPath };
+	const config = { componentsPath, buildable };
 
 	tree.write(configPath, JSON.stringify(config, null, 2));
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [x] cli

## What is the current behavior?

Libs are generated always as buildable

Closes #805 

## What is the new behavior?

Add config flag to make in non buildable

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
