### PR TITLE
refactor(slider): polish for v1

### DIFF
--- a/libs/brain/slider/src/index.ts
+++ b/libs/brain/slider/src/index.ts
@@ -10,5 +10,6 @@ export * from './lib/brn-slider-thumb';
 export * from './lib/brn-slider-tick';
 export * from './lib/brn-slider-track';
 export * from './lib/brn-slider.token';
+export * from './lib/brn-slider-track.token';
 
 export const BrnSliderImports = [BrnSlider, BrnSliderTrack, BrnSliderThumb, BrnSliderRange, BrnSliderTick] as const;

--- a/libs/brain/slider/src/index.ts
+++ b/libs/brain/slider/src/index.ts
@@ -9,7 +9,7 @@ export * from './lib/brn-slider-range';
 export * from './lib/brn-slider-thumb';
 export * from './lib/brn-slider-tick';
 export * from './lib/brn-slider-track';
-export * from './lib/brn-slider.token';
 export * from './lib/brn-slider-track.token';
+export * from './lib/brn-slider.token';
 
 export const BrnSliderImports = [BrnSlider, BrnSliderTrack, BrnSliderThumb, BrnSliderRange, BrnSliderTick] as const;

--- a/libs/brain/slider/src/lib/__tests__/brn-slider-accessibility.spec.ts
+++ b/libs/brain/slider/src/lib/__tests__/brn-slider-accessibility.spec.ts
@@ -1,0 +1,78 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { render } from '@testing-library/angular';
+import { BrnSlider, BrnSliderRange, BrnSliderThumb, BrnSliderTrack } from '../../index';
+
+@Component({
+	imports: [BrnSlider, BrnSliderThumb, BrnSliderTrack, BrnSliderRange],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<label id="volume-label">Volume</label>
+		<div brnSlider aria-labelledby="volume-label" [value]="[50]">
+			<div brnSliderTrack>
+				<div brnSliderRange></div>
+			</div>
+			<span brnSliderThumb></span>
+		</div>
+	`,
+})
+class SliderWithAriaLabelledby {}
+
+@Component({
+	imports: [BrnSlider, BrnSliderThumb, BrnSliderTrack, BrnSliderRange],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div brnSlider aria-label="Volume" [value]="[50]">
+			<div brnSliderTrack>
+				<div brnSliderRange></div>
+			</div>
+			<span brnSliderThumb></span>
+		</div>
+	`,
+})
+class SliderWithAriaLabel {}
+
+@Component({
+	imports: [BrnSlider, BrnSliderThumb, BrnSliderTrack, BrnSliderRange],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div brnSlider [value]="[25, 75]">
+			<div brnSliderTrack>
+				<div brnSliderRange></div>
+			</div>
+			<span brnSliderThumb></span>
+			<span brnSliderThumb></span>
+		</div>
+	`,
+})
+class SliderWithDefaultAriaLabels {}
+
+describe('Slider Accessibility', () => {
+	it('should forward aria-labelledby from slider to thumb', async () => {
+		const { container } = await render(SliderWithAriaLabelledby);
+		const thumb = container.querySelector('[role="slider"]') as HTMLElement;
+
+		expect(thumb.getAttribute('aria-labelledby')).toBe('volume-label');
+	});
+
+	it('should forward aria-label from slider to thumb', async () => {
+		const { container } = await render(SliderWithAriaLabel);
+		const thumb = container.querySelector('[role="slider"]') as HTMLElement;
+
+		expect(thumb.getAttribute('aria-label')).toBe('Volume');
+	});
+
+	it('should generate default positional aria-labels for multiple thumbs', async () => {
+		const { container } = await render(SliderWithDefaultAriaLabels);
+		const thumbs = container.querySelectorAll('[role="slider"]');
+
+		expect(thumbs[0].getAttribute('aria-label')).toBe('Value 1 of 2');
+		expect(thumbs[1].getAttribute('aria-label')).toBe('Value 2 of 2');
+	});
+
+	it('should not set aria-labelledby when not provided', async () => {
+		const { container } = await render(SliderWithDefaultAriaLabels);
+		const thumb = container.querySelector('[role="slider"]') as HTMLElement;
+
+		expect(thumb.getAttribute('aria-labelledby')).toBeNull();
+	});
+});

--- a/libs/brain/slider/src/lib/__tests__/brn-slider-accessibility.spec.ts
+++ b/libs/brain/slider/src/lib/__tests__/brn-slider-accessibility.spec.ts
@@ -46,6 +46,26 @@ class SliderWithAriaLabel {}
 })
 class SliderWithDefaultAriaLabels {}
 
+@Component({
+	imports: [BrnSlider, BrnSliderThumb, BrnSliderTrack, BrnSliderRange],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div brnSlider [value]="[30]">
+			<div brnSliderTrack>
+				<div brnSliderRange></div>
+			</div>
+			<span brnSliderThumb></span>
+		</div>
+		<div brnSlider [value]="[70]">
+			<div brnSliderTrack>
+				<div brnSliderRange></div>
+			</div>
+			<span brnSliderThumb></span>
+		</div>
+	`,
+})
+class TwoSliders {}
+
 describe('Slider Accessibility', () => {
 	it('should forward aria-labelledby from slider to thumb', async () => {
 		const { container } = await render(SliderWithAriaLabelledby);
@@ -74,5 +94,16 @@ describe('Slider Accessibility', () => {
 		const thumb = container.querySelector('[role="slider"]') as HTMLElement;
 
 		expect(thumb.getAttribute('aria-labelledby')).toBeNull();
+	});
+
+	it('should generate unique IDs for multiple slider instances', async () => {
+		const { container } = await render(TwoSliders);
+		const sliders = container.querySelectorAll('[data-slot="slider"]');
+		const id1 = sliders[0].getAttribute('id');
+		const id2 = sliders[1].getAttribute('id');
+
+		expect(id1).toBeTruthy();
+		expect(id2).toBeTruthy();
+		expect(id1).not.toBe(id2);
 	});
 });

--- a/libs/brain/slider/src/lib/brn-slider-thumb.ts
+++ b/libs/brain/slider/src/lib/brn-slider-thumb.ts
@@ -10,7 +10,8 @@ const PAGE_KEYS = ['PageUp', 'PageDown'];
 	selector: '[brnSliderThumb]',
 	host: {
 		role: 'slider',
-		'[attr.aria-label]': `_ariaLabel()`,
+		'[attr.aria-label]': `_computedAriaLabel()`,
+		'[attr.aria-labelledby]': '_slider.ariaLabelledby() || null',
 		'[attr.aria-orientation]': '_slider.orientation()',
 		'[attr.aria-valuenow]': '_slider.normalizedValue()[_index()]',
 		'[attr.aria-valuemin]': '_slider.min()',
@@ -95,8 +96,8 @@ export class BrnSliderThumb {
 		return `calc(${this.percentage()}% + ${this._thumbInBoundsOffset()}px)`;
 	});
 
-	protected readonly _ariaLabel = computed(
-		() => `Value ${this._index() + 1} of ${this._slider.normalizedValue().length}`,
+	protected readonly _computedAriaLabel = computed(
+		() => this._slider.ariaLabel() || `Value ${this._index() + 1} of ${this._slider.normalizedValue().length}`,
 	);
 
 	protected readonly _transformValue = computed(() =>

--- a/libs/brain/slider/src/lib/brn-slider-tick.ts
+++ b/libs/brain/slider/src/lib/brn-slider-tick.ts
@@ -1,9 +1,9 @@
 import {
+	DestroyRef,
 	Directive,
 	effect,
 	type EmbeddedViewRef,
 	inject,
-	type OnDestroy,
 	Renderer2,
 	TemplateRef,
 	ViewContainerRef,
@@ -16,11 +16,12 @@ import { injectBrnSlider } from './brn-slider.token';
 		'data-slot': 'slider-tick',
 	},
 })
-export class BrnSliderTick implements OnDestroy {
+export class BrnSliderTick {
 	private readonly _slider = injectBrnSlider();
 	private readonly _templateRef = inject<TemplateRef<BrnSliderTickContext>>(TemplateRef);
 	private readonly _renderer = inject(Renderer2);
 	private readonly _viewContainer = inject(ViewContainerRef);
+	private readonly _destroyRef = inject(DestroyRef);
 	private _ticks: EmbeddedViewRef<BrnSliderTickContext>[] = [];
 
 	constructor() {
@@ -49,14 +50,14 @@ export class BrnSliderTick implements OnDestroy {
 				this._ticks.push(view);
 			});
 		});
-	}
 
-	ngOnDestroy(): void {
-		this._ticks.forEach((tick) => this._viewContainer.remove(this._viewContainer.indexOf(tick)));
+		this._destroyRef.onDestroy(() => {
+			this._ticks.forEach((tick) => this._viewContainer.remove(this._viewContainer.indexOf(tick)));
+		});
 	}
 }
 
-interface BrnSliderTickContext {
+export interface BrnSliderTickContext {
 	$implicit: number;
 	index: number;
 	formattedTick: string;

--- a/libs/brain/slider/src/lib/brn-slider.ts
+++ b/libs/brain/slider/src/lib/brn-slider.ts
@@ -22,6 +22,8 @@ import type { BrnSliderThumb } from './brn-slider-thumb';
 import type { BrnSliderTrack } from './brn-slider-track';
 import { provideBrnSlider } from './brn-slider.token';
 
+let nextId = 0;
+
 @Directive({
 	selector: '[brnSlider]',
 	exportAs: 'brnSlider',
@@ -34,6 +36,7 @@ import { provideBrnSlider } from './brn-slider.token';
 		},
 	],
 	host: {
+		'[attr.id]': 'id()',
 		'[attr.dir]': '_direction()',
 		'[attr.aria-disabled]': 'mutableDisabled() ? "true" : null',
 		'[attr.data-disabled]': 'mutableDisabled() ? "" : null',
@@ -47,6 +50,15 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 	private readonly _dir = inject(Directionality);
 	private readonly _injector = inject(Injector);
 	private _ngControl: NgControl | null = null;
+
+	/** Unique identifier for the slider element. Auto-generated if not provided. */
+	public readonly id = input<string>(`brn-slider-${++nextId}`);
+
+	/** Accessibility label for the slider. Forwarded to all thumbs. */
+	public readonly ariaLabel = input<string | null>(null, { alias: 'aria-label' });
+
+	/** ID of the element that labels this slider for accessibility. Forwarded to all thumbs. */
+	public readonly ariaLabelledby = input<string | null>(null, { alias: 'aria-labelledby' });
 
 	/**
 	 * The current slider value(s).
@@ -214,7 +226,6 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 			if (!this.value().length) {
 				const defaultValue = [this.min()];
 				this.value.set(defaultValue);
-				this.valueChange.emit(defaultValue);
 			}
 
 			const normalizedValue = this.value()
@@ -223,7 +234,6 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 
 			if (!areArrsEqual(normalizedValue, this.value())) {
 				this.value.set(normalizedValue);
-				this.valueChange.emit(normalizedValue);
 			}
 		}
 	}

--- a/libs/helm/slider/src/lib/hlm-slider.ts
+++ b/libs/helm/slider/src/lib/hlm-slider.ts
@@ -10,6 +10,7 @@ import { classes } from '@spartan-ng/helm/utils';
 		{
 			directive: BrnSlider,
 			inputs: [
+				'id',
 				'value',
 				'disabled',
 				'min',
@@ -24,6 +25,8 @@ import { classes } from '@spartan-ng/helm/utils';
 				'formatTick',
 				'draggableRange',
 				'draggableRangeOnly',
+				'aria-label',
+				'aria-labelledby',
 			],
 			outputs: ['valueChange'],
 		},

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -4684,6 +4684,21 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
         "exportAs": "brnSlider",
         "inputs": [
           {
+            "name": "id",
+            "required": false,
+            "type": "string",
+          },
+          {
+            "name": "aria-label",
+            "required": false,
+            "type": "string | null",
+          },
+          {
+            "name": "aria-labelledby",
+            "required": false,
+            "type": "string | null",
+          },
+          {
             "name": "min",
             "required": false,
             "type": "number",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [x] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

Aria Label cannot be set for thumb. 
Aria LabelledBy cannot be set for role slider 

## What is the new behavior?

Replaced ngOnDestroy with destroyRef
Added Input for Aria-Label and Labelledby


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The e2e tests for slider are green. need to rebase once the autocomplete PR is merged. 