### PR TITLE
feat: autocomplete transform option to string

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(autocomplete)/autocomplete--config.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(autocomplete)/autocomplete--config.example.ts
@@ -9,22 +9,20 @@ type Country = {
 };
 
 @Component({
-	selector: 'spartan-autocomplete-countries',
+	selector: 'spartan-autocomplete-config',
 	imports: [HlmAutocompleteImports],
 	template: `
-		<hlm-autocomplete [filteredOptions]="filteredCountries()" [optionTemplate]="option" [(search)]="search" />
-
-		<!-- custom option template with access to the option item -->
-		<ng-template #option let-option>{{ option.flag }} {{ option.name }}</ng-template>
+		<hlm-autocomplete [filteredOptions]="filteredCountries()" [(search)]="search" />
 	`,
 	providers: [
 		provideHlmAutocompleteConfig({
+			transformOptionToString: (option: Country) => `${option.flag} ${option.name}`,
 			transformValueToSearch: (option: Country) => `${option.flag} ${option.name}`,
 		}),
 	],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AutocompleteCountries {
+export class AutocompleteConfig {
 	private readonly _countries: Country[] = [
 		{ name: 'Argentina', code: 'AR', flag: '🇦🇷' },
 		{ name: 'Australia', code: 'AU', flag: '🇦🇺' },

--- a/apps/app/src/app/pages/(components)/components/(autocomplete)/autocomplete.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(autocomplete)/autocomplete.page.ts
@@ -1,6 +1,6 @@
 import type { RouteMeta } from '@analogjs/router';
 import { Component, computed, inject } from '@angular/core';
-import { hlmH4, hlmP } from '@spartan-ng/helm/typography';
+import { hlmCode, hlmH4, hlmP, hlmUl } from '@spartan-ng/helm/typography';
 import { Code } from '../../../../shared/code/code';
 import { CodePreview } from '../../../../shared/code/code-preview';
 import { MainSection } from '../../../../shared/layout/main-section';
@@ -17,6 +17,7 @@ import { UIApiDocs } from '@spartan-ng/app/app/shared/layout/ui-docs-section/ui-
 import { Tabs } from '../../../../shared/layout/tabs';
 import { metaWith } from '../../../../shared/meta/meta.util';
 import { AutocompleteAsync } from './autocomplete--async.example';
+import { AutocompleteConfig } from './autocomplete--config.example';
 import { AutocompleteCountries } from './autocomplete--countries.example';
 import { AutocompleteForm } from './autocomplete--form.example';
 import { AutocompletePreview, defaultImports, defaultSkeleton } from './autocomplete.preview';
@@ -45,6 +46,7 @@ export const routeMeta: RouteMeta = {
 		AutocompleteAsync,
 		AutocompleteForm,
 		AutocompleteCountries,
+		AutocompleteConfig,
 	],
 	template: `
 		<section spartanMainSection>
@@ -88,7 +90,60 @@ export const routeMeta: RouteMeta = {
 			<spartan-ui-api-docs docType="helm" />
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 id="examples__objects" class="${hlmH4} mb-2 mt-6">Objects</h3>
+			<h3 id="examples__custom_config" class="${hlmH4} mb-2 mt-6">Custom Config</h3>
+
+			<p class="${hlmP}">
+				Use
+				<code class="${hlmCode}">provideHlmAutocompleteConfig</code>
+				to define custom configurations for the autocomplete component. This is especially useful when the
+				autocomplete's
+				<code class="${hlmCode}">filteredOptions</code>
+				contain objects rather than plain strings.
+			</p>
+			<ul class="${hlmUl}">
+				<li>
+					<code class="${hlmCode}">transformOptionToString: (option: T) => string;</code>
+					defines how an option should be transformed into the string displayed in the dropdown list.
+				</li>
+				<li>
+					<code class="${hlmCode}">transformValueToSearch: (option: T) => string;</code>
+					defines how the selected option should be transformed into the string written to the search input.
+				</li>
+			</ul>
+
+			<p class="${hlmP}">
+				You can customize a specific instance of
+				<code class="${hlmCode}">hlm-autocomplete</code>
+				by passing
+				<code class="${hlmCode}">transformOptionToString</code>
+				and
+				<code class="${hlmCode}">transformValueToSearch</code>
+				directly as inputs. This allows you to modify the behavior for just that instance, without affecting all
+				autocompletes configured via
+				<code class="${hlmCode}">provideHlmAutocompleteConfig</code>
+				.
+			</p>
+
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-autocomplete-config />
+				</div>
+				<spartan-code secondTab [code]="_configCode()" />
+			</spartan-tabs>
+
+			<h3 id="examples__custom_option_template" class="${hlmH4} mb-2 mt-6">Custom Option Template</h3>
+
+			<p class="${hlmP} mb-6">
+				You can customize the rendering of each option in the dropdown list by using the
+				<code class="${hlmCode}">ng-template</code>
+				with the
+				<code class="${hlmCode}">optionTemplate</code>
+				input. This is especially useful when
+				<code class="${hlmCode}">filteredOptions</code>
+				are objects instead of simple strings, or when you want to display additional content such as icons,
+				descriptions, or custom formatting alongside the option text.
+			</p>
+
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-autocomplete-countries />
@@ -124,6 +179,7 @@ export default class AutocompletePage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('autocomplete');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
 	protected readonly _countriesCode = computed(() => this._snippets()['countries']);
+	protected readonly _configCode = computed(() => this._snippets()['config']);
 	protected readonly _asyncCode = computed(() => this._snippets()['async']);
 	protected readonly _formCode = computed(() => this._snippets()['form']);
 	protected readonly _defaultImports = defaultImports;

--- a/libs/helm/autocomplete/src/lib/hlm-autocomplete.token.ts
+++ b/libs/helm/autocomplete/src/lib/hlm-autocomplete.token.ts
@@ -1,14 +1,16 @@
 import { inject, InjectionToken, type ValueProvider } from '@angular/core';
 
-export type TransformValueToString<T> = (value: T) => string;
+export type TransformValueToString<T> = (option: T) => string;
 
 export interface HlmAutocompleteConfig<T> {
 	transformValueToSearch: TransformValueToString<T>;
+	transformOptionToString: TransformValueToString<T>;
 }
 
 function getDefaultConfig<T>(): HlmAutocompleteConfig<T> {
 	return {
-		transformValueToSearch: (value: T) => (typeof value === 'string' ? value : String(value)),
+		transformValueToSearch: (option: T) => (typeof option === 'string' ? option : String(option)),
+		transformOptionToString: (option: T) => (typeof option === 'string' ? option : String(option)),
 	};
 }
 

--- a/libs/helm/autocomplete/src/lib/hlm-autocomplete.ts
+++ b/libs/helm/autocomplete/src/lib/hlm-autocomplete.ts
@@ -115,7 +115,7 @@ export const HLM_AUTOCOMPLETE_VALUE_ACCESSOR = {
 									@if (optionTemplate(); as optionTemplate) {
 										<ng-container *ngTemplateOutlet="optionTemplate; context: { $implicit: option }" />
 									} @else {
-										{{ option }}
+										{{ transformOptionToString()(option) }}
 									}
 								</button>
 							}
@@ -171,7 +171,10 @@ export class HlmAutocomplete<T> implements ControlValueAccessor {
 	protected readonly _search = linkedSignal(() => this.search() || '');
 
 	/** Function to transform an option value to a search string. Defaults to identity function for strings. */
-	public readonly transformValueToSearch = input<(value: T) => string>(this._config.transformValueToSearch);
+	public readonly transformValueToSearch = input<(option: T) => string>(this._config.transformValueToSearch);
+
+	/** Function to transform an option value to a display string. Defaults to identity function for strings. */
+	public readonly transformOptionToString = input<(option: T) => string>(this._config.transformOptionToString);
 
 	/** Optional template for rendering each option. */
 	public readonly optionTemplate = input<TemplateRef<HlmAutocompleteOption<T>>>();
@@ -281,6 +284,6 @@ export class HlmAutocomplete<T> implements ControlValueAccessor {
 	}
 }
 
-interface HlmAutocompleteOption<T> {
+export interface HlmAutocompleteOption<T> {
 	$implicit: T;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [x] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The option value is displayed assuming a string value. When a object is used in the `filteredOptions` it can be customized with an `optionTemplate`.

## What is the new behavior?

Adding `transformOptionToString` to allow for simple transformation to avoid the custom `optionTemplate`. The custom `optionTemplate` is still available for further customizations like adding icons, descriptions of formatting.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
