### PR TITLE
feat: add prettier tailwind function sorting config and docs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+	"printWidth": 120,
+	"singleQuote": true,
+	"useTabs": true,
+	"bracketSpacing": true,
+	"htmlWhitespaceSensitivity": "ignore",
+	"plugins": ["prettier-plugin-organize-imports", "prettier-plugin-packagejson", "prettier-plugin-tailwindcss"]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
 	"useTabs": true,
 	"bracketSpacing": true,
 	"htmlWhitespaceSensitivity": "ignore",
+	"tailwindFunctions": ["hlm", "cva"],
 	"plugins": ["prettier-plugin-organize-imports", "prettier-plugin-packagejson", "prettier-plugin-tailwindcss"]
 }

--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -1,8 +1,0 @@
-export default {
-	printWidth: 120,
-	singleQuote: true,
-	useTabs: true,
-	bracketSpacing: true,
-	htmlWhitespaceSensitivity: 'ignore',
-	plugins: ['prettier-plugin-organize-imports', 'prettier-plugin-packagejson', 'prettier-plugin-tailwindcss'],
-};

--- a/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group--card.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group--card.example.ts
@@ -38,14 +38,14 @@ export class RadioGroupCard {
 	public payment = 'card';
 
 	public readonly cardClass = hlm(
-		'block space-x-0 relative',
+		'relative block space-x-0',
 		// base card styles
-		'flex flex-col items-center justify-center py-8 px-4 rounded-lg border-2 border-border',
+		'border-border flex flex-col items-center justify-center rounded-lg border-2 px-4 py-8',
 		// hover and background styles
 		'bg-background hover:bg-accent/10 cursor-pointer transition-colors',
 		// spacing for the icon and text
 		'[&>span]:mt-4',
 		// target the checked state properly
-		'[&:has([data-checked=true])]:border-2 [&:has([data-checked=true])]:border-primary',
+		'[&:has([data-checked=true])]:border-primary [&:has([data-checked=true])]:border-2',
 	);
 }

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
@@ -5,7 +5,7 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideChevronRight } from '@ng-icons/lucide';
 import { HlmButton } from '@spartan-ng/helm/button';
 import { HlmIcon } from '@spartan-ng/helm/icon';
-import { hlmCode, hlmP } from '@spartan-ng/helm/typography';
+import { hlmCode, hlmH4, hlmP } from '@spartan-ng/helm/typography';
 import { Code } from '../../../../shared/code/code';
 import { MainSection } from '../../../../shared/layout/main-section';
 import { PageBottomNav } from '../../../../shared/layout/page-bottom-nav/page-bottom-nav';
@@ -53,8 +53,8 @@ export const routeMeta: RouteMeta = {
 			<spartan-section-sub-heading id="prerequisites">Prerequisites</spartan-section-sub-heading>
 			<p class="${hlmP}">
 				<code class="${hlmCode}">spartan/ui</code>
-				is built on top of TailwindCSS. Make sure your application has a working TailwindCSS setup before you continue.
-				Tailwind installation instructions can be found
+				is built on top of Tailwind CSS. Make sure your application has a working Tailwind CSS setup before you
+				continue. Tailwind installation instructions can be found
 				<a class="${hlmCode}" href="https://tailwindcss.com/docs/installation/framework-guides/angular" target="_blank">
 					here.
 				</a>
@@ -64,9 +64,9 @@ export const routeMeta: RouteMeta = {
 				also builds on top of angular/cdk. To install it run the following command:
 			</p>
 			<spartan-code class="mt-4" code="npm i @angular/cdk" />
-			<spartan-section-sub-heading id="setting-up-tailwind">Setup Tailwind</spartan-section-sub-heading>
+			<spartan-section-sub-heading id="setting-up-tailwindcss">Setup Tailwind CSS</spartan-section-sub-heading>
 			<p class="${hlmP}">
-				You now have to add our spartan-specific configuration to your TailwindCSS setup. To make the setup as easy as
+				You now have to add our spartan-specific configuration to your Tailwind CSS setup. To make the setup as easy as
 				possible, the
 				<code class="${hlmCode}">&#64;spartan-ng/brain</code>
 				package comes with it own preset.
@@ -112,10 +112,54 @@ module.exports = {
 
 			<spartan-code class="mt-4" code="@import '@spartan-ng/brain/hlm-tailwind-preset.css';" />
 
+			<h3 id="sorting-classes" class="${hlmH4} mb-2 mt-6">Sorting classes</h3>
+
+			<p class="${hlmP} text-pretty">
+				You can enable automatic sorting of Tailwind CSS classes in
+				<span class="${hlmCode}">hlm</span>
+				and
+				<span class="${hlmCode}">cva</span>
+				functions with the
+				<span class="${hlmCode}">prettier-plugin-tailwindcss</span>
+				.
+			</p>
+
+			<ol class="my-6 ml-6 list-decimal [&>li]:mt-2">
+				<li>
+					Install and configure the
+					<a class="${hlmCode}" href="https://github.com/tailwindlabs/prettier-plugin-tailwindcss" target="_blank">
+						prettier-plugin-tailwindcss
+					</a>
+
+					in your project.
+				</li>
+				<li>
+					Add
+					<a
+						class="${hlmCode}"
+						href="https://github.com/tailwindlabs/prettier-plugin-tailwindcss?tab=readme-ov-file#sorting-classes-in-function-calls"
+						target="_blank"
+					>
+						tailwindFunctions
+					</a>
+					option to your prettier config file (e.g.
+					<span class="${hlmCode}">.prettierrc</span>
+					):
+				</li>
+			</ol>
+
+			<spartan-code
+				class="mt-4"
+				code='// .prettierrc
+{
+  "tailwindFunctions": ["hlm", "cva"]
+}'
+			/>
+
 			<spartan-section-sub-heading id="adding-css-vars">Adding CSS variables</spartan-section-sub-heading>
 			<p class="${hlmP}">
-				To complete your TailwindCSS setup, you need to add our spartan-specific CSS variables to your style entrypoint.
-				This is most likely a
+				To complete your Tailwind CSS setup, you need to add our spartan-specific CSS variables to your style
+				entrypoint. This is most likely a
 				<code class="${hlmCode}">styles.css</code>
 				in the
 				<code class="${hlmCode}">src</code>

--- a/apps/ui-storybook/stories/select.stories.ts
+++ b/apps/ui-storybook/stories/select.stories.ts
@@ -673,7 +673,7 @@ export class CustomSelectTrigger {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'!bg-sky-500 flex h-10 items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 w-[180px]',
+			'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus:ring-ring flex h-10 w-[180px] items-center justify-between rounded-md border !bg-sky-500 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/accordion/src/lib/hlm-accordion-content.ts
+++ b/libs/helm/accordion/src/lib/hlm-accordion-content.ts
@@ -22,6 +22,6 @@ export class HlmAccordionContent extends BrnAccordionContent {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() => {
 		const gridRows = this.state() === 'open' ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]';
-		return hlm('text-sm transition-all grid', gridRows, this.userClass());
+		return hlm('grid text-sm transition-all', gridRows, this.userClass());
 	});
 }

--- a/libs/helm/accordion/src/lib/hlm-accordion-item.ts
+++ b/libs/helm/accordion/src/lib/hlm-accordion-item.ts
@@ -18,6 +18,6 @@ import type { ClassValue } from 'clsx';
 export class HlmAccordionItem {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('flex flex-1 flex-col border-b border-border', this.userClass()),
+		hlm('border-border flex flex-1 flex-col border-b', this.userClass()),
 	);
 }

--- a/libs/helm/accordion/src/lib/hlm-accordion-trigger.ts
+++ b/libs/helm/accordion/src/lib/hlm-accordion-trigger.ts
@@ -15,7 +15,7 @@ export class HlmAccordionTrigger {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>[hlmAccIcon]]:rotate-180',
+			'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium outline-none transition-all hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>[hlmAccIcon]]:rotate-180',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/alert-dialog/src/lib/hlm-alert-dialog-content.ts
+++ b/libs/helm/alert-dialog/src/lib/hlm-alert-dialog-content.ts
@@ -22,7 +22,7 @@ export class HlmAlertDialogContent {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'relative bg-background data-[state=open]:animate-in justify-self-center data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 grid w-full max-w-[calc(100%-2rem)] gap-4 justify-self-center rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/alert-dialog/src/lib/hlm-alert-dialog-overlay.ts
+++ b/libs/helm/alert-dialog/src/lib/hlm-alert-dialog-overlay.ts
@@ -12,7 +12,7 @@ export class HlmAlertDialogOverlay {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+			'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 bg-black/50',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/alert/src/lib/hlm-alert.ts
+++ b/libs/helm/alert/src/lib/hlm-alert.ts
@@ -4,13 +4,13 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
 
 const alertVariants = cva(
-	'relative w-full rounded-lg border px-4 py-3 text-sm has-[>[hlmAlertIcon]]:grid has-[>[hlmAlertIcon]]:grid-cols-[calc(theme(spacing.1)*4)_1fr] has-[>[hlmAlertIcon]]:gap-x-3 gap-y-0.5 items-start [&>[hlmAlertIcon]]:size-4 [&>[hlmAlertIcon]]:translate-y-0.5 [&>[hlmAlertIcon]]:text-current',
+	'relative w-full items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>[hlmAlertIcon]]:grid has-[>[hlmAlertIcon]]:grid-cols-[calc(theme(spacing.1)*4)_1fr] has-[>[hlmAlertIcon]]:gap-x-3 [&>[hlmAlertIcon]]:size-4 [&>[hlmAlertIcon]]:translate-y-0.5 [&>[hlmAlertIcon]]:text-current',
 	{
 		variants: {
 			variant: {
 				default: 'bg-card text-card-foreground',
 				destructive:
-					'text-destructive bg-card [&>[hlmAlertIcon]]:text-current [&>[hlmAlertDescription]]:text-destructive/90 [&>[hlmAlertDesc]]:text-destructive/90',
+					'text-destructive bg-card [&>[hlmAlertDescription]]:text-destructive/90 [&>[hlmAlertDesc]]:text-destructive/90 [&>[hlmAlertIcon]]:text-current',
 			},
 		},
 		defaultVariants: {

--- a/libs/helm/aspect-ratio/src/lib/helm-aspect-ratio.ts
+++ b/libs/helm/aspect-ratio/src/lib/helm-aspect-ratio.ts
@@ -34,7 +34,7 @@ export class HlmAspectRatio {
 
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'relative w-full [&>*:first-child]:absolute [&>*:first-child]:w-full [&>*:first-child]:h-full [&>*:first-child]:object-cover',
+			'relative w-full [&>*:first-child]:absolute [&>*:first-child]:h-full [&>*:first-child]:w-full [&>*:first-child]:object-cover',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/avatar/src/lib/hlm-avatar.ts
+++ b/libs/helm/avatar/src/lib/hlm-avatar.ts
@@ -22,6 +22,6 @@ export class HlmAvatar extends BrnAvatar {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 
 	protected readonly _computedClass = computed(() =>
-		hlm('relative flex shrink-0 overflow-hidden rounded-full size-8', this.userClass()),
+		hlm('relative flex size-8 shrink-0 overflow-hidden rounded-full', this.userClass()),
 	);
 }

--- a/libs/helm/badge/src/lib/hlm-badge.ts
+++ b/libs/helm/badge/src/lib/hlm-badge.ts
@@ -4,14 +4,14 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
 
 const badgeVariants = cva(
-	'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&_ng-icon]:size-3 gap-1 [&_ng-icon]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+	'focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-md border px-2 py-0.5 text-xs font-medium transition-[color,box-shadow] focus-visible:ring-[3px] [&_ng-icon]:pointer-events-none [&_ng-icon]:size-3',
 	{
 		variants: {
 			variant: {
-				default: 'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
-				secondary: 'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+				default: 'bg-primary text-primary-foreground [a&]:hover:bg-primary/90 border-transparent',
+				secondary: 'bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90 border-transparent',
 				destructive:
-					'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+					'bg-destructive [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60 border-transparent text-white',
 				outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
 			},
 		},

--- a/libs/helm/breadcrumb/src/lib/hlm-breadcrumb-list.ts
+++ b/libs/helm/breadcrumb/src/lib/hlm-breadcrumb-list.ts
@@ -12,6 +12,6 @@ export class HlmBreadcrumbList {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 
 	protected readonly _computedClass = computed(() =>
-		hlm('text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5', this.userClass()),
+		hlm('text-muted-foreground flex flex-wrap items-center gap-1.5 break-words text-sm sm:gap-2.5', this.userClass()),
 	);
 }

--- a/libs/helm/breadcrumb/src/lib/hlm-breadcrumb-page.ts
+++ b/libs/helm/breadcrumb/src/lib/hlm-breadcrumb-page.ts
@@ -14,5 +14,5 @@ import type { ClassValue } from 'clsx';
 export class HlmBreadcrumbPage {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 
-	protected readonly _computedClass = computed(() => hlm('font-normal text-foreground', this.userClass()));
+	protected readonly _computedClass = computed(() => hlm('text-foreground font-normal', this.userClass()));
 }

--- a/libs/helm/breadcrumb/src/lib/hlm-breadcrumb-separator.ts
+++ b/libs/helm/breadcrumb/src/lib/hlm-breadcrumb-separator.ts
@@ -24,5 +24,5 @@ import type { ClassValue } from 'clsx';
 export class HlmBreadcrumbSeparator {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 
-	protected readonly _computedClass = computed(() => hlm('[&_ng-icon]:size-3.5 [&_ng-icon]:block', this.userClass()));
+	protected readonly _computedClass = computed(() => hlm('[&_ng-icon]:block [&_ng-icon]:size-3.5', this.userClass()));
 }

--- a/libs/helm/button/src/lib/hlm-button.ts
+++ b/libs/helm/button/src/lib/hlm-button.ts
@@ -6,22 +6,22 @@ import type { ClassValue } from 'clsx';
 import { injectBrnButtonConfig } from './hlm-button.token';
 
 export const buttonVariants = cva(
-	'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_ng-icon]:pointer-events-none shrink-0 [&_ng-icon]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-default',
+	'focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 cursor-default items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all focus-visible:ring-[3px] data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_ng-icon]:pointer-events-none [&_ng-icon]:shrink-0',
 	{
 		variants: {
 			variant: {
 				default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
 				destructive:
-					'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+					'bg-destructive shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60 text-white',
 				outline:
-					'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+					'bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 border',
 				secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
 				ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
 				link: 'text-primary underline-offset-4 hover:underline',
 			},
 			size: {
 				default: 'h-9 px-4 py-2 has-[>ng-icon]:px-3',
-				sm: 'h-8 rounded-md gap-1.5 px-3 has-[>ng-icon]:px-2.5',
+				sm: 'h-8 gap-1.5 rounded-md px-3 has-[>ng-icon]:px-2.5',
 				lg: 'h-10 rounded-md px-6 has-[>ng-icon]:px-4',
 				icon: 'size-9',
 			},

--- a/libs/helm/calendar/src/lib/hlm-calendar-multi.ts
+++ b/libs/helm/calendar/src/lib/hlm-calendar-multi.ts
@@ -182,7 +182,7 @@ export class HlmCalendarMulti<T> {
 	protected readonly _btnClass = hlm(
 		buttonVariants({ variant: 'ghost' }),
 		'size-8 p-0 font-normal aria-selected:opacity-100',
-		'data-[outside]:text-muted-foreground data-[outside]:opacity-50 data-[outside]:aria-selected:bg-accent/50 data-[outside]:aria-selected:text-muted-foreground data-[outside]:aria-selected:opacity-30',
+		'data-[outside]:text-muted-foreground data-[outside]:aria-selected:bg-accent/50 data-[outside]:aria-selected:text-muted-foreground data-[outside]:opacity-50 data-[outside]:aria-selected:opacity-30',
 		'data-[today]:bg-accent data-[today]:text-accent-foreground',
 		'data-[selected]:bg-primary data-[selected]:text-primary-foreground data-[selected]:hover:bg-primary data-[selected]:hover:text-primary-foreground data-[selected]:focus:bg-primary data-[selected]:focus:text-primary-foreground',
 		'data-[disabled]:text-muted-foreground data-[disabled]:opacity-50',

--- a/libs/helm/calendar/src/lib/hlm-calendar-range.ts
+++ b/libs/helm/calendar/src/lib/hlm-calendar-range.ts
@@ -180,6 +180,6 @@ export class HlmCalendarRange<T> {
 		'data-[disabled]:text-muted-foreground data-[disabled]:opacity-50',
 		'data-[range-start]:rounded-l-md',
 		'data-[range-end]:rounded-r-md',
-		'data-[range-between]:rounded-none data-[range-between]:bg-accent data-[range-between]:text-accent-foreground',
+		'data-[range-between]:bg-accent data-[range-between]:text-accent-foreground data-[range-between]:rounded-none',
 	);
 }

--- a/libs/helm/calendar/src/lib/hlm-calendar.ts
+++ b/libs/helm/calendar/src/lib/hlm-calendar.ts
@@ -170,7 +170,7 @@ export class HlmCalendar<T> {
 	protected readonly _btnClass = hlm(
 		buttonVariants({ variant: 'ghost' }),
 		'size-8 p-0 font-normal aria-selected:opacity-100',
-		'data-[outside]:text-muted-foreground data-[outside]:opacity-50 data-[outside]:aria-selected:bg-accent/50 data-[outside]:aria-selected:text-muted-foreground data-[outside]:aria-selected:opacity-30',
+		'data-[outside]:text-muted-foreground data-[outside]:aria-selected:bg-accent/50 data-[outside]:aria-selected:text-muted-foreground data-[outside]:opacity-50 data-[outside]:aria-selected:opacity-30',
 		'data-[today]:bg-accent data-[today]:text-accent-foreground',
 		'data-[selected]:bg-primary data-[selected]:text-primary-foreground data-[selected]:hover:bg-primary dark:hover:text-accent-foreground data-[selected]:focus:bg-primary data-[selected]:focus:text-primary-foreground',
 		'data-[disabled]:text-muted-foreground data-[disabled]:opacity-50',

--- a/libs/helm/card/src/lib/hlm-card-footer.ts
+++ b/libs/helm/card/src/lib/hlm-card-footer.ts
@@ -10,5 +10,5 @@ import type { ClassValue } from 'clsx';
 })
 export class HlmCardFooter {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() => hlm('flex items-center px-6 [.border-t]:pt-6', this.userClass()));
+	protected readonly _computedClass = computed(() => hlm('[.border-t]:pt-6 flex items-center px-6', this.userClass()));
 }

--- a/libs/helm/card/src/lib/hlm-card-header.ts
+++ b/libs/helm/card/src/lib/hlm-card-header.ts
@@ -12,7 +12,7 @@ export class HlmCardHeader {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+			'@container/card-header has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/card/src/lib/hlm-card-title.ts
+++ b/libs/helm/card/src/lib/hlm-card-title.ts
@@ -10,5 +10,5 @@ import type { ClassValue } from 'clsx';
 })
 export class HlmCardTitle {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() => hlm('leading-none font-semibold', this.userClass()));
+	protected readonly _computedClass = computed(() => hlm('font-semibold leading-none', this.userClass()));
 }

--- a/libs/helm/checkbox/src/lib/hlm-checkbox.ts
+++ b/libs/helm/checkbox/src/lib/hlm-checkbox.ts
@@ -66,7 +66,7 @@ export class HlmCheckbox implements ControlValueAccessor {
 
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 cursor-default',
+			'border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive shadow-xs peer size-4 shrink-0 cursor-default rounded-[4px] border outline-none transition-shadow focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
 			this.userClass(),
 			this._state().disabled() ? 'cursor-not-allowed opacity-50' : '',
 		),

--- a/libs/helm/command/src/lib/hlm-command-dialog-close-button.ts
+++ b/libs/helm/command/src/lib/hlm-command-dialog-close-button.ts
@@ -17,7 +17,7 @@ export class HlmCommandDialogCloseButton {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'absolute top-3 right-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring font-medium h-10 hover:bg-accent hover:text-accent-foreground inline-flex items-center justify-center px-4 py-2 ring-offset-background rounded-md text-sm transition-colors !h-5 !p-1 !w-5',
+			'focus-visible:ring-ring hover:bg-accent hover:text-accent-foreground ring-offset-background absolute right-3 top-3 inline-flex !h-5 h-10 !w-5 items-center justify-center rounded-md !p-1 px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/command/src/lib/hlm-command-group.ts
+++ b/libs/helm/command/src/lib/hlm-command-group.ts
@@ -22,6 +22,6 @@ export class HlmCommandGroup {
 
 	/*** The styles to apply  */
 	protected readonly _computedClass = computed(() =>
-		hlm('text-foreground overflow-hidden p-1 block data-[hidden]:hidden', this.userClass()),
+		hlm('text-foreground block overflow-hidden p-1 data-[hidden]:hidden', this.userClass()),
 	);
 }

--- a/libs/helm/command/src/lib/hlm-command-item.ts
+++ b/libs/helm/command/src/lib/hlm-command-item.ts
@@ -38,7 +38,7 @@ export class HlmCommandItem {
 	/*** The styles to apply  */
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'data-[selected]:bg-accent data-[selected=true]:text-accent-foreground [&>ng-icon]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>ng-icon]:pointer-events-none [&>ng-icon]:shrink-0 [&>ng-icon]:text-base w-full data-[hidden]:hidden',
+			'data-[selected]:bg-accent data-[selected=true]:text-accent-foreground [&>ng-icon]:text-muted-foreground outline-hidden relative flex w-full cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled]:pointer-events-none data-[hidden]:hidden data-[disabled]:opacity-50 [&>ng-icon]:pointer-events-none [&>ng-icon]:shrink-0 [&>ng-icon]:text-base',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/command/src/lib/hlm-command-list.ts
+++ b/libs/helm/command/src/lib/hlm-command-list.ts
@@ -22,6 +22,6 @@ export class HlmCommandList {
 
 	/** The styles to apply  */
 	protected readonly _computedClass = computed(() =>
-		hlm('max-h-[300px] overflow-x-hidden overflow-y-auto', this.userClass()),
+		hlm('max-h-[300px] overflow-y-auto overflow-x-hidden', this.userClass()),
 	);
 }

--- a/libs/helm/command/src/lib/hlm-command-separator.ts
+++ b/libs/helm/command/src/lib/hlm-command-separator.ts
@@ -15,5 +15,5 @@ export class HlmCommandSeparator {
 	public readonly userClass = input<string>('', { alias: 'class' });
 
 	/*** The styles to apply  */
-	protected readonly _computedClass = computed(() => hlm('block bg-border -mx-1 h-px', this.userClass()));
+	protected readonly _computedClass = computed(() => hlm('bg-border -mx-1 block h-px', this.userClass()));
 }

--- a/libs/helm/date-picker/src/lib/hlm-date-picker-multi.ts
+++ b/libs/helm/date-picker/src/lib/hlm-date-picker-multi.ts
@@ -73,8 +73,8 @@ export class HlmDatePickerMulti<T> implements ControlValueAccessor {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'inline-flex items-center gap-2 whitespace-nowrap rounded-md text-sm ring-offset-background transition-all border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 w-[280px] justify-start text-left font-normal',
-			'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+			'ring-offset-background border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex h-10 w-[280px] items-center justify-start gap-2 whitespace-nowrap rounded-md border px-4 py-2 text-left text-sm font-normal transition-all',
+			'focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
 			'disabled:pointer-events-none disabled:opacity-50',
 			'[&_ng-icon]:pointer-events-none [&_ng-icon]:shrink-0',
 			!this._mutableDate() ? 'text-muted-foreground' : '',

--- a/libs/helm/date-picker/src/lib/hlm-date-picker.ts
+++ b/libs/helm/date-picker/src/lib/hlm-date-picker.ts
@@ -70,8 +70,8 @@ export class HlmDatePicker<T> implements ControlValueAccessor {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'inline-flex items-center gap-2 whitespace-nowrap rounded-md text-sm transition-all disabled:pointer-events-none disabled:opacity-50 ring-offset-background border border-input bg-background hover:bg-accent dark:bg-input/30 dark:hover:bg-input/50 hover:text-accent-foreground h-9 px-3 py-2 w-[280px] justify-start text-left font-normal cursor-default justify-between',
-			'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+			'ring-offset-background border-input bg-background hover:bg-accent dark:bg-input/30 dark:hover:bg-input/50 hover:text-accent-foreground inline-flex h-9 w-[280px] cursor-default items-center justify-start justify-between gap-2 whitespace-nowrap rounded-md border px-3 py-2 text-left text-sm font-normal transition-all disabled:pointer-events-none disabled:opacity-50',
+			'focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
 			'disabled:pointer-events-none disabled:opacity-50',
 			'[&_ng-icon]:pointer-events-none [&_ng-icon]:shrink-0',
 			!this._mutableDate() ? 'text-muted-foreground' : '',

--- a/libs/helm/date-picker/src/lib/hlm-date-range-picker.ts
+++ b/libs/helm/date-picker/src/lib/hlm-date-range-picker.ts
@@ -78,8 +78,8 @@ export class HlmDateRangePicker<T> implements ControlValueAccessor {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'inline-flex items-center gap-2 whitespace-nowrap rounded-md text-sm ring-offset-background transition-all border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 w-[280px] justify-start text-left font-normal',
-			'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+			'ring-offset-background border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex h-10 w-[280px] items-center justify-start gap-2 whitespace-nowrap rounded-md border px-4 py-2 text-left text-sm font-normal transition-all',
+			'focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
 			'disabled:pointer-events-none disabled:opacity-50',
 			'[&_ng-icon]:pointer-events-none [&_ng-icon]:shrink-0',
 			!this._mutableDate() ? 'text-muted-foreground' : '',

--- a/libs/helm/dialog/src/lib/hlm-dialog-close.ts
+++ b/libs/helm/dialog/src/lib/hlm-dialog-close.ts
@@ -13,7 +13,7 @@ export class HlmDialogClose {
 
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground',
+			'ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/dialog/src/lib/hlm-dialog-content.ts
+++ b/libs/helm/dialog/src/lib/hlm-dialog-content.ts
@@ -43,7 +43,7 @@ export class HlmDialogContent {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'border-border grid w-full max-w-lg relative gap-4 border bg-background p-6 shadow-lg [animation-duration:200] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-top-[2%]  data-[state=open]:slide-in-from-top-[2%] sm:rounded-lg md:w-full',
+			'border-border bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-top-[2%] data-[state=open]:slide-in-from-top-[2%] relative grid w-full max-w-lg gap-4 border p-6 shadow-lg [animation-duration:200] sm:rounded-lg md:w-full',
 			this.userClass(),
 			this._dynamicComponentClass,
 		),

--- a/libs/helm/dialog/src/lib/hlm-dialog-description.ts
+++ b/libs/helm/dialog/src/lib/hlm-dialog-description.ts
@@ -12,5 +12,5 @@ import type { ClassValue } from 'clsx';
 })
 export class HlmDialogDescription {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() => hlm('text-sm text-muted-foreground', this.userClass()));
+	protected readonly _computedClass = computed(() => hlm('text-muted-foreground text-sm', this.userClass()));
 }

--- a/libs/helm/form-field/src/lib/hlm-error.ts
+++ b/libs/helm/form-field/src/lib/hlm-error.ts
@@ -12,6 +12,6 @@ import { ClassValue } from 'clsx';
 export class HlmError {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('block text-destructive text-sm font-medium', this.userClass()),
+		hlm('text-destructive block text-sm font-medium', this.userClass()),
 	);
 }

--- a/libs/helm/form-field/src/lib/hlm-form-field.ts
+++ b/libs/helm/form-field/src/lib/hlm-form-field.ts
@@ -33,7 +33,7 @@ import { HlmError } from './hlm-error';
 })
 export class HlmFormField {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() => hlm('space-y-2 block', this.userClass()));
+	protected readonly _computedClass = computed(() => hlm('block space-y-2', this.userClass()));
 	public readonly control = contentChild(BrnFormFieldControl);
 
 	public readonly errorChildren = contentChildren(HlmError);

--- a/libs/helm/form-field/src/lib/hlm-hint.ts
+++ b/libs/helm/form-field/src/lib/hlm-hint.ts
@@ -11,5 +11,5 @@ import { ClassValue } from 'clsx';
 })
 export class HlmHint {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() => hlm('block text-sm text-muted-foreground', this.userClass()));
+	protected readonly _computedClass = computed(() => hlm('text-muted-foreground block text-sm', this.userClass()));
 }

--- a/libs/helm/hover-card/src/lib/hlm-hover-card-content.ts
+++ b/libs/helm/hover-card/src/lib/hlm-hover-card-content.ts
@@ -40,7 +40,7 @@ export class HlmHoverCardContent {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'z-50 w-64 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md outline-none',
+			'border-border bg-popover text-popover-foreground z-50 w-64 rounded-md border p-4 shadow-md outline-none',
 			'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
 			this.userClass(),
 		),

--- a/libs/helm/input-otp/src/lib/hlm-input-otp-slot.ts
+++ b/libs/helm/input-otp/src/lib/hlm-input-otp-slot.ts
@@ -26,8 +26,8 @@ export class HlmInputOtpSlot {
 
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md',
-			'has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:z-10 has-[brn-input-otp-slot[data-active="true"]]:ring-[3px] has-[brn-input-otp-slot[data-active="true"]]:ring-ring/50',
+			'dark:bg-input/30 border-input shadow-xs relative flex h-9 w-9 items-center justify-center border-y border-r text-sm outline-none transition-all first:rounded-l-md first:border-l last:rounded-r-md',
+			'has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/50 has-[brn-input-otp-slot[data-active="true"]]:z-10 has-[brn-input-otp-slot[data-active="true"]]:ring-[3px]',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/input-otp/src/lib/hlm-input-otp.ts
+++ b/libs/helm/input-otp/src/lib/hlm-input-otp.ts
@@ -12,6 +12,6 @@ export class HlmInputOtp {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 
 	protected readonly _computedClass = computed(() =>
-		hlm('flex items-center gap-2 has-disabled:opacity-50', this.userClass()),
+		hlm('has-disabled:opacity-50 flex items-center gap-2', this.userClass()),
 	);
 }

--- a/libs/helm/input/src/lib/hlm-input.ts
+++ b/libs/helm/input/src/lib/hlm-input.ts
@@ -18,7 +18,7 @@ import { cva, VariantProps } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
 
 export const inputVariants = cva(
-	'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+	'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input shadow-xs focus-visible:border-ring focus-visible:ring-ring/50 flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base outline-none transition-[color,box-shadow] file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
 	{
 		variants: {
 			error: {

--- a/libs/helm/label/src/lib/hlm-label.ts
+++ b/libs/helm/label/src/lib/hlm-label.ts
@@ -20,7 +20,7 @@ export class HlmLabel {
 
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50 peer-data-[disabled]:cursor-not-allowed peer-data-[disabled]:opacity-50 has-[[disabled]]:cursor-not-allowed has-[[disabled]]:opacity-50',
+			'flex select-none items-center gap-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50 has-[[disabled]]:cursor-not-allowed has-[[disabled]]:opacity-50 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-data-[disabled]:cursor-not-allowed peer-data-[disabled]:opacity-50',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/menu/src/lib/hlm-menu-bar-item.ts
+++ b/libs/helm/menu/src/lib/hlm-menu-bar-item.ts
@@ -14,7 +14,7 @@ export class HlmMenuBarItem {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'focus:bg-accent focus:text-accent-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground flex items-center rounded-sm px-2 py-1 text-sm font-medium outline-none select-none',
+			'focus:bg-accent focus:text-accent-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground flex select-none items-center rounded-sm px-2 py-1 text-sm font-medium outline-none',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/menu/src/lib/hlm-menu-bar.ts
+++ b/libs/helm/menu/src/lib/hlm-menu-bar.ts
@@ -15,6 +15,6 @@ import type { ClassValue } from 'clsx';
 export class HlmMenuBar {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() =>
-		hlm('bg-background flex h-9 items-center gap-1 rounded-md border p-1 shadow-xs', this.userClass()),
+		hlm('bg-background shadow-xs flex h-9 items-center gap-1 rounded-md border p-1', this.userClass()),
 	);
 }

--- a/libs/helm/menu/src/lib/hlm-menu-item-check.ts
+++ b/libs/helm/menu/src/lib/hlm-menu-item-check.ts
@@ -22,7 +22,7 @@ export class HlmMenuItemCheck {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() =>
 		hlm(
-			'group-[.checked]:opacity-100 opacity-0 absolute left-2 flex h-3.5 w-3.5 items-center justify-center',
+			'absolute left-2 flex h-3.5 w-3.5 items-center justify-center opacity-0 group-[.checked]:opacity-100',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/menu/src/lib/hlm-menu-item-checkbox.ts
+++ b/libs/helm/menu/src/lib/hlm-menu-item-checkbox.ts
@@ -20,7 +20,7 @@ export class HlmMenuItemCheckbox {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'group w-full relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground disabled:pointer-events-none disabled:opacity-50',
+			'hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground group relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors disabled:pointer-events-none disabled:opacity-50',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/menu/src/lib/hlm-menu-item-radio-indicator.ts
+++ b/libs/helm/menu/src/lib/hlm-menu-item-radio-indicator.ts
@@ -22,7 +22,7 @@ export class HlmMenuItemRadioIndicator {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'group-[.checked]:opacity-100 opacity-0 absolute left-2 flex h-3.5 w-3.5 items-center justify-center',
+			'absolute left-2 flex h-3.5 w-3.5 items-center justify-center opacity-0 group-[.checked]:opacity-100',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/menu/src/lib/hlm-menu-item-radio.ts
+++ b/libs/helm/menu/src/lib/hlm-menu-item-radio.ts
@@ -20,7 +20,7 @@ export class HlmMenuItemRadio {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'group w-full relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground disabled:pointer-events-none disabled:opacity-50',
+			'hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground group relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors disabled:pointer-events-none disabled:opacity-50',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/menu/src/lib/hlm-menu-item.ts
+++ b/libs/helm/menu/src/lib/hlm-menu-item.ts
@@ -29,7 +29,7 @@ export class HlmMenuItem {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			`hover:bg-accent focus-visible:bg-accent w-full focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[ng-icon]:!text-destructive [&_ng-icon]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_ng-icon]:pointer-events-none [&_ng-icon]:shrink-0`,
+			`hover:bg-accent focus-visible:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[ng-icon]:!text-destructive [&_ng-icon]:text-muted-foreground relative flex w-full cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[disabled]:opacity-50 [&_ng-icon]:pointer-events-none [&_ng-icon]:shrink-0`,
 			this.userClass(),
 		),
 	);

--- a/libs/helm/menu/src/lib/hlm-menu-separator.ts
+++ b/libs/helm/menu/src/lib/hlm-menu-separator.ts
@@ -12,5 +12,5 @@ import { ClassValue } from 'clsx';
 })
 export class HlmMenuSeparator {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() => hlm('block bg-border -mx-1 my-1 h-px', this.userClass()));
+	protected readonly _computedClass = computed(() => hlm('bg-border -mx-1 my-1 block h-px', this.userClass()));
 }

--- a/libs/helm/menu/src/lib/hlm-menu.ts
+++ b/libs/helm/menu/src/lib/hlm-menu.ts
@@ -5,7 +5,7 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
 
 export const menuVariants = cva(
-	'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-top overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+	'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-top overflow-y-auto overflow-x-hidden rounded-md border p-1 shadow-md',
 	{
 		variants: {
 			variant: {

--- a/libs/helm/menu/src/lib/hlm-sub-menu.ts
+++ b/libs/helm/menu/src/lib/hlm-sub-menu.ts
@@ -18,7 +18,7 @@ export class HlmSubMenu {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'border-border min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+			'border-border bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/popover/src/lib/hlm-popover-close.ts
+++ b/libs/helm/popover/src/lib/hlm-popover-close.ts
@@ -12,7 +12,7 @@ export class HlmPopoverClose {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground',
+			'ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/popover/src/lib/hlm-popover-content.ts
+++ b/libs/helm/popover/src/lib/hlm-popover-content.ts
@@ -24,7 +24,7 @@ export class HlmPopoverContent {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'relative border-border w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+			'border-border bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative w-72 rounded-md border p-4 shadow-md outline-none',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/progress/src/lib/hlm-progress.ts
+++ b/libs/helm/progress/src/lib/hlm-progress.ts
@@ -13,6 +13,6 @@ import type { ClassValue } from 'clsx';
 export class HlmProgress {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('inline-flex bg-primary/20 relative h-2 w-full overflow-hidden rounded-full', this.userClass()),
+		hlm('bg-primary/20 relative inline-flex h-2 w-full overflow-hidden rounded-full', this.userClass()),
 	);
 }

--- a/libs/helm/radio-group/src/lib/hlm-radio-indicator.ts
+++ b/libs/helm/radio-group/src/lib/hlm-radio-indicator.ts
@@ -16,7 +16,7 @@ export class HlmRadioIndicator {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'relative flex items-center justify-center border-input text-primary group-has-[:focus-visible]:border-ring group-has-[:focus-visible]:ring-ring/50 dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none group-has-[:focus-visible]:ring-[3px] group-data=[disabled=true]:cursor-not-allowed group-data=[disabled=true]:opacity-50',
+			'border-input text-primary group-has-[:focus-visible]:border-ring group-has-[:focus-visible]:ring-ring/50 dark:bg-input/30 shadow-xs group-data=[disabled=true]:cursor-not-allowed group-data=[disabled=true]:opacity-50 relative flex aspect-square size-4 shrink-0 items-center justify-center rounded-full border outline-none transition-[color,box-shadow] group-has-[:focus-visible]:ring-[3px]',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/select/src/lib/hlm-select-content.ts
+++ b/libs/helm/select/src/lib/hlm-select-content.ts
@@ -22,7 +22,7 @@ export class HlmSelectContent {
 
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'w-full relative z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md p-1 data-[side=bottom]:top-[2px] data-[side=top]:bottom-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+			'border-border bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 w-full min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md data-[side=bottom]:top-[2px] data-[side=top]:bottom-[2px]',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/select/src/lib/hlm-select-label.ts
+++ b/libs/helm/select/src/lib/hlm-select-label.ts
@@ -18,7 +18,7 @@ export class HlmSelectLabel {
 	protected readonly _computedClass = computed(() =>
 		hlm(
 			'text-muted-foreground px-2 py-1.5 text-xs',
-			this._stickyLabels() ? 'sticky top-0 bg-popover block z-[2]' : '',
+			this._stickyLabels() ? 'bg-popover sticky top-0 z-[2] block' : '',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/select/src/lib/hlm-select-option.ts
+++ b/libs/helm/select/src/lib/hlm-select-option.ts
@@ -30,7 +30,7 @@ export class HlmSelectOption {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'data-[active]:bg-accent data-[active]:text-accent-foreground [&>ng-icon]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>ng-icon]:pointer-events-none [&>ng-icon]:shrink-0 [&>ng-icon]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2',
+			'data-[active]:bg-accent data-[active]:text-accent-foreground [&>ng-icon]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>ng-icon]:pointer-events-none [&>ng-icon]:size-4 [&>ng-icon]:shrink-0',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/select/src/lib/hlm-select-trigger.ts
+++ b/libs/helm/select/src/lib/hlm-select-trigger.ts
@@ -8,7 +8,7 @@ import { cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
 
 export const selectTriggerVariants = cva(
-	`border-input [&>ng-icon]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 [&>ng-icon]:pointer-events-none [&>ng-icon]:shrink-0 [&>ng-icon]:size-4`,
+	`border-input [&>ng-icon]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 dark:hover:bg-input/50 shadow-xs flex w-fit items-center justify-between gap-2 whitespace-nowrap rounded-md border bg-transparent px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 [&>ng-icon]:pointer-events-none [&>ng-icon]:size-4 [&>ng-icon]:shrink-0`,
 	{
 		variants: {
 			error: {

--- a/libs/helm/select/src/lib/hlm-select-value.ts
+++ b/libs/helm/select/src/lib/hlm-select-value.ts
@@ -11,6 +11,6 @@ import type { ClassValue } from 'clsx';
 export class HlmSelectValue {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('line-clamp-1 flex items-center gap-2 data-[placeholder]:text-muted-foreground', this.userClass()),
+		hlm('data-[placeholder]:text-muted-foreground line-clamp-1 flex items-center gap-2', this.userClass()),
 	);
 }

--- a/libs/helm/separator/src/lib/hlm-separator.ts
+++ b/libs/helm/separator/src/lib/hlm-separator.ts
@@ -14,7 +14,7 @@ export class HlmSeparator {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected _computedClass = computed(() =>
 		hlm(
-			'inline-flex shrink-0 border-0 bg-border',
+			'bg-border inline-flex shrink-0 border-0',
 			this.orientation() === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
 			this.userClass(),
 		),

--- a/libs/helm/sheet/src/lib/hlm-sheet-close.ts
+++ b/libs/helm/sheet/src/lib/hlm-sheet-close.ts
@@ -12,7 +12,7 @@ export class HlmSheetClose {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none',
+			'ring-offset-background focus:ring-ring data-[state=open]:bg-secondary rounded-xs focus:outline-hidden absolute right-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/sheet/src/lib/hlm-sheet-content.ts
+++ b/libs/helm/sheet/src/lib/hlm-sheet-content.ts
@@ -29,7 +29,7 @@ export const sheetVariants = cva(
 					'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t',
 				left: 'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
 				right:
-					'inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right',
+					'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
 			},
 		},
 		defaultVariants: {

--- a/libs/helm/sheet/src/lib/hlm-sheet-overlay.ts
+++ b/libs/helm/sheet/src/lib/hlm-sheet-overlay.ts
@@ -14,7 +14,7 @@ export class HlmSheetOverlay {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+			'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 bg-black/50',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/skeleton/src/lib/hlm-skeleton.ts
+++ b/libs/helm/skeleton/src/lib/hlm-skeleton.ts
@@ -12,5 +12,5 @@ import type { ClassValue } from 'clsx';
 })
 export class HlmSkeleton {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected _computedClass = computed(() => hlm('block animate-pulse rounded-md bg-muted', this.userClass()));
+	protected _computedClass = computed(() => hlm('bg-muted block animate-pulse rounded-md', this.userClass()));
 }

--- a/libs/helm/spinner/src/lib/hlm-spinner.ts
+++ b/libs/helm/spinner/src/lib/hlm-spinner.ts
@@ -32,6 +32,6 @@ import type { ClassValue } from 'clsx';
 export class HlmSpinner {
 	public readonly userClass = input<ClassValue>('size-8', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('inline-block [&>svg]:text-foreground/30 [&>svg]:fill-accent', this.userClass()),
+		hlm('[&>svg]:text-foreground/30 [&>svg]:fill-accent inline-block', this.userClass()),
 	);
 }

--- a/libs/helm/switch/src/lib/hlm-switch-thumb.ts
+++ b/libs/helm/switch/src/lib/hlm-switch-thumb.ts
@@ -13,7 +13,7 @@ export class HlmSwitchThumb {
 
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'bg-background dark:group-data-[state=unchecked]:bg-foreground dark:group-data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform group-data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
+			'bg-background dark:group-data-[state=unchecked]:bg-foreground dark:group-data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=unchecked]:translate-x-0 group-data-[state=checked]:translate-x-[calc(100%-2px)]',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/switch/src/lib/hlm-switch.ts
+++ b/libs/helm/switch/src/lib/hlm-switch.ts
@@ -54,7 +54,7 @@ export class HlmSwitch implements ControlValueAccessor {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'group data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-50',
+			'data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 shadow-xs group inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent outline-none transition-all focus-visible:ring-[3px] data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-50',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/tabs/src/lib/hlm-tabs-content.ts
+++ b/libs/helm/tabs/src/lib/hlm-tabs-content.ts
@@ -16,7 +16,7 @@ export class HlmTabsContent {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+			'ring-offset-background focus-visible:ring-ring mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/tabs/src/lib/hlm-tabs-list.ts
+++ b/libs/helm/tabs/src/lib/hlm-tabs-list.ts
@@ -5,12 +5,12 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
 
 export const listVariants = cva(
-	'inline-flex h-9 w-fit items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground',
+	'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
 	{
 		variants: {
 			orientation: {
 				horizontal: 'h-10 space-x-1',
-				vertical: 'mt-2 flex-col h-fit space-y-1',
+				vertical: 'mt-2 h-fit flex-col space-y-1',
 			},
 		},
 		defaultVariants: {

--- a/libs/helm/tabs/src/lib/hlm-tabs-paginated-list.ts
+++ b/libs/helm/tabs/src/lib/hlm-tabs-paginated-list.ts
@@ -84,7 +84,7 @@ export class HlmTabsPaginatedList extends BrnTabsPaginatedList {
 
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
-		hlm('flex overflow-hidden relative gap-1 flex-shrink-0', this.userClass()),
+		hlm('relative flex flex-shrink-0 gap-1 overflow-hidden', this.userClass()),
 	);
 
 	public readonly tabListClass = input<ClassValue>('', { alias: 'tabListClass' });

--- a/libs/helm/tabs/src/lib/hlm-tabs-trigger.ts
+++ b/libs/helm/tabs/src/lib/hlm-tabs-trigger.ts
@@ -15,7 +15,7 @@ export class HlmTabsTrigger {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_ng-icon]:pointer-events-none [&_ng-icon]:shrink-0 [&_ng-icon]:text-base',
+			'data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 text-sm font-medium transition-[color,box-shadow] focus-visible:outline-1 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_ng-icon]:pointer-events-none [&_ng-icon]:shrink-0 [&_ng-icon]:text-base',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/toggle-group/src/lib/hlm-toggle-group.ts
+++ b/libs/helm/toggle-group/src/lib/hlm-toggle-group.ts
@@ -21,7 +21,7 @@ export class HlmToggleGroup {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'group/toggle-group flex w-fit items-center rounded-md data-[variant=outline]:shadow-xs focus:[&>[hlm][brnToggle]]:z-10',
+			'group/toggle-group data-[variant=outline]:shadow-xs flex w-fit items-center rounded-md focus:[&>[hlm][brnToggle]]:z-10',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/toggle-group/src/lib/hlm-toggle-item.ts
+++ b/libs/helm/toggle-group/src/lib/hlm-toggle-item.ts
@@ -5,17 +5,17 @@ import type { ClassValue } from 'clsx';
 import { injectHlmToggleGroup } from './hlm-toggle-group.token';
 
 export const toggleGroupItemVariants = cva(
-	'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_ng-icon]:pointer-events-none [&_ng-icon]:text-base [&_ng-icon]:shrink-0 gap-2',
+	'ring-offset-background hover:bg-muted hover:text-muted-foreground focus-visible:ring-ring data-[state=on]:bg-accent data-[state=on]:text-accent-foreground inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_ng-icon]:pointer-events-none [&_ng-icon]:shrink-0 [&_ng-icon]:text-base',
 	{
 		variants: {
 			variant: {
 				default: 'bg-transparent',
-				outline: 'border border-input bg-transparent hover:bg-accent hover:text-accent-foreground',
+				outline: 'border-input hover:bg-accent hover:text-accent-foreground border bg-transparent',
 			},
 			size: {
-				default: 'h-10 px-3 min-w-10',
-				sm: 'h-9 px-2 min-w-9',
-				lg: 'h-11 px-5 min-w-11',
+				default: 'h-10 min-w-10 px-3',
+				sm: 'h-9 min-w-9 px-2',
+				lg: 'h-11 min-w-11 px-5',
 			},
 		},
 		defaultVariants: {

--- a/libs/helm/toggle/src/lib/hlm-toggle.ts
+++ b/libs/helm/toggle/src/lib/hlm-toggle.ts
@@ -4,12 +4,12 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import type { ClassValue } from 'clsx';
 
 export const toggleVariants = cva(
-	'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground',
+	'ring-offset-background hover:bg-muted hover:text-muted-foreground focus-visible:ring-ring data-[state=on]:bg-accent data-[state=on]:text-accent-foreground inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
 	{
 		variants: {
 			variant: {
 				default: 'bg-transparent',
-				outline: 'border border-input bg-transparent hover:bg-accent hover:text-accent-foreground',
+				outline: 'border-input hover:bg-accent hover:text-accent-foreground border bg-transparent',
 			},
 			size: {
 				default: 'h-9 px-3',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #825 

## What is the new behavior?

Adds `"tailwindFunctions": ["hlm", "cva"]` to `.prettierrc` to sort hlm and cva functions. I didn't format all the components, maybe we could do that per component, to avoid a large PR.

Add a section to the installation docs about the sorting.

<img width="888" height="374" alt="CleanShot 2025-08-20 at 12 39 40" src="https://github.com/user-attachments/assets/a728401d-14ee-4e10-98d5-348e34f8a2d5" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
