### PR TITLE
docs(sidebar): fix bottom navigation

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(sheet)/sheet.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(sheet)/sheet.page.ts
@@ -111,7 +111,7 @@ export const routeMeta: RouteMeta = {
 			</spartan-tabs>
 
 			<spartan-page-bottom-nav>
-				<spartan-page-bottom-nav-link href="skeleton" label="Skeleton" />
+				<spartan-page-bottom-nav-link href="sidebar" label="Sidebar" />
 				<spartan-page-bottom-nav-link direction="previous" href="separator" label="Separator" />
 			</spartan-page-bottom-nav>
 		</section>

--- a/apps/app/src/app/pages/(components)/components/(sidebar)/sidebar.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(sidebar)/sidebar.page.ts
@@ -754,8 +754,8 @@ export const routeMeta: RouteMeta = {
 				</p>
 
 				<spartan-page-bottom-nav>
-					<spartan-page-bottom-nav-link href="alert" label="Alert" />
-					<spartan-page-bottom-nav-placeholder />
+					<spartan-page-bottom-nav-link href="skeleton" label="Skeleton" />
+					<spartan-page-bottom-nav-link direction="previous" href="sheet" label="Sheet" />
 				</spartan-page-bottom-nav>
 			</div>
 		</section>

--- a/apps/app/src/app/pages/(components)/components/(skeleton)/skeleton.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(skeleton)/skeleton.page.ts
@@ -78,7 +78,7 @@ export const routeMeta: RouteMeta = {
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="slider" label="Slider" />
-				<spartan-page-bottom-nav-link direction="previous" href="sheet" label="Sheet" />
+				<spartan-page-bottom-nav-link direction="previous" href="sidebar" label="Sidebar" />
 			</spartan-page-bottom-nav>
 		</section>
 		<spartan-page-nav />


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [x] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

The sidebar page only has a next navigation to alert.
The sheet page skips the sidebar.
The skeleton skips the sidebar for previous.

Closes #

## What is the new behavior?

The navigation is set for the mentioned pages according to menu order

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
