### PR TITLE
fix(autocomplete): fix failing tests, add functionality for tabbing out

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/autocomplete/autocomplete.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/autocomplete/autocomplete.cy.ts
@@ -12,14 +12,30 @@ describe('autocomplete', () => {
 
 		it('should show options when typing', () => {
 			cy.get('input[hlmInputGroupInput]').type('Mar');
-			cy.get('hlm-autocomplete-list').should('exist');
-			cy.get('button[hlm-autocomplete-item]').should('have.length.gt', 0);
-			cy.get('button[hlm-autocomplete-item]').first().should('contain.text', 'Marty McFly');
+			cy.get('[hlmAutocompleteList]').should('exist');
+			cy.get('hlm-autocomplete-item').should('have.length.gt', 0);
+			cy.get('hlm-autocomplete-item').first().should('contain.text', 'Marty McFly');
 		});
 
 		it('should select an option', () => {
 			cy.get('input[hlmInputGroupInput]').type('Mar');
-			cy.get('button[hlm-autocomplete-item]').first().click();
+			cy.get('hlm-autocomplete-item').first().click();
+			cy.get('input[hlmInputGroupInput]').should('have.value', 'Marty McFly');
+		});
+
+		it('should close popup when tabbing out', () => {
+			cy.get('input[hlmInputGroupInput]').type('Mar');
+			cy.get('hlm-autocomplete-content').should('exist');
+			cy.get('input[hlmInputGroupInput]').realPress('Tab');
+			cy.get('hlm-autocomplete-content').should('not.exist');
+		});
+
+		it('should select highlighted option on tab out', () => {
+			cy.get('input[hlmInputGroupInput]').type('Mar');
+			cy.get('hlm-autocomplete-item').should('have.length.gt', 1);
+			cy.get('input[hlmInputGroupInput]').realPress('ArrowDown');
+			cy.get('input[hlmInputGroupInput]').realPress('Tab');
+			cy.get('hlm-autocomplete-content').should('not.exist');
 			cy.get('input[hlmInputGroupInput]').should('have.value', 'Marty McFly');
 		});
 
@@ -43,7 +59,7 @@ describe('autocomplete', () => {
 			cy.get('form').should('exist');
 			cy.get('input[hlmInputGroupInput]').clear();
 			cy.get('input[hlmInputGroupInput]').type('Doc');
-			cy.get('button[hlm-autocomplete-item]').contains('Doc Brown').click();
+			cy.get('hlm-autocomplete-item').contains('Doc Brown').click();
 			cy.get('input[hlmInputGroupInput]').should('have.value', 'Doc Brown');
 		});
 	});
@@ -56,7 +72,7 @@ describe('autocomplete', () => {
 
 		it('should show loading state', () => {
 			cy.get('input[hlmInputGroupInput]').type('test');
-			cy.get('button[hlm-autocomplete-item]').should('have.length.gt', 0);
+			cy.get('hlm-autocomplete-item').should('have.length.gt', 0);
 		});
 	});
 });

--- a/libs/brain/autocomplete/src/lib/brn-autocomplete-input.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete-input.ts
@@ -63,6 +63,11 @@ export class BrnAutocompleteInput<T> {
 			this._autocomplete.selectActiveItem();
 		}
 
+		if (event.key === 'Tab' && this._isExpanded()) {
+			this._autocomplete.selectActiveItem();
+			return;
+		}
+
 		if (!this._isExpanded()) {
 			if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
 				this._autocomplete.open();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [x] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

The e2e Tests are failing because there was a refactoring to the autocomplete component. 
I guess there must have been some merge problems or confusion. 

Additionally the autocomplete does not close when pressing tab. 

Closes #1205 

## What is the new behavior?

The Stories have been rewritten to match the implementation. 
e2e Tests compile and run for autocomplete.

When pressing tab, the popup closes, if a value was marked with arrow down, this value is used.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Some other e2e tests seem to fail, but this should nothing have to do with these changes. Maybe its only on my machine. 