### PR TITLE
fix: include color scheme in cli ui-theme

### DIFF
--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
@@ -146,7 +146,10 @@ module.exports = {
 				class="mb-6 mt-4"
 				code="
 :root {
-	--font-sans: 'Geist Sans', sans-serif;
+  color-scheme: light;
+  
+  --font-sans: 'Geist Sans', sans-serif;
+  
   --background: 0 0% 100%;
   --foreground: 240 10% 3.9%;
   --card: 0 0% 100%;
@@ -167,10 +170,11 @@ module.exports = {
   --input: 240 5.9% 90%;
   --ring: 240 5.9% 10%;
   --radius: 0.5rem;
-  color-scheme: light;
 }
 
-.dark {
+:root.dark {
+  color-scheme: dark;
+
   --background: 240 10% 3.9%;
   --foreground: 0 0% 98%;
   --card: 240 10% 3.9%;
@@ -190,7 +194,6 @@ module.exports = {
   --border: 240 3.7% 15.9%;
   --input: 240 3.7% 15.9%;
   --ring: 240 4.9% 83.9%;
-  color-scheme: dark;
 }
 
 @layer base {

--- a/apps/app/src/styles.css
+++ b/apps/app/src/styles.css
@@ -6,9 +6,6 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-	--font-sans: 'Geist Sans', sans-serif;
-}
 
 select {
 	background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
@@ -22,6 +19,10 @@ select {
 }
 
 :root {
+	color-scheme: light;
+
+	--font-sans: 'Geist Sans', sans-serif;
+
 	--background: 0deg 0% 100%;
 	--foreground: 0deg 0.02% 3.94%;
 	--card: 0deg 0% 100%;
@@ -47,6 +48,8 @@ select {
 }
 
 :root.dark {
+	color-scheme: dark;
+
 	--background: 0deg 0.02% 3.94%;
 	--foreground: 0deg 0.5% 98.03%;
 	--card: 0deg 0.02% 9.06%;

--- a/libs/cli/src/generators/theme/__snapshots__/generator.spec.ts.snap
+++ b/libs/cli/src/generators/theme/__snapshots__/generator.spec.ts.snap
@@ -11,10 +11,10 @@ exports[`Theme generator Tailwind v3 should add the gray theme styles to the glo
 
 
 :root {
---font-sans: ''
-}
+color-scheme: light;
 
-:root {
+--font-sans: ''
+
 --background: 0deg 0% 100%;
 --foreground: 224.06deg 72.27% 4.17%;
 --card: 0deg 0% 100%;
@@ -37,6 +37,8 @@ exports[`Theme generator Tailwind v3 should add the gray theme styles to the glo
 }
 
 :root.dark {
+color-scheme: dark;
+
 --background: 224.06deg 72.27% 4.17%;
 --foreground: 344.54deg 18.99% 98.19%;
 --card: 220.99deg 41.69% 11.07%;
@@ -75,10 +77,10 @@ exports[`Theme generator Tailwind v3 should add the neutral theme styles to the 
 
 
 :root {
---font-sans: ''
-}
+color-scheme: light;
 
-:root {
+--font-sans: ''
+
 --background: 0deg 0% 100%;
 --foreground: 0deg 0.02% 3.94%;
 --card: 0deg 0% 100%;
@@ -101,6 +103,8 @@ exports[`Theme generator Tailwind v3 should add the neutral theme styles to the 
 }
 
 :root.dark {
+color-scheme: dark;
+
 --background: 0deg 0.02% 3.94%;
 --foreground: 0deg 0.5% 98.03%;
 --card: 0deg 0.02% 9.06%;
@@ -139,10 +143,10 @@ exports[`Theme generator Tailwind v3 should add the slate theme styles to the gl
 
 
 :root {
---font-sans: ''
-}
+color-scheme: light;
 
-:root {
+--font-sans: ''
+
 --background: 0deg 0% 100%;
 --foreground: 228.82deg 85.15% 5%;
 --card: 0deg 0% 100%;
@@ -165,6 +169,8 @@ exports[`Theme generator Tailwind v3 should add the slate theme styles to the gl
 }
 
 :root.dark {
+color-scheme: dark;
+
 --background: 228.82deg 85.15% 5%;
 --foreground: 344.69deg 27.87% 98.13%;
 --card: 222.33deg 49.39% 11.3%;
@@ -203,10 +209,10 @@ exports[`Theme generator Tailwind v3 should add the stone theme styles to the gl
 
 
 :root {
---font-sans: ''
-}
+color-scheme: light;
 
-:root {
+--font-sans: ''
+
 --background: 0deg 0% 100%;
 --foreground: 344.17deg 10.1% 4.29%;
 --card: 0deg 0% 100%;
@@ -229,6 +235,8 @@ exports[`Theme generator Tailwind v3 should add the stone theme styles to the gl
 }
 
 :root.dark {
+color-scheme: dark;
+
 --background: 344.17deg 10.1% 4.29%;
 --foreground: 344deg 8.87% 98.11%;
 --card: 344.37deg 6.88% 10.34%;
@@ -266,10 +274,10 @@ exports[`Theme generator Tailwind v3 should add the zinc theme styles to the glo
 
 
 :root {
---font-sans: ''
-}
+color-scheme: light;
 
-:root {
+--font-sans: ''
+
 --background: 0deg 0% 100%;
 --foreground: 344.97deg 13.46% 3.85%;
 --card: 0deg 0% 100%;
@@ -292,6 +300,8 @@ exports[`Theme generator Tailwind v3 should add the zinc theme styles to the glo
 }
 
 :root.dark {
+color-scheme: dark;
+
 --background: 344.97deg 13.46% 3.85%;
 --foreground: 0deg 0.5% 98.03%;
 --card: 344.35deg 7.21% 9.8%;
@@ -326,10 +336,10 @@ exports[`Theme generator Tailwind v4 should add the gray theme styles to the glo
 @import "@spartan-ng/brain/hlm-tailwind-preset.css";
 
 :root {
---font-sans: ''
-}
+color-scheme: light;
 
-:root {
+--font-sans: ''
+
 --background: oklch(1 0 0);
 --foreground: oklch(0.13 0.028 261.692);
 --card: oklch(1 0 0);
@@ -352,6 +362,8 @@ exports[`Theme generator Tailwind v4 should add the gray theme styles to the glo
 }
 
 :root.dark {
+color-scheme: dark;
+
 --background: oklch(0.13 0.028 261.692);
 --foreground: oklch(0.985 0.002 247.839);
 --card: oklch(0.21 0.034 264.665);
@@ -386,10 +398,10 @@ exports[`Theme generator Tailwind v4 should add the neutral theme styles to the 
 @import "@spartan-ng/brain/hlm-tailwind-preset.css";
 
 :root {
---font-sans: ''
-}
+color-scheme: light;
 
-:root {
+--font-sans: ''
+
 --background: oklch(1 0 0);
 --foreground: oklch(0.145 0 0);
 --card: oklch(1 0 0);
@@ -412,6 +424,8 @@ exports[`Theme generator Tailwind v4 should add the neutral theme styles to the 
 }
 
 :root.dark {
+color-scheme: dark;
+
 --background: oklch(0.145 0 0);
 --foreground: oklch(0.985 0 0);
 --card: oklch(0.205 0 0);
@@ -446,10 +460,10 @@ exports[`Theme generator Tailwind v4 should add the slate theme styles to the gl
 @import "@spartan-ng/brain/hlm-tailwind-preset.css";
 
 :root {
---font-sans: ''
-}
+color-scheme: light;
 
-:root {
+--font-sans: ''
+
 --background: oklch(1 0 0);
 --foreground: oklch(0.129 0.042 264.695);
 --card: oklch(1 0 0);
@@ -472,6 +486,8 @@ exports[`Theme generator Tailwind v4 should add the slate theme styles to the gl
 }
 
 :root.dark {
+color-scheme: dark;
+
 --background: oklch(0.129 0.042 264.695);
 --foreground: oklch(0.984 0.003 247.858);
 --card: oklch(0.208 0.042 265.755);
@@ -506,10 +522,10 @@ exports[`Theme generator Tailwind v4 should add the stone theme styles to the gl
 @import "@spartan-ng/brain/hlm-tailwind-preset.css";
 
 :root {
---font-sans: ''
-}
+color-scheme: light;
 
-:root {
+--font-sans: ''
+
 --background: oklch(1 0 0);
 --foreground: oklch(0.147 0.004 49.25);
 --card: oklch(1 0 0);
@@ -532,6 +548,8 @@ exports[`Theme generator Tailwind v4 should add the stone theme styles to the gl
 }
 
 :root.dark {
+color-scheme: dark;
+
 --background: oklch(0.147 0.004 49.25);
 --foreground: oklch(0.985 0.001 106.423);
 --card: oklch(0.216 0.006 56.043);
@@ -566,10 +584,10 @@ exports[`Theme generator Tailwind v4 should add the zinc theme styles to the glo
 @import "@spartan-ng/brain/hlm-tailwind-preset.css";
 
 :root {
---font-sans: ''
-}
+color-scheme: light;
 
-:root {
+--font-sans: ''
+
 --background: oklch(1 0 0);
 --foreground: oklch(0.141 0.005 285.823);
 --card: oklch(1 0 0);
@@ -592,6 +610,8 @@ exports[`Theme generator Tailwind v4 should add the zinc theme styles to the glo
 }
 
 :root.dark {
+color-scheme: dark;
+
 --background: oklch(0.141 0.005 285.823);
 --foreground: oklch(0.985 0 0);
 --card: oklch(0.21 0.006 285.885);

--- a/libs/cli/src/generators/theme/libs/add-theme-to-application-styles.ts
+++ b/libs/cli/src/generators/theme/libs/add-theme-to-application-styles.ts
@@ -54,11 +54,7 @@ export function addThemeToApplicationStyles(
 	const CDK_IMPORT = `@import '@angular/cdk/overlay-prebuilt.css';`;
 	const ckdOverlayImport = stylesEntryPointContent.includes(CDK_IMPORT) ? '' : CDK_IMPORT;
 
-	const rootFontSans = stylesEntryPointContent.includes('--font-sans')
-		? ''
-		: `:root {
-     --font-sans: ''
-     }`;
+	const fontSans = stylesEntryPointContent.includes('--font-sans') ? '' : `--font-sans: ''`;
 
 	const colorScheme = tailwindVersion === 4 ? themes[options.theme].cssVarsV4 : themes[options.theme].cssVarsV3;
 
@@ -70,15 +66,19 @@ export function addThemeToApplicationStyles(
     ${stylesEntryPointContent}
     ${tailwindImport}
 
-    ${rootFontSans}
-
 		:root${prefix} {
+			color-scheme: light;
+
+			${fontSans}
+
 			${Object.entries(colorScheme.light)
 				.map(([key, value]) => `--${key}: ${value};`)
 				.join('\n')}
 		}
 
 		:root.dark${prefix} {
+			color-scheme: dark;
+			
 			${Object.entries(colorScheme.dark)
 				.map(([key, value]) => `--${key}: ${value};`)
 				.join('\n')}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [x] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

1. `color-scheme: light;` and `color-scheme: dark;` is part of the installation style snippet, but is not included when running `npx nx g @spartan-ng/cli:ui-theme`.
2. `color-scheme: light;` and `color-scheme: dark;` is not used in the spartan docs app, thus scrollbars don't change colors in dark mode (https://github.com/spartan-ng/spartan/pull/853#issuecomment-3237164134)

## What is the new behavior?

Include `color-scheme: light;` and `color-scheme: dark;` in `npx nx g @spartan-ng/cli:ui-theme` and the spartan docs. Change the order of css in the installation guide

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
