### PR TITLE
feat(collapsible): add accordion-like animation example and enhance collapsible components

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(collapsible)/collapsible--animated.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(collapsible)/collapsible--animated.example.ts
@@ -19,6 +19,7 @@ import { HlmCollapsibleImports } from '@spartan-ng/helm/collapsible';
 			</div>
 			<div class="rounded-md border px-4 py-2 font-mono text-sm">&#64;radix-ui/primitives</div>
 			<hlm-collapsible-content
+				[hideWhenClosed]="false"
 				class="flex origin-top flex-col gap-2 transition-all ease-out data-[state=closed]:flex data-[state=closed]:-translate-y-1 data-[state=closed]:scale-80 data-[state=closed]:opacity-0"
 			>
 				<div class="rounded-md border px-4 py-2 font-mono text-sm">&#64;radix-ui/colors</div>

--- a/apps/app/src/app/pages/(components)/components/(collapsible)/collapsible-accordion-animation.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(collapsible)/collapsible-accordion-animation.example.ts
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronRight } from '@ng-icons/lucide';
+import { HlmButtonImports } from '@spartan-ng/helm/button';
+import { HlmCollapsibleImports } from '@spartan-ng/helm/collapsible';
+
+@Component({
+	selector: 'spartan-collapsible-accordion-animated-example',
+	imports: [HlmCollapsibleImports, HlmButtonImports, NgIcon],
+	providers: [provideIcons({ lucideChevronRight })],
+	template: `
+		<hlm-collapsible class="group/collapsible flex w-87.5 flex-col gap-2">
+			<div class="flex items-center justify-between gap-4 px-4">
+				<h4 class="text-sm font-semibold">&#64;peduarte starred 3 repositories</h4>
+				<button hlmCollapsibleTrigger hlmBtn variant="ghost" size="icon">
+					<ng-icon
+						name="lucideChevronRight"
+						class="transition-transform group-data-[state=open]/collapsible:rotate-90"
+					/>
+					<span class="sr-only">Toggle</span>
+				</button>
+			</div>
+			<hlm-collapsible-content
+				[hideWhenClosed]="false"
+				class="overflow-hidden transition-all duration-200 ease-out data-[state=closed]:h-0 data-[state=open]:h-(--brn-collapsible-content-height)"
+			>
+				<div class="flex flex-col gap-2">
+					<div class="rounded-md border px-4 py-2 font-mono text-sm">@radix-ui/primitives</div>
+					<div class="rounded-md border px-4 py-2 font-mono text-sm">@radix-ui/colors</div>
+					<div class="rounded-md border px-4 py-2 font-mono text-sm">@stitches/react</div>
+				</div>
+			</hlm-collapsible-content>
+		</hlm-collapsible>
+	`,
+})
+export class CollapsibleAccordionAnimatedExample {}

--- a/apps/app/src/app/pages/(components)/components/(collapsible)/collapsible.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(collapsible)/collapsible.page.ts
@@ -2,6 +2,7 @@ import type { RouteMeta } from '@analogjs/router';
 import { Component, computed, inject } from '@angular/core';
 import { PrimitiveSnippetsService } from '@spartan-ng/app/app/core/services/primitive-snippets.service';
 import { CollapsibleAnimatedExample } from '@spartan-ng/app/app/pages/(components)/components/(collapsible)/collapsible--animated.example';
+import { CollapsibleAccordionAnimatedExample } from '@spartan-ng/app/app/pages/(components)/components/(collapsible)/collapsible-accordion-animation.example';
 import { SectionSubSubHeading } from '@spartan-ng/app/app/shared/layout/section-sub-sub-heading';
 import { hlmCode } from '@spartan-ng/helm/typography';
 import { Code } from '../../../../shared/code/code';
@@ -41,6 +42,7 @@ export const routeMeta: RouteMeta = {
 		CollapsiblePreview,
 		SectionSubSubHeading,
 		CollapsibleAnimatedExample,
+		CollapsibleAccordionAnimatedExample,
 	],
 	template: `
 		<section spartanMainSection>
@@ -63,7 +65,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 id="examples__sizes" spartanH4>Animated</h3>
+			<h3 id="examples__animated" spartanH4>Animated</h3>
 			<p class="py-2">
 				You can use the
 				<code class="${hlmCode}">data-state</code>
@@ -74,6 +76,19 @@ export const routeMeta: RouteMeta = {
 					<spartan-collapsible-animated-example />
 				</div>
 				<spartan-code secondTab [code]="_animatedCode()" />
+			</spartan-tabs>
+
+			<h3 id="examples__accordion-animation" spartanH4>Accordion-Like Animation</h3>
+			<p class="py-2">
+				Use the
+				<code class="${hlmCode}">data-state</code>
+				attribute with Tailwind classes to animate height and opacity for an accordion-like reveal.
+			</p>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-collapsible-accordion-animated-example />
+				</div>
+				<spartan-code secondTab [code]="_accordionAnimationCode()" />
 			</spartan-tabs>
 
 			<spartan-section-sub-heading id="brn-api">Brain API</spartan-section-sub-heading>
@@ -94,6 +109,7 @@ export default class CollapsiblePage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('collapsible');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
 	protected readonly _animatedCode = computed(() => this._snippets()['animated']);
+	protected readonly _accordionAnimationCode = computed(() => this._snippets()['accordionAnimation']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 }

--- a/libs/brain/collapsible/src/lib/brn-collapsible-content.ts
+++ b/libs/brain/collapsible/src/lib/brn-collapsible-content.ts
@@ -23,6 +23,7 @@ import { injectBrnCollapsible, injectBrnCollapsibleConfig } from './brn-collapsi
 		'[id]': '_collapsible?.contentId()',
 		'[style.--brn-collapsible-content-width.px]': '_width()',
 		'[style.--brn-collapsible-content-height.px]': '_height()',
+		'[attr.style]': 'style()',
 	},
 })
 export class BrnCollapsibleContent {
@@ -40,6 +41,12 @@ export class BrnCollapsibleContent {
 	 * The id of the collapsible content element.
 	 */
 	public readonly id = input<string | null | undefined>();
+
+	/**
+	 * The style to be applied to the host element after the dimensions are calculated.
+	 * @default 'overflow: hidden'
+	 */
+	public readonly style = input<string>('overflow: hidden');
 
 	constructor() {
 		if (!this._collapsible) {

--- a/libs/brain/collapsible/src/lib/brn-collapsible.spec.ts
+++ b/libs/brain/collapsible/src/lib/brn-collapsible.spec.ts
@@ -6,7 +6,7 @@ import { BrnCollapsibleContent } from './brn-collapsible-content';
 import { BrnCollapsibleTrigger } from './brn-collapsible-trigger';
 
 describe('BrnCollapsibleComponent', () => {
-	const setup = async (id?: string, disabled = false) => {
+	const setup = async (id?: string, disabled = false, style?: string) => {
 		const container = await render(
 			`
      <brn-collapsible ${disabled ? 'disabled' : ''} data-testid='root'>
@@ -15,7 +15,7 @@ describe('BrnCollapsibleComponent', () => {
         <button brnCollapsibleTrigger data-testid='trigger'>Toggle</button>
       </div>
       <div>&#64;radix-ui/primitives</div>
-      <brn-collapsible-content ${id ? `id=${id}` : ''} data-testid='content'>
+      <brn-collapsible-content ${id ? `id=${id}` : ''} ${style ? `style="${style}"` : ''} data-testid='content'>
         <div>&#64;radix-ui/colors</div>
         <div>&#64;stitches/react</div>
       </brn-collapsible-content>
@@ -60,6 +60,7 @@ describe('BrnCollapsibleComponent', () => {
 		expect(trigger).toHaveAttribute('data-state', 'open');
 		expect(trigger).toHaveAttribute('aria-expanded', 'true');
 		expect(content).toHaveAttribute('data-state', 'open');
+		expect(content).not.toHaveAttribute('hidden');
 
 		await validateAttributes({ root, trigger, content, id });
 	};
@@ -72,6 +73,7 @@ describe('BrnCollapsibleComponent', () => {
 		expect(trigger).toHaveAttribute('data-state', 'closed');
 		expect(trigger).toHaveAttribute('aria-expanded', 'false');
 		expect(content).toHaveAttribute('data-state', 'closed');
+		expect(content).not.toHaveAttribute('hidden');
 
 		await validateAttributes({ root, trigger, content, id });
 	};
@@ -142,5 +144,12 @@ describe('BrnCollapsibleComponent', () => {
 		await user.keyboard('[Space]');
 		container.detectChanges();
 		await validateClosed();
+	});
+
+	it('applies overflow hidden as the default host style', async () => {
+		await setup();
+		const content = await screen.findByTestId('content');
+
+		expect(content).toHaveAttribute('style', expect.stringContaining('overflow: hidden'));
 	});
 });

--- a/libs/helm/collapsible/src/lib/hlm-collapsible-content.ts
+++ b/libs/helm/collapsible/src/lib/hlm-collapsible-content.ts
@@ -1,16 +1,23 @@
-import { Directive } from '@angular/core';
+import type { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input } from '@angular/core';
 import { BrnCollapsibleContent } from '@spartan-ng/brain/collapsible';
 import { classes } from '@spartan-ng/helm/utils';
 
 @Directive({
 	selector: '[hlmCollapsibleContent],hlm-collapsible-content',
-	hostDirectives: [{ directive: BrnCollapsibleContent, inputs: ['id'] }],
+	hostDirectives: [{ directive: BrnCollapsibleContent, inputs: ['id', 'style'] }],
 	host: {
 		'data-slot': 'collapsible-content',
 	},
 })
 export class HlmCollapsibleContent {
+	/**
+	 * Hides the content when closed. Disable for CSS-driven animations.
+	 * @default true
+	 */
+	public readonly hideWhenClosed = input<boolean, BooleanInput>(true, { transform: booleanAttribute });
+
 	constructor() {
-		classes(() => 'data-[state=closed]:hidden');
+		classes(() => (this.hideWhenClosed() ? 'data-[state=closed]:hidden' : ''));
 	}
 }

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -1448,6 +1448,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "required": false,
             "type": "string | null | undefined",
           },
+          {
+            "name": "style",
+            "required": false,
+            "type": "string",
+          },
         ],
         "models": [],
         "outputs": [],
@@ -1474,7 +1479,13 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
         "selector": "[hlmCollapsible],hlm-collapsible",
       },
       "HlmCollapsibleContent": {
-        "inputs": [],
+        "inputs": [
+          {
+            "name": "hideWhenClosed",
+            "required": false,
+            "type": "boolean",
+          },
+        ],
         "models": [],
         "outputs": [],
         "selector": "[hlmCollapsibleContent],hlm-collapsible-content",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [x] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] form-field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

`hlm-collapsible-content` hides closed content by default, which makes the basic collapsible usage work as expected, but it also prevents CSS-driven animations such as accordion-like height transitions from running on close/open.

Closes #

## What is the new behavior?
This PR keeps the default hidden-on-closed behavior for `hlm-collapsible-content`, while making animated usage opt out explicitly.

- `brn-collapsible-content` follows the same pattern as accordion by exposing state and measured content dimensions, with a default `overflow: hidden` style.
- `hlm-collapsible-content` now supports disabling the default hidden behavior for animation cases.
- Animated collapsible examples were updated to opt out of the hidden behavior so transform/height animations work correctly.
- The collapsible generator template was updated to match the new API.
- Collapsible tests were updated to reflect the new default behavior and styling contract.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
