### PR TITLE
Fix module import check untouched

### DIFF
--- a/libs/cli/src/generators/migrate-module-imports/generator.ts
+++ b/libs/cli/src/generators/migrate-module-imports/generator.ts
@@ -58,7 +58,7 @@ function replaceUsages(tree: Tree, oldPackageName: string, newPackageName: strin
 function deduplicateImports(tree: Tree) {
 	const changedFiles = tree
 		.listChanges()
-		// 'CREATE' should never occur but is needed for testing
+		// 'CREATE' is needed for testing
 		.filter((change) => change.type === 'CREATE' || change.type === 'UPDATE')
 		.map((change) => change.path);
 

--- a/libs/cli/src/generators/migrate-module-imports/generator.ts
+++ b/libs/cli/src/generators/migrate-module-imports/generator.ts
@@ -56,7 +56,13 @@ function replaceUsages(tree: Tree, oldPackageName: string, newPackageName: strin
 }
 
 function deduplicateImports(tree: Tree) {
-	visitNotIgnoredFiles(tree, '.', (path) => {
+	const changedFiles = tree
+		.listChanges()
+		// 'CREATE' should never occur but is needed for testing
+		.filter((change) => change.type === 'CREATE' || change.type === 'UPDATE')
+		.map((change) => change.path);
+
+	changedFiles.forEach((path) => {
 		if (isBinaryPath(path)) return;
 
 		try {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [x] cli

## What is the current behavior?

All files are scanned and the imports are reordered because of the deduplicate method.
This happens in the module import Healthcheck although the file does not even use module imports. 

Closes #904 

## What is the new behavior?

The generator now only deduplicates imports for the files that it changed before. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
