### PR TITLE
feat(input-opt): add input OTP masking options on parent, group and slot

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--group-mask.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--group-mask.example.ts
@@ -67,7 +67,6 @@ export class InputOtpGroupMaskExample {
 
 	public maxLength = 12;
 
-	/** Overrides global formatDate  */
 	public transformPaste = (pastedText: string) => pastedText.replaceAll('-', '');
 
 	public form = this._formBuilder.group({

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--group-mask.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--group-mask.example.ts
@@ -1,0 +1,83 @@
+import { Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { BrnInputOtp } from '@spartan-ng/brain/input-otp';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmInputOtp, HlmInputOtpGroup, HlmInputOtpSeparator, HlmInputOtpSlot } from '@spartan-ng/helm/input-otp';
+import { HlmToaster } from '@spartan-ng/helm/sonner';
+import { toast } from 'ngx-sonner';
+
+@Component({
+	selector: 'spartan-input-otp-group-mask',
+	imports: [
+		ReactiveFormsModule,
+		HlmButton,
+		HlmToaster,
+		BrnInputOtp,
+		HlmInputOtp,
+		HlmInputOtpGroup,
+		HlmInputOtpSlot,
+		HlmInputOtpSeparator,
+	],
+	host: {
+		class: 'preview flex min-h-[350px] w-full justify-center p-10 items-center',
+	},
+	template: `
+		<hlm-toaster />
+
+		<form [formGroup]="form" (ngSubmit)="submit()" class="space-y-8">
+			<brn-input-otp
+				hlmInputOtp
+				[maxLength]="maxLength"
+				inputClass="disabled:cursor-not-allowed"
+				formControlName="otp"
+				[transformPaste]="transformPaste"
+				(completed)="submit()"
+				[mask]="true"
+			>
+				<div hlmInputOtpGroup [mask]="true">
+					<hlm-input-otp-slot index="0" />
+					<hlm-input-otp-slot index="1" />
+					<hlm-input-otp-slot index="2" />
+					<hlm-input-otp-slot index="3" />
+				</div>
+				<hlm-input-otp-separator />
+				<div hlmInputOtpGroup [mask]="true">
+					<hlm-input-otp-slot index="4" />
+					<hlm-input-otp-slot index="5" />
+					<hlm-input-otp-slot index="6" />
+					<hlm-input-otp-slot index="7" />
+				</div>
+				<hlm-input-otp-separator />
+				<div hlmInputOtpGroup [mask]="false">
+					<hlm-input-otp-slot index="8" />
+					<hlm-input-otp-slot index="9" />
+					<hlm-input-otp-slot index="10" />
+					<hlm-input-otp-slot index="11" />
+				</div>
+			</brn-input-otp>
+
+			<div class="flex flex-col gap-4">
+				<button type="submit" hlmBtn [disabled]="form.invalid">Submit</button>
+			</div>
+		</form>
+	`,
+})
+export class InputOtpGroupMaskExample {
+	private readonly _formBuilder = inject(FormBuilder);
+
+	public maxLength = 12;
+
+	/** Overrides global formatDate  */
+	public transformPaste = (pastedText: string) => pastedText.replaceAll('-', '');
+
+	public form = this._formBuilder.group({
+		otp: [null, [Validators.required, Validators.minLength(this.maxLength), Validators.maxLength(this.maxLength)]],
+	});
+
+	submit() {
+		console.log(this.form.value);
+		toast('OTP submitted', {
+			description: `Your OTP ${this.form.value.otp} has been submitted`,
+		});
+	}
+}

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--mask.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--mask.example.ts
@@ -1,0 +1,74 @@
+import { Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { BrnInputOtp } from '@spartan-ng/brain/input-otp';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmInputOtp, HlmInputOtpGroup, HlmInputOtpSeparator, HlmInputOtpSlot } from '@spartan-ng/helm/input-otp';
+import { HlmToaster } from '@spartan-ng/helm/sonner';
+import { toast } from 'ngx-sonner';
+
+@Component({
+	selector: 'spartan-input-otp-mask',
+	imports: [
+		ReactiveFormsModule,
+		HlmButton,
+		HlmToaster,
+		BrnInputOtp,
+		HlmInputOtp,
+		HlmInputOtpGroup,
+		HlmInputOtpSlot,
+		HlmInputOtpSeparator,
+	],
+	host: {
+		class: 'preview flex min-h-[350px] w-full justify-center p-10 items-center',
+	},
+	template: `
+		<hlm-toaster />
+
+		<form [formGroup]="form" (ngSubmit)="submit()" class="space-y-8">
+			<brn-input-otp
+				hlmInputOtp
+				[maxLength]="maxLength"
+				inputClass="disabled:cursor-not-allowed"
+				formControlName="otp"
+				[transformPaste]="transformPaste"
+				(completed)="submit()"
+				[mask]="true"
+			>
+				<div hlmInputOtpGroup>
+					<hlm-input-otp-slot index="0" />
+					<hlm-input-otp-slot index="1" />
+					<hlm-input-otp-slot index="2" />
+				</div>
+				<hlm-input-otp-separator />
+				<div hlmInputOtpGroup>
+					<hlm-input-otp-slot index="3" />
+					<hlm-input-otp-slot index="4" />
+					<hlm-input-otp-slot index="5" />
+				</div>
+			</brn-input-otp>
+
+			<div class="flex flex-col gap-4">
+				<button type="submit" hlmBtn [disabled]="form.invalid">Submit</button>
+			</div>
+		</form>
+	`,
+})
+export class InputOtpMaskExample {
+	private readonly _formBuilder = inject(FormBuilder);
+
+	public maxLength = 6;
+
+	/** Overrides global formatDate  */
+	public transformPaste = (pastedText: string) => pastedText.replaceAll('-', '');
+
+	public form = this._formBuilder.group({
+		otp: [null, [Validators.required, Validators.minLength(this.maxLength), Validators.maxLength(this.maxLength)]],
+	});
+
+	submit() {
+		console.log(this.form.value);
+		toast('OTP submitted', {
+			description: `Your OTP ${this.form.value.otp} has been submitted`,
+		});
+	}
+}

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--mask.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--mask.example.ts
@@ -58,7 +58,6 @@ export class InputOtpMaskExample {
 
 	public maxLength = 6;
 
-	/** Overrides global formatDate  */
 	public transformPaste = (pastedText: string) => pastedText.replaceAll('-', '');
 
 	public form = this._formBuilder.group({

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--slot-mask.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--slot-mask.example.ts
@@ -1,0 +1,59 @@
+import { Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { BrnInputOtp } from '@spartan-ng/brain/input-otp';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmInputOtp, HlmInputOtpGroup, HlmInputOtpSlot } from '@spartan-ng/helm/input-otp';
+import { HlmToaster } from '@spartan-ng/helm/sonner';
+import { toast } from 'ngx-sonner';
+
+@Component({
+	selector: 'spartan-input-otp-slot-mask',
+	imports: [ReactiveFormsModule, HlmButton, HlmToaster, BrnInputOtp, HlmInputOtp, HlmInputOtpGroup, HlmInputOtpSlot],
+	host: {
+		class: 'preview flex min-h-[350px] w-full justify-center p-10 items-center',
+	},
+	template: `
+		<hlm-toaster />
+
+		<form [formGroup]="form" (ngSubmit)="submit()" class="space-y-8">
+			<brn-input-otp
+				hlmInputOtp
+				[maxLength]="maxLength"
+				inputClass="disabled:cursor-not-allowed"
+				formControlName="otp"
+				[transformPaste]="transformPaste"
+				(completed)="submit()"
+			>
+				<div hlmInputOtpGroup>
+					@for (num of mobileDigits; track num; let count = $count; let i = $index) {
+						<hlm-input-otp-slot [mask]="i < count - 3" [index]="i" />
+					}
+				</div>
+			</brn-input-otp>
+
+			<div class="flex flex-col gap-4">
+				<button type="submit" hlmBtn [disabled]="form.invalid">Submit</button>
+			</div>
+		</form>
+	`,
+})
+export class InputOtpMaskSlotExample {
+	private readonly _formBuilder = inject(FormBuilder);
+
+	public readonly mobileDigits = Array.from({ length: 11 }, (_, i) => i);
+	public maxLength = 11;
+
+	/** Overrides global formatDate  */
+	public transformPaste = (pastedText: string) => pastedText.replaceAll('-', '');
+
+	public form = this._formBuilder.group({
+		otp: [null, [Validators.required, Validators.minLength(this.maxLength), Validators.maxLength(this.maxLength)]],
+	});
+
+	submit() {
+		console.log(this.form.value);
+		toast('OTP submitted', {
+			description: `Your OTP ${this.form.value.otp} has been submitted`,
+		});
+	}
+}

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--slot-mask.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--slot-mask.example.ts
@@ -43,7 +43,6 @@ export class InputOtpMaskSlotExample {
 	public readonly mobileDigits = Array.from({ length: 11 }, (_, i) => i);
 	public maxLength = 11;
 
-	/** Overrides global formatDate  */
 	public transformPaste = (pastedText: string) => pastedText.replaceAll('-', '');
 
 	public form = this._formBuilder.group({

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp.page.ts
@@ -17,6 +17,9 @@ import { Tabs } from '../../../../shared/layout/tabs';
 import { TabsCli } from '../../../../shared/layout/tabs-cli';
 import { metaWith } from '../../../../shared/meta/meta.util';
 import { InputOtpFormExample } from './input-otp--form.example';
+import { InputOtpGroupMaskExample } from './input-otp--group-mask.example';
+import { InputOtpMaskExample } from './input-otp--mask.example';
+import { InputOtpMaskSlotExample } from './input-otp--slot-mask.example';
 import { defaultImports, defaultSkeleton, InputOtpPreview } from './input-otp.preview';
 
 export const routeMeta: RouteMeta = {
@@ -42,6 +45,9 @@ export const routeMeta: RouteMeta = {
 		InputOtpPreview,
 		InputOtpFormExample,
 		SectionSubSubHeading,
+		InputOtpMaskExample,
+		InputOtpGroupMaskExample,
+		InputOtpMaskSlotExample,
 	],
 	template: `
 		<section spartanMainSection>
@@ -135,9 +141,56 @@ export const routeMeta: RouteMeta = {
 			</p>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
-					<spartan-input-otp-form />
+					<spartan-input-otp-form></spartan-input-otp-form>
 				</div>
 				<spartan-code secondTab [code]="_formCode()" />
+			</spartan-tabs>
+
+			<h3 id="examples__masked" spartanH4>Masked</h3>
+			<p class="${hlmP} mb-6">
+				Mask the otp by adding
+				<code class="${hlmCode}">mask</code>
+				to
+				<code class="${hlmCode}">true</code>
+				.
+			</p>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-input-otp-mask></spartan-input-otp-mask>
+				</div>
+				<spartan-code secondTab [code]="_maskCode()" />
+			</spartan-tabs>
+
+			<h3 id="examples__group-mask" spartanH4>Masked group</h3>
+			<p class="${hlmP} mb-6">
+				Mask the otp group by adding
+				<code class="${hlmCode}">mask</code>
+				to
+				<code class="${hlmCode}">true</code>
+				.
+			</p>
+
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-input-otp-group-mask></spartan-input-otp-group-mask>
+				</div>
+				<spartan-code secondTab [code]="_groupMaskCode()" />
+			</spartan-tabs>
+
+			<h3 id="examples__slot-mask" spartanH4>Masked slot</h3>
+			<p class="${hlmP} mb-6">
+				Mask an individual otp slot by adding
+				<code class="${hlmCode}">mask</code>
+				to
+				<code class="${hlmCode}">true</code>
+				.
+			</p>
+
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-input-otp-slot-mask></spartan-input-otp-slot-mask>
+				</div>
+				<spartan-code secondTab [code]="_slotMaskCode()" />
 			</spartan-tabs>
 
 			<spartan-section-sub-heading id="brn-api">Brain API</spartan-section-sub-heading>
@@ -158,6 +211,9 @@ export default class InputOtpPage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('input-otp');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
 	protected readonly _formCode = computed(() => this._snippets()['form']);
+	protected readonly _maskCode = computed(() => this._snippets()['mask']);
+	protected readonly _groupMaskCode = computed(() => this._snippets()['group-mask']);
+	protected readonly _slotMaskCode = computed(() => this._snippets()['slot-mask']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 }

--- a/apps/ui-storybook/stories/input-otp.stories.ts
+++ b/apps/ui-storybook/stories/input-otp.stories.ts
@@ -6,8 +6,14 @@ const meta: Meta<BrnInputOtp> = {
 	title: 'Input OTP',
 	component: BrnInputOtp,
 	tags: ['autodocs'],
-	args: {},
-	argTypes: {},
+	args: {
+		maxLength: 6,
+		autofocus: true,
+		mask: false,
+	},
+	argTypes: {
+		mask: { control: 'boolean' },
+	},
 	decorators: [
 		moduleMetadata({
 			imports: [BrnInputOtp, HlmInputOtp, HlmInputOtpGroup, HlmInputOtpSeparator, HlmInputOtpSlot],
@@ -16,19 +22,24 @@ const meta: Meta<BrnInputOtp> = {
 	render: ({ ...args }) => ({
 		props: args,
 		template: `
-		<brn-input-otp hlmInputOtp maxLength="6" inputClass="disabled:cursor-not-allowed" [autofocus]="true">
-			<div hlmInputOtpGroup>
-				<hlm-input-otp-slot index="0" />
-				<hlm-input-otp-slot index="1" />
-				<hlm-input-otp-slot index="2" />
-			</div>
-			<hlm-input-otp-separator />
-			<div hlmInputOtpGroup>
-				<hlm-input-otp-slot index="3" />
-				<hlm-input-otp-slot index="4" />
-				<hlm-input-otp-slot index="5" />
-			</div>
-		</brn-input-otp>
+			<brn-input-otp
+				hlmInputOtp
+				[maxLength]="maxLength"
+				inputClass="disabled:cursor-not-allowed"
+				[autofocus]="autofocus"
+			>
+				<div hlmInputOtpGroup>
+					<hlm-input-otp-slot index="0" />
+					<hlm-input-otp-slot index="1" />
+					<hlm-input-otp-slot index="2" />
+				</div>
+				<hlm-input-otp-separator />
+				<div hlmInputOtpGroup>
+					<hlm-input-otp-slot index="3" />
+					<hlm-input-otp-slot index="4" />
+					<hlm-input-otp-slot index="5" />
+				</div>
+			</brn-input-otp>
 		`,
 	}),
 };
@@ -39,4 +50,83 @@ type Story = StoryObj<BrnInputOtp>;
 
 export const Default: Story = {
 	args: {},
+};
+
+export const Mask: Story = {
+	args: {
+		mask: true,
+	},
+	render: ({ ...args }) => ({
+		props: args,
+		template: `
+			<brn-input-otp
+				hlmInputOtp
+				[maxLength]="maxLength"
+				inputClass="disabled:cursor-not-allowed"
+				[autofocus]="autofocus"
+				[mask]="mask"
+			>
+				<div hlmInputOtpGroup>
+					<hlm-input-otp-slot index="0" />
+					<hlm-input-otp-slot index="1" />
+					<hlm-input-otp-slot index="2" />
+				</div>
+				<hlm-input-otp-separator />
+				<div hlmInputOtpGroup>
+					<hlm-input-otp-slot index="3" />
+					<hlm-input-otp-slot index="4" />
+					<hlm-input-otp-slot index="5" />
+				</div>
+			</brn-input-otp>
+		`,
+	}),
+};
+
+export const GroupMask: Story = {
+	render: ({ ...args }) => ({
+		props: args,
+		template: `
+			<brn-input-otp
+				hlmInputOtp
+				[maxLength]="maxLength"
+				inputClass="disabled:cursor-not-allowed"
+				[autofocus]="autofocus"
+			>
+				<div hlmInputOtpGroup [mask]="true">
+					<hlm-input-otp-slot index="0" />
+					<hlm-input-otp-slot index="1" />
+					<hlm-input-otp-slot index="2" />
+				</div>
+				<hlm-input-otp-separator />
+				<div hlmInputOtpGroup>
+					<hlm-input-otp-slot index="3" />
+					<hlm-input-otp-slot index="4" />
+					<hlm-input-otp-slot index="5" />
+				</div>
+			</brn-input-otp>
+		`,
+	}),
+};
+
+export const SlotMask: Story = {
+	render: ({ ...args }) => ({
+		props: args,
+		template: `
+			<brn-input-otp
+				hlmInputOtp
+				[maxLength]="maxLength"
+				inputClass="disabled:cursor-not-allowed"
+				[autofocus]="autofocus"
+			>
+				<div hlmInputOtpGroup>
+					<hlm-input-otp-slot [mask]="true" index="0" />
+					<hlm-input-otp-slot [mask]="true" index="1" />
+					<hlm-input-otp-slot [mask]="true" index="2" />
+					<hlm-input-otp-slot [mask]="false" index="3" />
+					<hlm-input-otp-slot [mask]="false" index="4" />
+					<hlm-input-otp-slot [mask]="false" index="5" />
+				</div>
+			</brn-input-otp>
+		`,
+	}),
 };

--- a/libs/brain/input-otp/src/index.ts
+++ b/libs/brain/input-otp/src/index.ts
@@ -1,7 +1,9 @@
 import { BrnInputOtp } from './lib/brn-input-otp';
+import { BrnInputOtpMask } from './lib/brn-input-otp-mask';
 import { BrnInputOtpSlot } from './lib/brn-input-otp-slot';
 
 export * from './lib/brn-input-otp';
+export * from './lib/brn-input-otp-mask';
 export * from './lib/brn-input-otp-slot';
 
-export const BrnInputOtpImports = [BrnInputOtp, BrnInputOtpSlot] as const;
+export const BrnInputOtpImports = [BrnInputOtp, BrnInputOtpSlot, BrnInputOtpMask] as const;

--- a/libs/brain/input-otp/src/lib/brn-input-otp-mask.ts
+++ b/libs/brain/input-otp/src/lib/brn-input-otp-mask.ts
@@ -1,0 +1,9 @@
+import { Directive, input } from '@angular/core';
+
+@Directive({
+	selector: '[brnInputOtpMask]',
+})
+export class BrnInputOtpMask {
+	/* Determine if the input should be masked */
+	public readonly mask = input<boolean | undefined>(undefined);
+}

--- a/libs/brain/input-otp/src/lib/brn-input-otp-slot.ts
+++ b/libs/brain/input-otp/src/lib/brn-input-otp-slot.ts
@@ -1,16 +1,18 @@
 import type { NumberInput } from '@angular/cdk/coercion';
-import { ChangeDetectionStrategy, Component, computed, input, numberAttribute } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, numberAttribute } from '@angular/core';
+import { BrnInputOtpMask } from './brn-input-otp-mask';
 import { injectBrnInputOtp } from './brn-input-otp.token';
+import { MaskValuePipe } from './util/mask-value-pipe';
 
 @Component({
 	selector: 'brn-input-otp-slot',
+	imports: [MaskValuePipe],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
 		'[attr.data-active]': '_slot().isActive',
 	},
 	template: `
-		{{ _slot().char }}
-
+		{{ _slot().char | maskValue: _hasMask() : 200 }}
 		@if (_slot().hasFakeCaret) {
 			<ng-content />
 		}
@@ -22,6 +24,14 @@ export class BrnInputOtpSlot {
 
 	/** The index of the slot to render the char or a fake caret */
 	public readonly index = input.required<number, NumberInput>({ transform: numberAttribute });
+	public readonly mask = input<boolean | undefined>(undefined);
+
+	/** Optional group-level mask directive (provided by hlmInputOtpGroup hostDirectives) */
+	protected readonly _groupMask = inject(BrnInputOtpMask, { optional: true });
 
 	protected readonly _slot = computed(() => this._inputOtp.context()[this.index()]);
+
+	protected readonly _hasMask = computed(() => {
+		return this.mask() ?? this._groupMask?.mask() ?? this._inputOtp.mask();
+	});
 }

--- a/libs/brain/input-otp/src/lib/brn-input-otp.spec.ts
+++ b/libs/brain/input-otp/src/lib/brn-input-otp.spec.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/angular';
+import { render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import type { InputMode } from './brn-input-otp';
 import { BrnInputOtp } from './brn-input-otp';
@@ -9,6 +9,7 @@ describe('BrnInputOtp', () => {
 		options: {
 			maxLength?: number;
 			disabled?: boolean;
+			mask?: boolean;
 			inputMode?: InputMode;
 			inputId?: string;
 			inputAutocomplete?: string;
@@ -18,6 +19,7 @@ describe('BrnInputOtp', () => {
 		const {
 			maxLength = 6,
 			disabled = false,
+			mask = false,
 			inputMode = 'numeric',
 			inputId,
 			inputAutocomplete = 'one-time-code',
@@ -27,6 +29,7 @@ describe('BrnInputOtp', () => {
 		let template = `
       <brn-input-otp
         [maxLength]="${maxLength}"
+        [mask]="${mask}"
         data-testid="brnInputOtp"
         ${disabled ? 'disabled' : ''}
         [inputMode]="'${inputMode}'"
@@ -361,6 +364,36 @@ describe('BrnInputOtp', () => {
 			expect(getSlot(1)).toBeInTheDocument();
 			expect(getSlot(2)).toBeInTheDocument();
 			expect(screen.queryByTestId('slot-3')).not.toBeInTheDocument();
+		});
+	});
+	describe('mask behavior', () => {
+		it('shows typed character first, then masks it when mask is enabled', async () => {
+			const { user, input, getSlot } = await setup({ maxLength: 4, mask: true });
+
+			await user.click(input);
+			await user.keyboard('1');
+
+			expect(getSlot(0)).toHaveTextContent('1');
+
+			await waitFor(
+				() => {
+					expect(getSlot(0)).toHaveTextContent('\u2217');
+				},
+				{ timeout: 1000 },
+			);
+		});
+
+		it('keeps character visible when mask is disabled', async () => {
+			const { user, input, getSlot } = await setup({ maxLength: 4, mask: false });
+
+			await user.click(input);
+			await user.keyboard('1');
+
+			expect(getSlot(0)).toHaveTextContent('1');
+
+			await new Promise((resolve) => setTimeout(resolve, 300));
+
+			expect(getSlot(0)).toHaveTextContent('1');
 		});
 	});
 });

--- a/libs/brain/input-otp/src/lib/brn-input-otp.ts
+++ b/libs/brain/input-otp/src/lib/brn-input-otp.ts
@@ -88,6 +88,8 @@ export class BrnInputOtp implements ControlValueAccessor {
 		transform: booleanAttribute,
 	});
 
+	public readonly mask = input<boolean>(false);
+
 	protected readonly _disabled = linkedSignal(this.disabled);
 
 	/** The number of slots. */

--- a/libs/brain/input-otp/src/lib/brn-input-otp.ts
+++ b/libs/brain/input-otp/src/lib/brn-input-otp.ts
@@ -88,7 +88,10 @@ export class BrnInputOtp implements ControlValueAccessor {
 		transform: booleanAttribute,
 	});
 
-	public readonly mask = input<boolean>(false);
+	/** Determine if the full otp should be masked */
+	public readonly mask = input<boolean, BooleanInput>(false, {
+		transform: booleanAttribute,
+	});
 
 	protected readonly _disabled = linkedSignal(this.disabled);
 

--- a/libs/brain/input-otp/src/lib/util/mask-value-pipe.spec.ts
+++ b/libs/brain/input-otp/src/lib/util/mask-value-pipe.spec.ts
@@ -1,12 +1,16 @@
 import { TestBed } from '@angular/core/testing';
 import { MaskValuePipe } from './mask-value-pipe';
+import { ChangeDetectorRef } from '@angular/core';
 
 describe('MaskValuePipe', () => {
 	let pipe: MaskValuePipe;
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			providers: [MaskValuePipe],
+			providers: [
+				MaskValuePipe,
+				{ provide: ChangeDetectorRef, useValue: { markForCheck: jest.fn() } },
+			],
 		});
 		pipe = TestBed.inject(MaskValuePipe);
 		jest.useFakeTimers();

--- a/libs/brain/input-otp/src/lib/util/mask-value-pipe.spec.ts
+++ b/libs/brain/input-otp/src/lib/util/mask-value-pipe.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed } from '@angular/core/testing';
+import { MaskValuePipe } from './mask-value-pipe';
+
+describe('MaskValuePipe', () => {
+	let pipe: MaskValuePipe;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			providers: [MaskValuePipe],
+		});
+		pipe = TestBed.inject(MaskValuePipe);
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('creates an instance', () => {
+		expect(pipe).toBeTruthy();
+	});
+
+	it('returns original value when mask is omitted (defaults to false)', () => {
+		expect(pipe.transform('7')).toBe('7');
+	});
+
+	it('returns original value when mask is false', () => {
+		expect(pipe.transform('7', false)).toBe('7');
+		expect(pipe.transform(7, false)).toBe(7);
+	});
+
+	it('returns original value immediately, then masks after default delay when mask is true', () => {
+		expect(pipe.transform('7', true)).toBe('7');
+
+		jest.advanceTimersByTime(199);
+		expect(pipe.transform('7', true)).toBe('7');
+
+		jest.advanceTimersByTime(1);
+		expect(pipe.transform('7', true)).toBe('\u2217');
+	});
+
+	it('respects custom delay', () => {
+		expect(pipe.transform('7', true, 50)).toBe('7');
+
+		jest.advanceTimersByTime(49);
+		expect(pipe.transform('7', true, 50)).toBe('7');
+
+		jest.advanceTimersByTime(1);
+		expect(pipe.transform('7', true, 50)).toBe('\u2217');
+	});
+
+	it('returns original value when mask is true but value is falsy', () => {
+		expect(pipe.transform('', true)).toBe('');
+		expect(pipe.transform(0, true)).toBe(0);
+		expect(pipe.transform(false, true)).toBe(false);
+		expect(pipe.transform(null, true)).toBeNull();
+		expect(pipe.transform(undefined, true)).toBeUndefined();
+	});
+});

--- a/libs/brain/input-otp/src/lib/util/mask-value-pipe.spec.ts
+++ b/libs/brain/input-otp/src/lib/util/mask-value-pipe.spec.ts
@@ -1,16 +1,13 @@
+import { ChangeDetectorRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MaskValuePipe } from './mask-value-pipe';
-import { ChangeDetectorRef } from '@angular/core';
 
 describe('MaskValuePipe', () => {
 	let pipe: MaskValuePipe;
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			providers: [
-				MaskValuePipe,
-				{ provide: ChangeDetectorRef, useValue: { markForCheck: jest.fn() } },
-			],
+			providers: [MaskValuePipe, { provide: ChangeDetectorRef, useValue: { markForCheck: jest.fn() } }],
 		});
 		pipe = TestBed.inject(MaskValuePipe);
 		jest.useFakeTimers();

--- a/libs/brain/input-otp/src/lib/util/mask-value-pipe.ts
+++ b/libs/brain/input-otp/src/lib/util/mask-value-pipe.ts
@@ -1,0 +1,61 @@
+import { ChangeDetectorRef, OnDestroy, Pipe, PipeTransform, inject } from '@angular/core';
+
+@Pipe({
+	name: 'maskValue',
+	pure: false /** Impure so the view can update after the timeout triggers. */,
+})
+export class MaskValuePipe implements PipeTransform, OnDestroy {
+	private readonly _cdr = inject(ChangeDetectorRef);
+
+	/** Last value/mask pair seen by the pipe. Used to detect a newly typed character. */
+	private _lastValue: unknown;
+	private _lastMask = false;
+
+	/** Whether the currently tracked value should be rendered masked. */
+	private _shouldMaskNow = false;
+
+	/** Active timer that flips `_shouldMaskNow` after `delayMs`. */
+	private _timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+	transform(value: unknown, mask = false, delayMs = 200): unknown {
+		/** If masking is disabled or value is empty/falsy, return raw value immediately. */
+		if (!mask || !value) {
+			this._clearTimer();
+			this._lastValue = value;
+			this._lastMask = mask;
+			this._shouldMaskNow = false;
+			return value;
+		}
+
+		/** New value (or mask toggled on): briefly show plain value, then mask after delay. */
+		if (value !== this._lastValue || !this._lastMask) {
+			this._clearTimer();
+			this._lastValue = value;
+			this._lastMask = mask;
+			this._shouldMaskNow = false;
+
+			this._timeoutId = setTimeout(() => {
+				this._shouldMaskNow = true;
+				/** Required because host component uses OnPush and this pipe is timer-driven. */
+				this._cdr.markForCheck();
+			}, delayMs);
+
+			return value;
+		}
+
+		/** Same value path: return masked or unmasked based on timer state. */
+		return this._shouldMaskNow ? '\u2217' : value;
+	}
+
+	ngOnDestroy(): void {
+		/** Prevent timer leaks when pipe instance is destroyed. */
+		this._clearTimer();
+	}
+
+	private _clearTimer(): void {
+		if (this._timeoutId) {
+			clearTimeout(this._timeoutId);
+			this._timeoutId = null;
+		}
+	}
+}

--- a/libs/helm/input-otp/src/lib/hlm-input-otp-group.ts
+++ b/libs/helm/input-otp/src/lib/hlm-input-otp-group.ts
@@ -1,8 +1,10 @@
 import { Directive } from '@angular/core';
+import { BrnInputOtpMask } from '@spartan-ng/brain/input-otp';
 import { classes } from '@spartan-ng/helm/utils';
 
 @Directive({
 	selector: '[hlmInputOtpGroup]',
+	hostDirectives: [{ directive: BrnInputOtpMask, inputs: ['mask'] }],
 	host: {
 		'data-slot': 'input-otp-group',
 	},

--- a/libs/helm/input-otp/src/lib/hlm-input-otp-slot.ts
+++ b/libs/helm/input-otp/src/lib/hlm-input-otp-slot.ts
@@ -21,7 +21,9 @@ export class HlmInputOtpSlot {
 	/** The index of the slot to render the char or a fake caret */
 	public readonly index = input.required<number, NumberInput>({ transform: numberAttribute });
 
+	/* Determine if the individual slot should be masked */
 	public readonly mask = input<boolean | undefined>(undefined);
+
 	constructor() {
 		classes(() => [
 			'dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md',

--- a/libs/helm/input-otp/src/lib/hlm-input-otp-slot.ts
+++ b/libs/helm/input-otp/src/lib/hlm-input-otp-slot.ts
@@ -12,7 +12,7 @@ import { HlmInputOtpFakeCaret } from './hlm-input-otp-fake-caret';
 		'data-slot': 'input-otp-slot',
 	},
 	template: `
-		<brn-input-otp-slot [index]="index()">
+		<brn-input-otp-slot [mask]="mask()" [index]="index()">
 			<hlm-input-otp-fake-caret />
 		</brn-input-otp-slot>
 	`,
@@ -21,6 +21,7 @@ export class HlmInputOtpSlot {
 	/** The index of the slot to render the char or a fake caret */
 	public readonly index = input.required<number, NumberInput>({ transform: numberAttribute });
 
+	public readonly mask = input<boolean | undefined>(undefined);
 	constructor() {
 		classes(() => [
 			'dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md',

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -3111,6 +3111,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "boolean",
           },
           {
+            "name": "mask",
+            "required": false,
+            "type": "boolean",
+          },
+          {
             "name": "maxLength",
             "required": true,
             "type": "number",
@@ -3154,12 +3159,29 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
         ],
         "selector": "brn-input-otp",
       },
+      "BrnInputOtpMask": {
+        "inputs": [
+          {
+            "name": "mask",
+            "required": false,
+            "type": "boolean | undefined",
+          },
+        ],
+        "models": [],
+        "outputs": [],
+        "selector": "[brnInputOtpMask]",
+      },
       "BrnInputOtpSlot": {
         "inputs": [
           {
             "name": "index",
             "required": true,
             "type": "number",
+          },
+          {
+            "name": "mask",
+            "required": false,
+            "type": "boolean | undefined",
           },
         ],
         "models": [],
@@ -3198,6 +3220,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "name": "index",
             "required": true,
             "type": "number",
+          },
+          {
+            "name": "mask",
+            "required": false,
+            "type": "boolean | undefined",
           },
         ],
         "models": [],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [x] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

--

Adds configurable masking for OTP slots across Brain and Helm.
• Introduces OTP character masking with brief reveal-then-mask behavior.
• Adds mask-value pipe and tests to cover masking timing and edge cases.
• Adds BrnInputOtpMask directive for group-level masking control.
• Wires group masking into Helm via hlmInputOtpGroup host directive.
• Supports per-slot [mask] overrides in hlm-input-otp-slot.
• Defines mask precedence as: slot mask -> group mask -> root brn-input-otp mask.
• Keeps existing behavior unchanged when masking is not enabled.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

https://github.com/user-attachments/assets/666105e2-9fdb-4dbe-b471-4011461804a6





