### PR TITLE
fix(tooltip): correct syntax in default content classes definition

### DIFF
--- a/libs/cli/src/generators/ui/libs/ui-tooltip-helm/files/lib/hlm-tooltip-trigger.ts.template
+++ b/libs/cli/src/generators/ui/libs/ui-tooltip-helm/files/lib/hlm-tooltip-trigger.ts.template
@@ -2,8 +2,8 @@ import { Directive } from '@angular/core';
 import { BrnTooltipTrigger, provideBrnTooltipDefaultOptions } from '@spartan-ng/brain/tooltip';
 
 const DEFAULT_TOOLTIP_CONTENT_CLASSES =
-	'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 z-50 w-fit rounded-md px-3 py-1.5 text-xs text-balance';
-'data-[state=open]:animate-in ' +
+	'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 z-50 w-fit rounded-md px-3 py-1.5 text-xs text-balance ' +
+	'data-[state=open]:animate-in ' +
 	'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ' +
 	'data-[side=below]:slide-in-from-top-2 data-[side=above]:slide-in-from-bottom-2 ' +
 	'data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 ';

--- a/libs/helm/tooltip/src/lib/hlm-tooltip-trigger.ts
+++ b/libs/helm/tooltip/src/lib/hlm-tooltip-trigger.ts
@@ -2,8 +2,8 @@ import { Directive } from '@angular/core';
 import { BrnTooltipTrigger, provideBrnTooltipDefaultOptions } from '@spartan-ng/brain/tooltip';
 
 const DEFAULT_TOOLTIP_CONTENT_CLASSES =
-	'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 z-50 w-fit rounded-md px-3 py-1.5 text-xs text-balance';
-'data-[state=open]:animate-in ' +
+	'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 z-50 w-fit rounded-md px-3 py-1.5 text-xs text-balance ' +
+	'data-[state=open]:animate-in ' +
 	'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 ' +
 	'data-[side=below]:slide-in-from-top-2 data-[side=above]:slide-in-from-bottom-2 ' +
 	'data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 ';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [x] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

Currently the template file `hlm-tooltip-trigger.ts.template` and the `hlm-tooltip-trigger.ts` contain a syntax error in the definition of the `DEFAULT_TOOLTIP_CONTENT_CLASSES` constant. I assume the intention was to concatenate all strings. The semicolon at the end of line 5 should rather be a +.

## What is the new behavior?

The syntax error is resolved and correct string concatenation is used.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

