### PR TITLE
fix: align components with input ids

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(checkbox)/checkbox.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(checkbox)/checkbox.preview.ts
@@ -8,25 +8,25 @@ import { HlmLabelImports } from '@spartan-ng/helm/label';
 	template: `
 		<div class="flex flex-col gap-6">
 			<div class="flex items-center gap-3">
-				<hlm-checkbox id="terms" />
+				<hlm-checkbox inputId="terms" />
 				<label hlmLabel for="terms">Accept terms and conditions</label>
 			</div>
 			<div class="flex items-start gap-3">
-				<hlm-checkbox id="terms-2" [checked]="true" />
+				<hlm-checkbox inputId="terms-2" [checked]="true" />
 				<div class="grid gap-2">
 					<label hlmLabel for="terms-2">Accept terms and conditions</label>
 					<p class="text-muted-foreground text-sm">By clicking this checkbox, you agree to the terms and conditions.</p>
 				</div>
 			</div>
 			<div class="flex items-start gap-3">
-				<hlm-checkbox id="toggle" disabled />
+				<hlm-checkbox inputId="toggle" disabled />
 				<label hlmLabel for="toggle">Enable notifications</label>
 			</div>
 			<label
 				class="hover:bg-accent/50 flex items-start gap-3 rounded-lg border p-3 has-[[aria-checked=true]]:border-blue-600 has-[[aria-checked=true]]:bg-blue-50 dark:has-[[aria-checked=true]]:border-blue-900 dark:has-[[aria-checked=true]]:bg-blue-950"
 			>
 				<hlm-checkbox
-					id="toggle-2"
+					inputId="toggle-2"
 					[checked]="true"
 					class="data-[state=checked]:border-blue-600 data-[state=checked]:bg-blue-600 data-[state=checked]:text-white dark:data-[state=checked]:border-blue-700 dark:data-[state=checked]:bg-blue-700"
 				/>

--- a/apps/app/src/app/pages/(components)/components/(field)/field--checkbox.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(field)/field--checkbox.preview.ts
@@ -15,26 +15,26 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 				<p hlmFieldDescription>Select the items you want to show on the desktop.</p>
 				<div hlmFieldGroup class="gap-3">
 					<div hlmField orientation="horizontal">
-						<hlm-checkbox id="field-hard-disks" />
+						<hlm-checkbox inputId="field-hard-disks" />
 						<label hlmFieldLabel for="field-hard-disks" class="font-normal">Hard disks</label>
 					</div>
 					<div hlmField orientation="horizontal">
-						<hlm-checkbox id="field-external-disks" />
+						<hlm-checkbox inputId="field-external-disks" />
 						<label hlmFieldLabel for="field-external-disks" class="font-normal">External disks</label>
 					</div>
 					<div hlmField orientation="horizontal">
-						<hlm-checkbox id="field-cds-dvds-ipods" />
+						<hlm-checkbox inputId="field-cds-dvds-ipods" />
 						<label hlmFieldLabel for="field-cds-dvds-ipods" class="font-normal">CDs, DVDs, and IPods</label>
 					</div>
 					<div hlmField orientation="horizontal">
-						<hlm-checkbox id="field-connected-servers" />
+						<hlm-checkbox inputId="field-connected-servers" />
 						<label hlmFieldLabel for="field-connected-servers" class="font-normal">Connected servers</label>
 					</div>
 				</div>
 			</fieldset>
 			<hlm-field-separator />
 			<div hlmField orientation="horizontal">
-				<hlm-checkbox id="field-sync-desktop-documents" [checked]="true" />
+				<hlm-checkbox inputId="field-sync-desktop-documents" [checked]="true" />
 				<div hlmFieldContent>
 					<label hlmFieldLabel for="field-sync-desktop-documents">Sync Desktop & Documents folders</label>
 					<p hlmFieldDescription>

--- a/apps/app/src/app/pages/(components)/components/(field)/field--choice-card.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(field)/field--choice-card.preview.ts
@@ -20,7 +20,7 @@ import { HlmRadioGroupImports } from '@spartan-ng/helm/radio-group';
 								<div hlmFieldTitle>Kubernetes</div>
 								<div hlmFieldDescription>Run GPU workloads on a K8s configured cluster.</div>
 							</div>
-							<hlm-radio value="kubernetes" id="kubernetes">
+							<hlm-radio value="kubernetes" inputId="kubernetes">
 								<hlm-radio-indicator indicator />
 							</hlm-radio>
 						</div>
@@ -31,7 +31,7 @@ import { HlmRadioGroupImports } from '@spartan-ng/helm/radio-group';
 								<div hlmFieldTitle>Virtual Machine</div>
 								<div hlmFieldDescription>Access a VM configured cluster to run GPU workloads.</div>
 							</div>
-							<hlm-radio value="virtual-machine" id="virtual-machine">
+							<hlm-radio value="virtual-machine" inputId="virtual-machine">
 								<hlm-radio-indicator indicator />
 							</hlm-radio>
 						</div>

--- a/apps/app/src/app/pages/(components)/components/(field)/field--group.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(field)/field--group.preview.ts
@@ -17,7 +17,7 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 				</p>
 				<div hlmFieldGroup data-slot="checkbox-group">
 					<div hlmField orientation="horizontal">
-						<hlm-checkbox id="field-group-push-notifications" disabled [checked]="true" />
+						<hlm-checkbox inputId="field-group-push-notifications" disabled [checked]="true" />
 						<label hlmFieldLabel for="field-group-push-notifications" class="font-normal">Push notifications</label>
 					</div>
 				</div>
@@ -31,11 +31,11 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 				</p>
 				<div hlmFieldGroup data-slot="checkbox-group">
 					<div hlmField orientation="horizontal">
-						<hlm-checkbox id="field-group-push-task" />
+						<hlm-checkbox inputId="field-group-push-task" />
 						<label hlmFieldLabel for="field-group-push-task" class="font-normal">Push notifications</label>
 					</div>
 					<div hlmField orientation="horizontal">
-						<hlm-checkbox id="field-group-email-task" />
+						<hlm-checkbox inputId="field-group-email-task" />
 						<label hlmFieldLabel for="field-group-email-task" class="font-normal">Email notifications</label>
 					</div>
 				</div>

--- a/apps/app/src/app/pages/(components)/components/(field)/field--radio.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(field)/field--radio.preview.ts
@@ -14,19 +14,19 @@ import { HlmRadioGroupImports } from '@spartan-ng/helm/radio-group';
 			<p hlmFieldDescription>Yearly and lifetime plans offer significant savings.</p>
 			<hlm-radio-group value="monthly">
 				<div hlmField orientation="horizontal">
-					<hlm-radio value="monthly" id="plan-monthly">
+					<hlm-radio value="monthly" inputId="plan-monthly">
 						<hlm-radio-indicator indicator />
 					</hlm-radio>
 					<label hlmFieldLabel for="plan-monthly" class="font-normal">Monthly ($9.99/month)</label>
 				</div>
 				<div hlmField orientation="horizontal">
-					<hlm-radio value="yearly" id="plan-yearly">
+					<hlm-radio value="yearly" inputId="plan-yearly">
 						<hlm-radio-indicator indicator />
 					</hlm-radio>
 					<label hlmFieldLabel for="plan-yearly" class="font-normal">Yearly ($99.99/year)</label>
 				</div>
 				<div hlmField orientation="horizontal">
-					<hlm-radio value="lifetime" id="plan-lifetime">
+					<hlm-radio value="lifetime" inputId="plan-lifetime">
 						<hlm-radio-indicator indicator />
 					</hlm-radio>
 					<label hlmFieldLabel for="plan-lifetime" class="font-normal">Lifetime ($299.99/lifetime)</label>

--- a/apps/app/src/app/pages/(components)/components/(field)/field--switch.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(field)/field--switch.preview.ts
@@ -17,7 +17,7 @@ import { HlmSwitchImports } from '@spartan-ng/helm/switch';
 					to your email.
 				</p>
 			</div>
-			<hlm-switch id="field-2fa" />
+			<hlm-switch inputId="field-2fa" />
 		</div>
 	`,
 })

--- a/apps/app/src/app/pages/(components)/components/(field)/field.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(field)/field.preview.ts
@@ -94,7 +94,7 @@ import { HlmTextareaImports } from '@spartan-ng/helm/textarea';
 					<p hlmFieldDescription>The billing address associated with your payment method</p>
 					<div hlmFieldGroup>
 						<div hlmField orientation="horizontal">
-							<hlm-checkbox id="field-preview-billing-address" [checked]="true" />
+							<hlm-checkbox inputId="field-preview-billing-address" [checked]="true" />
 							<label hlmFieldLabel for="field-preview-billing-address">Same as shipping address.</label>
 						</div>
 					</div>
@@ -138,7 +138,7 @@ export const defaultSkeleton = `
             <hlm-field-error>Choose another username.</hlm-field-error>
         </div>
         <div hlmField orientation="horizontal">
-            <hlm-switch id="field-preview-subscribe-newsletter" />
+            <hlm-switch inputId="field-preview-subscribe-newsletter" />
             <label hlmFieldLabel for="field-preview-subscribe-newsletter">Subscribe to the newsletter</label>
         </div>
     </div>

--- a/apps/app/src/app/pages/(components)/components/(label)/label.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(label)/label.preview.ts
@@ -8,7 +8,7 @@ import { HlmLabelImports } from '@spartan-ng/helm/label';
 	template: `
 		<div>
 			<div class="flex items-center gap-2">
-				<hlm-checkbox id="terms" />
+				<hlm-checkbox inputId="terms" />
 				<label hlmLabel for="terms">Accept terms and conditions</label>
 			</div>
 		</div>

--- a/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group--form.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group--form.example.ts
@@ -13,19 +13,19 @@ import { HlmRadioGroupImports } from '@spartan-ng/helm/radio-group';
 				<label hlmLabel>Subscription Plan</label>
 				<hlm-radio-group formControlName="plan">
 					<div class="flex items-center gap-3">
-						<hlm-radio value="monthly" id="monthly">
+						<hlm-radio value="monthly" inputId="monthly">
 							<hlm-radio-indicator indicator />
 						</hlm-radio>
 						<label hlmLabel for="monthly">Monthly ($9.99/month)</label>
 					</div>
 					<div class="flex items-center gap-3">
-						<hlm-radio value="yearly" id="yearly">
+						<hlm-radio value="yearly" inputId="yearly">
 							<hlm-radio-indicator indicator />
 						</hlm-radio>
 						<label hlmLabel for="yearly">Yearly ($99.99/year)</label>
 					</div>
 					<div class="flex items-center gap-3">
-						<hlm-radio value="lifetime" id="lifetime">
+						<hlm-radio value="lifetime" inputId="lifetime">
 							<hlm-radio-indicator indicator />
 						</hlm-radio>
 						<label hlmLabel for="lifetime">Lifetime ($299.99)</label>

--- a/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group.preview.ts
@@ -9,19 +9,19 @@ import { HlmRadioGroupImports } from '@spartan-ng/helm/radio-group';
 	template: `
 		<hlm-radio-group [(ngModel)]="spacing">
 			<div class="flex items-center gap-3">
-				<hlm-radio value="default" id="r1" disabled>
+				<hlm-radio value="default" inputId="r1" disabled>
 					<hlm-radio-indicator indicator />
 				</hlm-radio>
 				<label hlmLabel for="r1">Default</label>
 			</div>
 			<div class="flex items-center gap-3">
-				<hlm-radio value="comfortable" id="r2">
+				<hlm-radio value="comfortable" inputId="r2">
 					<hlm-radio-indicator indicator />
 				</hlm-radio>
 				<label hlmLabel for="r2">Comfortable</label>
 			</div>
 			<div class="flex items-center gap-3">
-				<hlm-radio value="compact" id="r3">
+				<hlm-radio value="compact" inputId="r3">
 					<hlm-radio-indicator indicator />
 				</hlm-radio>
 				<label hlmLabel for="r3">Compact</label>
@@ -39,13 +39,13 @@ import { HlmRadioGroupImports } from '@spartan-ng/helm/radio-group';
 export const defaultSkeleton = `
 <hlm-radio-group>
   <div class="flex items-center gap-3">
-    <hlm-radio value="option-one" id="option-one">
+    <hlm-radio value="option-one" inputId="option-one">
       <hlm-radio-indicator indicator />
     </hlm-radio>
     <label hlmLabel for="option-one"> option-one</label>
   </div>
   <div class="flex items-center gap-3">
-    <hlm-radio value="option-two" id="option-two">
+    <hlm-radio value="option-two" inputId="option-two">
       <hlm-radio-indicator indicator />
     </hlm-radio>
     <label hlmLabel for="option-two"> option-two</label>

--- a/apps/app/src/app/pages/(forms)/forms/(reactive-forms)/reactive-forms--checkbox.demo.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(reactive-forms)/reactive-forms--checkbox.demo.ts
@@ -25,7 +25,7 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 							</hlm-field-description>
 							<hlm-field-group>
 								<hlm-field orientation="horizontal">
-									<hlm-checkbox id="responses" formControlName="responses" />
+									<hlm-checkbox inputId="responses" formControlName="responses" />
 									<label hlmFieldLabel class="font-normal" for="responses">Push notifications</label>
 								</hlm-field>
 							</hlm-field-group>
@@ -42,7 +42,7 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 											[forceInvalid]="form.controls.tasks.invalid && form.controls.tasks.touched"
 										>
 											<hlm-checkbox
-												[id]="'task-' + task.id"
+												[inputId]="'task-' + task.id"
 												[forceInvalid]="form.controls.tasks.invalid && form.controls.tasks.touched"
 												[checked]="form.controls.tasks.value.includes(task.id)"
 												(checkedChange)="handleChange($event, task.id)"
@@ -140,7 +140,7 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 							</hlm-field-description>
 							<hlm-field-group>
 								<hlm-field orientation="horizontal">
-									<hlm-checkbox id="responses" formControlName="responses" />
+									<hlm-checkbox inputId="responses" formControlName="responses" />
 									<label hlmFieldLabel class="font-normal" for="responses">Push notifications</label>
 								</hlm-field>
 							</hlm-field-group>
@@ -154,7 +154,7 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 									@for (task of tasks; track task.id) {
 										<hlm-field orientation="horizontal">
 											<hlm-checkbox
-												[id]="'task-' + task.id"
+												[inputId]="'task-' + task.id"
 												[checked]="form.controls.tasks.value.includes(task.id)"
 												(checkedChange)="handleChange($event, task.id)"
 											/>

--- a/apps/app/src/app/pages/(forms)/forms/(reactive-forms)/reactive-forms--radio-group.demo.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(reactive-forms)/reactive-forms--radio-group.demo.ts
@@ -29,7 +29,7 @@ import { HlmRadioGroupImports } from '@spartan-ng/helm/radio-group';
 												<hlm-field-title>{{ plan.title }}</hlm-field-title>
 												<hlm-field-description>{{ plan.description }}</hlm-field-description>
 											</hlm-field-content>
-											<hlm-radio [value]="plan.id" [id]="'plan-' + plan.id">
+											<hlm-radio [value]="plan.id" [inputId]="'plan-' + plan.id">
 												<hlm-radio-indicator indicator />
 											</hlm-radio>
 										</hlm-field>
@@ -119,7 +119,7 @@ import { HlmRadioGroupImports } from '@spartan-ng/helm/radio-group';
 												<hlm-field-title>{{ plan.title }}</hlm-field-title>
 												<hlm-field-description>{{ plan.description }}</hlm-field-description>
 											</hlm-field-content>
-											<hlm-radio [value]="plan.id" [id]="'plan-' + plan.id">
+											<hlm-radio [value]="plan.id" [inputId]="'plan-' + plan.id">
 												<hlm-radio-indicator indicator />
 											</hlm-radio>
 										</hlm-field>

--- a/apps/app/src/app/pages/(forms)/forms/(reactive-forms)/reactive-forms--switch.demo.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(reactive-forms)/reactive-forms--switch.demo.ts
@@ -26,7 +26,7 @@ import { HlmSwitchImports } from '@spartan-ng/helm/switch';
 								</hlm-field-description>
 								<hlm-field-error>It is highly recommended to enable two-factor authentication.</hlm-field-error>
 							</hlm-field-content>
-							<hlm-switch id="two-factor" formControlName="twoFactor" />
+							<hlm-switch inputId="two-factor" formControlName="twoFactor" />
 						</hlm-field>
 					</hlm-field-group>
 				</form>
@@ -86,7 +86,7 @@ import { HlmSwitchImports } from '@spartan-ng/helm/switch';
 								</hlm-field-description>
 								<hlm-field-error>It is highly recommended to enable two-factor authentication.</hlm-field-error>
 							</hlm-field-content>
-							<hlm-switch id="two-factor" formControlName="twoFactor" />
+							<hlm-switch inputId="two-factor" formControlName="twoFactor" />
 						</hlm-field>
 					</hlm-field-group>
 				</form>

--- a/apps/app/src/app/pages/(home)/components/overview/components/appearance-settings.ts
+++ b/apps/app/src/app/pages/(home)/components/overview/components/appearance-settings.ts
@@ -36,7 +36,7 @@ import { HlmSwitch } from '@spartan-ng/helm/switch';
 									<div hlmFieldTitle>Kubernetes</div>
 									<div hlmFieldDescription>Run GPU workloads on a K8s configured cluster.</div>
 								</div>
-								<hlm-radio value="kubernetes" id="kubernetes">
+								<hlm-radio value="kubernetes" inputId="kubernetes">
 									<hlm-radio-indicator indicator />
 								</hlm-radio>
 							</div>
@@ -47,7 +47,7 @@ import { HlmSwitch } from '@spartan-ng/helm/switch';
 									<div hlmFieldTitle>Virtual Machine</div>
 									<div hlmFieldDescription>Access a VM configured cluster to run GPU workloads.</div>
 								</div>
-								<hlm-radio value="virtual-machine" id="virtual-machine">
+								<hlm-radio value="virtual-machine" inputId="virtual-machine">
 									<hlm-radio-indicator indicator />
 								</hlm-radio>
 							</div>
@@ -77,7 +77,7 @@ import { HlmSwitch } from '@spartan-ng/helm/switch';
 					<label hlmFieldLabel for="exp-wallpaper-tinting">Wallpaper Tinting</label>
 					<p hlmFieldDescription>Allow the wallpaper to be tinted.</p>
 				</div>
-				<hlm-switch id="exp-wallpaper-tinting" />
+				<hlm-switch inputId="exp-wallpaper-tinting" />
 			</div>
 		</fieldset>
 	`,

--- a/apps/app/src/app/pages/(home)/components/overview/components/field-checkbox.ts
+++ b/apps/app/src/app/pages/(home)/components/overview/components/field-checkbox.ts
@@ -10,7 +10,7 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 		<fieldset hlmFieldSet>
 			<label hlmFieldLabel for="exp-checkbox">
 				<div hlmField orientation="horizontal">
-					<hlm-checkbox id="exp-checkbox" [checked]="true" />
+					<hlm-checkbox inputId="exp-checkbox" [checked]="true" />
 					<label hlmFieldLabel for="exp-checkbox">I agree to the terms and conditions</label>
 				</div>
 			</label>

--- a/apps/app/src/app/pages/(home)/components/overview/components/field-demo.ts
+++ b/apps/app/src/app/pages/(home)/components/overview/components/field-demo.ts
@@ -89,7 +89,7 @@ import { HlmTextarea } from '@spartan-ng/helm/textarea';
 					<p hlmFieldDescription>The billing address associated with your payment method</p>
 					<div hlmFieldGroup>
 						<div hlmField orientation="horizontal">
-							<hlm-checkbox id="field-preview-billing-address" [checked]="true" />
+							<hlm-checkbox inputId="field-preview-billing-address" [checked]="true" />
 							<label hlmFieldLabel for="field-preview-billing-address">Same as shipping address.</label>
 						</div>
 					</div>

--- a/apps/app/src/app/pages/(home)/components/overview/components/field-hear.ts
+++ b/apps/app/src/app/pages/(home)/components/overview/components/field-hear.ts
@@ -27,7 +27,7 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 										>
 											<hlm-checkbox
 												class="-ml-6 -translate-x-1 rounded-full! transition-all duration-100 ease-linear data-[state=checked]:ml-0 data-[state=checked]:translate-x-0"
-												[id]="option.value"
+												[inputId]="option.value"
 												[checked]="option.value === 'social-media'"
 											/>
 											<div hlmFieldTitle>{{ option.label }}</div>

--- a/apps/app/src/app/pages/(home)/components/overview/components/notion-prompt.ts
+++ b/apps/app/src/app/pages/(home)/components/overview/components/notion-prompt.ts
@@ -169,7 +169,12 @@ type GroupedItems = {
 								<label for="web-search" (click)="$event.stopPropagation()" class="flex flex-1 items-center">
 									<ng-icon hlm name="lucideGlobe" class="mr-2" size="sm" />
 									Web Search
-									<hlm-switch id="web-search" class="ml-auto" [checked]="true" (click)="$event.stopPropagation()" />
+									<hlm-switch
+										inputId="web-search"
+										class="ml-auto"
+										[checked]="true"
+										(click)="$event.stopPropagation()"
+									/>
 								</label>
 							</button>
 						</hlm-dropdown-menu-group>
@@ -180,7 +185,7 @@ type GroupedItems = {
 									<ng-icon hlm name="lucideBlocks" class="mr-2" size="sm" />
 									Apps and Integrations
 									<hlm-switch
-										id="app-integrations"
+										inputId="app-integrations"
 										class="ml-auto"
 										[checked]="true"
 										(click)="$event.stopPropagation()"

--- a/apps/app/src/app/pages/(home)/components/playground/components/preset-action.ts
+++ b/apps/app/src/app/pages/(home)/components/playground/components/preset-action.ts
@@ -43,7 +43,7 @@ import { HlmSwitch } from '@spartan-ng/helm/switch';
 				<div class="py-6">
 					<h4 class="text-muted-foreground text-sm">Playground Warnings</h4>
 					<div class="flex items-start justify-between gap-4 pt-3">
-						<hlm-switch name="show" id="show" [checked]="true" />
+						<hlm-switch name="show" inputId="show" [checked]="true" />
 						<label hlmLabel class="grid gap-1 font-normal" for="show">
 							<span class="font-semibold">Show a warning when content is flagged</span>
 							<span class="text-muted-foreground text-sm">

--- a/apps/ui-storybook/stories/checkbox.stories.ts
+++ b/apps/ui-storybook/stories/checkbox.stories.ts
@@ -19,7 +19,12 @@ import { HlmLabel } from '@spartan-ng/helm/label';
 			<div class="flex items-center gap-4">
 				<label id="checkbox-label" for="testCheckboxDis1" hlmLabel>
 					Test Disabled Checkbox with Reactive Forms
-					<hlm-checkbox class="ml-2" id="testCheckboxDis1" aria-labelledby="testCheckbox" formControlName="checkbox" />
+					<hlm-checkbox
+						class="ml-2"
+						inputId="testCheckboxDis1"
+						aria-labelledby="testCheckbox"
+						formControlName="checkbox"
+					/>
 				</label>
 
 				<button hlmBtn type="button" role="button" (click)="enableOrDisableCheckbox()">
@@ -47,7 +52,7 @@ class HlmCheckboxTester {
 	template: `
 		<form [formGroup]="form" class="space-y-3">
 			<div hlmField orientation="horizontal" class="items-start gap-2">
-				<hlm-checkbox id="field-terms" formControlName="agreement" />
+				<hlm-checkbox inputId="field-terms" formControlName="agreement" />
 				<label hlmFieldLabel class="font-normal">I agree to the terms and conditions.</label>
 				<hlm-field-error>You must accept the terms to continue.</hlm-field-error>
 			</div>
@@ -92,7 +97,7 @@ type Story = StoryObj<HlmCheckbox>;
 export const Default: Story = {
 	render: () => ({
 		template: /* HTML */ `
-			<hlm-checkbox id="testCheckbox" aria-checked="mixed" aria-label="test checkbox" />
+			<hlm-checkbox inputId="testCheckbox" aria-checked="mixed" aria-label="test checkbox" />
 		`,
 	}),
 };
@@ -102,7 +107,7 @@ export const InsideLabel: Story = {
 		template: /* HTML */ `
 			<label id="checkbox-label" class="flex items-center" hlmLabel>
 				Test Checkbox
-				<hlm-checkbox class="ml-2" id="testCheckbox" />
+				<hlm-checkbox class="ml-2" inputId="testCheckbox" />
 			</label>
 		`,
 	}),
@@ -113,7 +118,7 @@ export const LabeledWithAriaLabeledBy: Story = {
 		template: /* HTML */ `
 			<div id="checkbox-label" class="flex items-center">
 				<label id="testCheckbox" for="testCheckboxAria" hlmLabel>Test Checkbox</label>
-				<hlm-checkbox class="ml-2" id="testCheckboxAria" aria-labelledby="testCheckbox" />
+				<hlm-checkbox class="ml-2" inputId="testCheckboxAria" aria-labelledby="testCheckbox" />
 			</div>
 		`,
 	}),
@@ -124,16 +129,16 @@ export const Disabled: Story = {
 		template: /* HTML */ `
 			<div class="flex items-center">
 				<label id="checkbox-label" for="testCheckboxDis1" hlmLabel>Test Checkbox</label>
-				<hlm-checkbox disabled class="ml-2" id="testCheckboxDis1" aria-labelledby="testCheckbox" />
+				<hlm-checkbox disabled class="ml-2" inputId="testCheckboxDis1" aria-labelledby="testCheckbox" />
 			</div>
 
 			<div class="flex items-center pt-4">
-				<hlm-checkbox disabled id="testCheckboxDis2" />
+				<hlm-checkbox disabled inputId="testCheckboxDis2" />
 				<label class="ml-2" for="testCheckboxDis2" hlmLabel>Test Checkbox 2</label>
 			</div>
 
 			<div class="flex items-center pt-4">
-				<hlm-checkbox id="testCheckboxDis3" />
+				<hlm-checkbox inputId="testCheckboxDis3" />
 				<label class="ml-2" for="testCheckboxDis3" hlmLabel>Test Checkbox 3 enabled</label>
 			</div>
 		`,
@@ -153,7 +158,12 @@ export const Indeterminate: Story = {
 		template: /* HTML */ `
 			<div id="checkbox-label" class="flex items-center">
 				<label id="testCheckbox" for="testCheckboxIndeterminate" hlmLabel>Test Checkbox</label>
-				<hlm-checkbox indeterminate="true" class="ml-2" id="testCheckboxIndeterminate" aria-labelledby="testCheckbox" />
+				<hlm-checkbox
+					indeterminate="true"
+					class="ml-2"
+					inputId="testCheckboxIndeterminate"
+					aria-labelledby="testCheckbox"
+				/>
 			</div>
 		`,
 	}),

--- a/apps/ui-storybook/stories/field.stories.ts
+++ b/apps/ui-storybook/stories/field.stories.ts
@@ -91,26 +91,26 @@ export const WithCheckbox: Story = {
 						<p hlmFieldDescription>Select the items you want to show on the desktop.</p>
 						<div hlmFieldGroup class="gap-3">
 							<div hlmField orientation="horizontal">
-								<hlm-checkbox id="field-hard-disks" />
+								<hlm-checkbox inputId="field-hard-disks" />
 								<label hlmFieldLabel for="field-hard-disks" class="font-normal">Hard disks</label>
 							</div>
 							<div hlmField orientation="horizontal">
-								<hlm-checkbox id="field-external-disks" />
+								<hlm-checkbox inputId="field-external-disks" />
 								<label hlmFieldLabel for="field-external-disks" class="font-normal">External disks</label>
 							</div>
 							<div hlmField orientation="horizontal">
-								<hlm-checkbox id="field-cds-dvds-ipods" />
+								<hlm-checkbox inputId="field-cds-dvds-ipods" />
 								<label hlmFieldLabel for="field-cds-dvds-ipods" class="font-normal">CDs, DVDs, and IPods</label>
 							</div>
 							<div hlmField orientation="horizontal">
-								<hlm-checkbox id="field-connected-servers" />
+								<hlm-checkbox inputId="field-connected-servers" />
 								<label hlmFieldLabel for="field-connected-servers" class="font-normal">Connected servers</label>
 							</div>
 						</div>
 					</fieldset>
 					<hlm-field-separator />
 					<div hlmField orientation="horizontal">
-						<hlm-checkbox id="field-sync-desktop-documents" [checked]="true" />
+						<hlm-checkbox inputId="field-sync-desktop-documents" [checked]="true" />
 						<div hlmFieldContent>
 							<label hlmFieldLabel for="field-sync-desktop-documents">Sync Desktop & Documents folders</label>
 							<p hlmFieldDescription>
@@ -138,7 +138,7 @@ export const WithSwitch: Story = {
 							sent to your email.
 						</p>
 					</div>
-					<hlm-switch id="field-2fa" />
+					<hlm-switch inputId="field-2fa" />
 				</div>
 			</div>
 		`,
@@ -155,19 +155,19 @@ export const WithRadio: Story = {
 					<p hlmFieldDescription>Yearly and lifetime plans offer significant savings.</p>
 					<hlm-radio-group data-slot="radio-group" value="monthly">
 						<div hlmField orientation="horizontal">
-							<hlm-radio value="monthly" id="plan-monthly">
+							<hlm-radio value="monthly" inputId="plan-monthly">
 								<hlm-radio-indicator indicator />
 							</hlm-radio>
 							<label hlmFieldLabel for="plan-monthly" class="font-normal">Monthly ($9.99/month)</label>
 						</div>
 						<div hlmField orientation="horizontal">
-							<hlm-radio value="yearly" id="plan-yearly">
+							<hlm-radio value="yearly" inputId="plan-yearly">
 								<hlm-radio-indicator indicator />
 							</hlm-radio>
 							<label hlmFieldLabel for="plan-yearly" class="font-normal">Yearly ($99.99/year)</label>
 						</div>
 						<div hlmField orientation="horizontal">
-							<hlm-radio value="lifetime" id="plan-lifetime">
+							<hlm-radio value="lifetime" inputId="plan-lifetime">
 								<hlm-radio-indicator indicator />
 							</hlm-radio>
 							<label hlmFieldLabel for="plan-lifetime" class="font-normal">Lifetime ($299.99/lifetime)</label>
@@ -284,7 +284,7 @@ export const FieldGroup: Story = {
 						</p>
 						<div hlmFieldGroup data-slot="checkbox-group">
 							<div hlmField orientation="horizontal">
-								<hlm-checkbox id="field-group-push-notifications" disabled [checked]="true" />
+								<hlm-checkbox inputId="field-group-push-notifications" disabled [checked]="true" />
 								<label hlmFieldLabel for="field-group-push-notifications" class="font-normal">Push notifications</label>
 							</div>
 						</div>
@@ -298,11 +298,11 @@ export const FieldGroup: Story = {
 						</p>
 						<div hlmFieldGroup class="gap-3" data-slot="checkbox-group">
 							<div hlmField orientation="horizontal">
-								<hlm-checkbox id="field-group-push-task" />
+								<hlm-checkbox inputId="field-group-push-task" />
 								<label hlmFieldLabel for="field-group-push-task" class="font-normal">Push notifications</label>
 							</div>
 							<div hlmField orientation="horizontal">
-								<hlm-checkbox id="field-group-email-task" />
+								<hlm-checkbox inputId="field-group-email-task" />
 								<label hlmFieldLabel for="field-group-email-task" class="font-normal">Email notifications</label>
 							</div>
 						</div>
@@ -390,7 +390,7 @@ export const ComplexForm: Story = {
 							<p hlmFieldDescription>The billing address associated with your payment method</p>
 							<div hlmFieldGroup>
 								<div hlmField orientation="horizontal">
-									<hlm-checkbox id="field-complex-billing-address" [checked]="true" />
+									<hlm-checkbox inputId="field-complex-billing-address" [checked]="true" />
 									<label hlmFieldLabel for="field-complex-billing-address">Same as shipping address.</label>
 								</div>
 							</div>
@@ -421,15 +421,15 @@ export const HorizontalOrientation: Story = {
 			<div class="w-full max-w-md">
 				<div hlmFieldGroup>
 					<div hlmField orientation="horizontal">
-						<hlm-switch id="field-horizontal-notifications" />
+						<hlm-switch inputId="field-horizontal-notifications" />
 						<label hlmFieldLabel for="field-horizontal-notifications">Enable notifications</label>
 					</div>
 					<div hlmField orientation="horizontal">
-						<hlm-checkbox id="field-horizontal-marketing" />
+						<hlm-checkbox inputId="field-horizontal-marketing" />
 						<label hlmFieldLabel for="field-horizontal-marketing" class="font-normal">Receive marketing emails</label>
 					</div>
 					<div hlmField orientation="horizontal">
-						<hlm-checkbox id="field-horizontal-updates" />
+						<hlm-checkbox inputId="field-horizontal-updates" />
 						<label hlmFieldLabel for="field-horizontal-updates" class="font-normal">Product updates</label>
 					</div>
 				</div>
@@ -445,14 +445,14 @@ export const WithFieldContent: Story = {
 			<div class="w-full max-w-md">
 				<div hlmFieldGroup class="gap-4">
 					<div hlmField orientation="horizontal">
-						<hlm-checkbox id="field-content-security-updates" [checked]="true" />
+						<hlm-checkbox inputId="field-content-security-updates" [checked]="true" />
 						<div hlmFieldContent>
 							<label hlmFieldLabel for="field-content-security-updates">Security Updates</label>
 							<p hlmFieldDescription>Receive emails about your account security and important updates.</p>
 						</div>
 					</div>
 					<div hlmField orientation="horizontal">
-						<hlm-switch id="field-content-two-factor" />
+						<hlm-switch inputId="field-content-two-factor" />
 						<div hlmFieldContent>
 							<label hlmFieldLabel for="field-content-two-factor">Two-Factor Authentication</label>
 							<p hlmFieldDescription>

--- a/apps/ui-storybook/stories/radio-group.stories.ts
+++ b/apps/ui-storybook/stories/radio-group.stories.ts
@@ -189,7 +189,7 @@ export const LabelFor: Story = {
 		template: `
 		<hlm-radio-group class="text-sm font-medium" >
 			<div class="flex items-center gap-3">
-				<hlm-radio value="default" id="default">
+				<hlm-radio value="default" inputId="default">
 					<hlm-radio-indicator indicator />
 				</hlm-radio>
 				<label hlmLabel for="default" >
@@ -197,7 +197,7 @@ export const LabelFor: Story = {
 				</label>
 			</div>
 			<div class="flex items-center gap-3">
-				<hlm-radio value="comfortable" id="comfortable">
+				<hlm-radio value="comfortable" inputId="comfortable">
 					<hlm-radio-indicator indicator />
 				</hlm-radio>
 				<label hlmLabel for="comfortable" >
@@ -205,7 +205,7 @@ export const LabelFor: Story = {
 				</label>
 			</div>
 			<div class="flex items-center gap-3">
-				<hlm-radio value="compact" id="compact">
+				<hlm-radio value="compact" inputId="compact">
 					<hlm-radio-indicator indicator />
 				</hlm-radio>
 				<label hlmLabel for="compact" >
@@ -213,7 +213,7 @@ export const LabelFor: Story = {
 				</label>
 			</div>
 			<div class="flex items-center gap-3">
-				<hlm-radio class="peer group" disabled=true value="disabled" id="disabled">
+				<hlm-radio class="peer group" disabled=true value="disabled" inputId="disabled">
 					<hlm-radio-indicator indicator />
 				</hlm-radio>
 				<label hlmLabel for="disabled" >

--- a/apps/ui-storybook/stories/switch.stories.ts
+++ b/apps/ui-storybook/stories/switch.stories.ts
@@ -16,7 +16,7 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 		<!-- eslint-disable-next-line @angular-eslint/template/label-has-associated-control -->
 		<label class="flex items-center" hlmLabel>
 			test switch
-			<hlm-switch [(ngModel)]="switchValue" id="testSwitchForm" (checkedChange)="handleChange($event)" />
+			<hlm-switch [(ngModel)]="switchValue" inputId="testSwitchForm" (checkedChange)="handleChange($event)" />
 		</label>
 
 		<p data-testid="switchValue">{{ switchValue }}</p>
@@ -45,7 +45,7 @@ export class SwitchForm {
 			<hlm-field-group>
 				<hlm-field>
 					<label id="test-switch-label" hlmFieldLabel>Test Switch</label>
-					<hlm-switch formControlName="test" class="ml-2" id="test-switch-label-with-aria" />
+					<hlm-switch formControlName="test" class="ml-2" inputId="test-switch-label-with-aria" />
 					<p hlmFieldDescription>This is a test switch.</p>
 
 					<hlm-field-error>Test switch must be enabled.</hlm-field-error>
@@ -81,7 +81,7 @@ type Story = StoryObj<BrnSwitch>;
 export const Default: Story = {
 	render: () => ({
 		template: `
-       <hlm-switch id='testSwitchDefault' aria-label='test switch' />
+       <hlm-switch inputId='testSwitchDefault' aria-label='test switch' />
     `,
 	}),
 };
@@ -90,7 +90,7 @@ export const InsideLabel: Story = {
 	render: () => ({
 		template: `
       <label class='flex items-center' hlmLabel> Test Switch
-        <hlm-switch class='ml-2' id='testSwitchInsideLabel' />
+        <hlm-switch class='ml-2' inputId='testSwitchInsideLabel' />
       </label>
     `,
 	}),
@@ -101,7 +101,7 @@ export const LabeledWithAriaLabeledBy: Story = {
 		template: `
       <div class='flex items-center'>
         <label id='testSwitchLabel' for='testSwitchLabeledWithAria' hlmLabel> Test Switch </label>
-        <hlm-switch class='ml-2' id='testSwitchLabeledWithAria' aria-labelledby='testSwitchLabel' />
+        <hlm-switch class='ml-2' inputId='testSwitchLabeledWithAria' aria-labelledby='testSwitchLabel' />
       </div>
     `,
 	}),
@@ -112,7 +112,7 @@ export const Disabled: Story = {
 		template: `
       <div class='flex items-center'>
          <label id='testSwitchLabel' for='testSwitchDisabled' hlmLabel> Disabled Switch </label>
-       <hlm-switch  disabled="true" class='ml-2' id='testSwitchDisabled' aria-labelledby='testSwitchLabel' />
+       <hlm-switch  disabled="true" class='ml-2' inputId='testSwitchDisabled' aria-labelledby='testSwitchLabel' />
       </div>
     `,
 	}),

--- a/libs/cli/generators.json
+++ b/libs/cli/generators.json
@@ -55,6 +55,11 @@
 			"schema": "./src/generators/migrate-hlm/schema.json",
 			"description": "Migrate hlm import from @spartan-ng/brain to @spartan-ng/helm/utils"
 		},
+		"migrate-input-id": {
+			"factory": "./src/generators/migrate-input-id/generator",
+			"schema": "./src/generators/migrate-input-id/schema.json",
+			"description": "Migrate renamed Helm id inputs to inputId"
+		},
 		"migrate-icon": {
 			"factory": "./src/generators/migrate-icon/generator",
 			"schema": "./src/generators/migrate-icon/schema.json",
@@ -166,6 +171,11 @@
 			"factory": "./src/generators/migrate-hlm/compat",
 			"schema": "./src/generators/migrate-hlm/schema.json",
 			"description": "Migrate hlm import from @spartan-ng/brain to @spartan-ng/helm/utils"
+		},
+		"migrate-input-id": {
+			"factory": "./src/generators/migrate-input-id/compat",
+			"schema": "./src/generators/migrate-input-id/schema.json",
+			"description": "Migrate renamed Helm id inputs to inputId"
 		},
 		"migrate-icon": {
 			"factory": "./src/generators/migrate-icon/compat",

--- a/libs/cli/src/generators/healthcheck/generator.spec.ts
+++ b/libs/cli/src/generators/healthcheck/generator.spec.ts
@@ -250,6 +250,19 @@ export class HlmButtonModule {}
 		// add a file with legacy output conventions
 		tree.write('libs/my-lib/src/checkbox-legacy.component.ts', `<brn-checkbox (changed)="onChange($event)"/>`);
 
+		// add files with renamed helm id inputs
+		tree.write(
+			'libs/my-lib/src/input-id-legacy.component.html',
+			`
+				<hlm-checkbox id="checkbox-id" />
+				<hlm-switch [id]="switchId" />
+				<hlm-radio bind-id="radioId" value="monthly" />
+				<hlm-command-input id="command-id" />
+				<input id="native-input" />
+				<hlm-combobox-input id="combobox-id" />
+			`,
+		);
+
 		// add a html file with legacy brain accordion trigger
 		tree.write(
 			'libs/my-lib/src/brn-accordion-trigger-legacy.component.html',
@@ -385,6 +398,17 @@ export class HlmButtonModule {}
 
 		expect(contents).toContain('<brn-checkbox (checkedChange)="onChange($event)"/>');
 		expect(contents).not.toContain('<brn-checkbox (changed)="onChange($event)"/>');
+	});
+
+	it('should update renamed helm id inputs', () => {
+		const contents = tree.read('libs/my-lib/src/input-id-legacy.component.html', 'utf-8');
+
+		expect(contents).toContain('<hlm-checkbox inputId="checkbox-id" />');
+		expect(contents).toContain('<hlm-switch [inputId]="switchId" />');
+		expect(contents).toContain('<hlm-radio bind-inputId="radioId" value="monthly" />');
+		expect(contents).toContain('<hlm-command-input inputId="command-id" />');
+		expect(contents).toContain('<input id="native-input" />');
+		expect(contents).toContain('<hlm-combobox-input id="combobox-id" />');
 	});
 
 	it('should update module imports to const imports', () => {

--- a/libs/cli/src/generators/healthcheck/generator.ts
+++ b/libs/cli/src/generators/healthcheck/generator.ts
@@ -20,6 +20,7 @@ import { helmDialogHealthcheck } from './healthchecks/hlm-dialog';
 import { helmDialogPortalHealthcheck } from './healthchecks/hlm-dialog-portal';
 import { helmFormFieldHealthcheck } from './healthchecks/hlm-form-field';
 import { helmIconHealthcheck } from './healthchecks/hlm-icon';
+import { hlmInputIdHealthcheck } from './healthchecks/hlm-input-id';
 import { helmMenuHealthcheck } from './healthchecks/hlm-menu';
 import { progressHealthcheck } from './healthchecks/hlm-progress';
 import { scrollAreaHealthcheck } from './healthchecks/hlm-scroll-area';
@@ -48,6 +49,7 @@ export async function healthcheckGenerator(tree: Tree, options: HealthcheckGener
 		helmImportsHealthcheck,
 		namingConventionHealthcheck,
 		datePickerHealthcheck,
+		hlmInputIdHealthcheck,
 		progressHealthcheck,
 		hlmImportHealthcheck,
 		brainSeparatorHealthcheck,

--- a/libs/cli/src/generators/healthcheck/healthchecks/hlm-input-id.spec.ts
+++ b/libs/cli/src/generators/healthcheck/healthchecks/hlm-input-id.spec.ts
@@ -1,0 +1,64 @@
+import type { Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { HealthcheckStatus } from '../healthchecks';
+import { runHealthcheck } from '../utils/runner';
+import { hlmInputIdHealthcheck } from './hlm-input-id';
+
+describe('hlm-input-id healthcheck', () => {
+	let tree: Tree;
+
+	beforeEach(() => {
+		tree = createTreeWithEmptyWorkspace();
+	});
+
+	it('should detect legacy id inputs and fix them', async () => {
+		tree.write(
+			'libs/my-lib/src/legacy.component.html',
+			`
+				<hlm-checkbox id="checkbox-id" />
+				<hlm-switch [id]="switchId" />
+				<hlm-radio bind-id="radioId" value="monthly" />
+				<hlm-command-input id="command-id" />
+			`,
+		);
+
+		const report = await runHealthcheck(tree, hlmInputIdHealthcheck, '@spartan-ng/helm');
+
+		expect(report.status).toBe(HealthcheckStatus.Failure);
+		expect(report.fixable).toBe(true);
+
+		if (!('fix' in hlmInputIdHealthcheck)) {
+			throw new Error('Expected hlmInputIdHealthcheck to be fixable.');
+		}
+
+		await hlmInputIdHealthcheck.fix(tree, { importAlias: '@spartan-ng/helm' });
+
+		const content = tree.read('libs/my-lib/src/legacy.component.html', 'utf-8');
+		expect(content).toContain('<hlm-checkbox inputId="checkbox-id" />');
+		expect(content).toContain('<hlm-switch [inputId]="switchId" />');
+		expect(content).toContain('<hlm-radio bind-inputId="radioId" value="monthly" />');
+		expect(content).toContain('<hlm-command-input inputId="command-id" />');
+	});
+
+	it('should not flag native ids, attr bindings, or already migrated inputs', async () => {
+		tree.write(
+			'libs/my-lib/src/current.component.ts',
+			`
+				@Component({
+					template: \`
+						<input id="native-input" />
+						<hlm-checkbox [attr.id]="checkboxAttrId" />
+						<hlm-combobox-input id="combobox-id" />
+						<hlm-switch inputId="switch-id" />
+					\`,
+				})
+				export class CurrentComponent {}
+			`,
+		);
+
+		const report = await runHealthcheck(tree, hlmInputIdHealthcheck, '@spartan-ng/helm');
+
+		expect(report.status).toBe(HealthcheckStatus.Success);
+		expect(report.fixable).toBe(false);
+	});
+});

--- a/libs/cli/src/generators/healthcheck/healthchecks/hlm-input-id.ts
+++ b/libs/cli/src/generators/healthcheck/healthchecks/hlm-input-id.ts
@@ -1,0 +1,34 @@
+import { visitNotIgnoredFiles } from '@nx/devkit';
+import migrateInputIdGenerator from '../../migrate-input-id/generator';
+import { type Healthcheck, HealthcheckSeverity } from '../healthchecks';
+
+const inputIdSelectors = ['hlm-checkbox', 'hlm-switch', 'hlm-radio', 'hlm-command-input'];
+const legacyInputIdPattern = new RegExp(
+	`<(${inputIdSelectors.join('|')})\\b[^>]*(\\sid\\s*=|\\s\\[id\\]\\s*=|\\sbind-id\\s*=)`,
+);
+
+export const hlmInputIdHealthcheck: Healthcheck = {
+	name: 'Helm input id rename',
+	async detect(tree, failure) {
+		visitNotIgnoredFiles(tree, '/', (file) => {
+			if (!file.endsWith('.ts') && !file.endsWith('.html')) {
+				return;
+			}
+
+			const contents = tree.read(file, 'utf-8');
+
+			if (!contents) {
+				return;
+			}
+
+			if (legacyInputIdPattern.test(contents)) {
+				failure('Helm components are using the renamed id input.', HealthcheckSeverity.Error, true);
+			}
+		});
+	},
+	fix: async (tree) => {
+		await migrateInputIdGenerator(tree, { skipFormat: true });
+		return true;
+	},
+	prompt: 'Would you like to migrate renamed Helm id inputs?',
+};

--- a/libs/cli/src/generators/migrate-input-id/compat.ts
+++ b/libs/cli/src/generators/migrate-input-id/compat.ts
@@ -1,0 +1,4 @@
+import { convertNxGenerator } from '@nx/devkit';
+import migrateInputIdGenerator from './generator';
+
+export default convertNxGenerator(migrateInputIdGenerator);

--- a/libs/cli/src/generators/migrate-input-id/generator.spec.ts
+++ b/libs/cli/src/generators/migrate-input-id/generator.spec.ts
@@ -1,0 +1,105 @@
+import { applicationGenerator, E2eTestRunner, UnitTestRunner } from '@nx/angular/generators';
+import type { Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { migrateInputIdGenerator } from './generator';
+
+jest.mock('enquirer');
+jest.mock('@nx/devkit', () => {
+	const original = jest.requireActual('@nx/devkit');
+	return {
+		...original,
+		ensurePackage: (pkg: string) => jest.requireActual(pkg),
+		createProjectGraphAsync: jest.fn().mockResolvedValue({
+			nodes: {},
+			dependencies: {},
+		}),
+	};
+});
+
+describe('migrate-input-id generator', () => {
+	let tree: Tree;
+
+	beforeEach(async () => {
+		tree = createTreeWithEmptyWorkspace();
+
+		await applicationGenerator(tree, {
+			name: 'app',
+			directory: 'app',
+			skipFormat: true,
+			e2eTestRunner: E2eTestRunner.None,
+			unitTestRunner: UnitTestRunner.None,
+			skipPackageJson: true,
+			skipTests: true,
+		});
+	});
+
+	it('should rename static id inputs on supported helm components in html templates', async () => {
+		tree.write(
+			'app/src/app/app.component.html',
+			`
+				<hlm-checkbox id="checkbox-id" />
+				<hlm-switch id="switch-id"></hlm-switch>
+				<hlm-radio id="radio-id" value="monthly"></hlm-radio>
+				<hlm-command-input id="command-id" placeholder="Search" />
+			`,
+		);
+
+		await migrateInputIdGenerator(tree, { skipFormat: true });
+
+		const content = tree.read('app/src/app/app.component.html', 'utf-8');
+		expect(content).toContain('<hlm-checkbox inputId="checkbox-id" />');
+		expect(content).toContain('<hlm-switch inputId="switch-id"></hlm-switch>');
+		expect(content).toContain('<hlm-radio inputId="radio-id" value="monthly"></hlm-radio>');
+		expect(content).toContain('<hlm-command-input inputId="command-id" placeholder="Search" />');
+		expect(content).not.toContain(' id=');
+	});
+
+	it('should rename bound [id] and bind-id inputs in inline templates', async () => {
+		tree.write(
+			'app/src/app/app.component.ts',
+			`
+				import { Component } from '@angular/core';
+
+				@Component({
+					template: \`
+						<hlm-checkbox [id]="checkboxId()" />
+						<hlm-switch bind-id="switchId" />
+						<hlm-radio [id]="radioId" value="yearly"></hlm-radio>
+						<hlm-command-input [id]="commandId" />
+					\`,
+				})
+				export class AppComponent {}
+			`,
+		);
+
+		await migrateInputIdGenerator(tree, { skipFormat: true });
+
+		const content = tree.read('app/src/app/app.component.ts', 'utf-8');
+		expect(content).toContain('<hlm-checkbox [inputId]="checkboxId()" />');
+		expect(content).toContain('<hlm-switch bind-inputId="switchId" />');
+		expect(content).toContain('<hlm-radio [inputId]="radioId" value="yearly"></hlm-radio>');
+		expect(content).toContain('<hlm-command-input [inputId]="commandId" />');
+	});
+
+	it('should not rename native elements, unrelated components, or attr bindings', async () => {
+		tree.write(
+			'app/src/app/app.component.html',
+			`
+				<input id="native-input" />
+				<hlm-combobox-input id="combobox-input" />
+				<hlm-checkbox [attr.id]="checkboxAttrId" />
+				<label for="terms">Terms</label>
+				<hlm-command-input inputId="search" aria-labelledby="search-label" />
+			`,
+		);
+
+		await migrateInputIdGenerator(tree, { skipFormat: true });
+
+		const content = tree.read('app/src/app/app.component.html', 'utf-8');
+		expect(content).toContain('<input id="native-input" />');
+		expect(content).toContain('<hlm-combobox-input id="combobox-input" />');
+		expect(content).toContain('<hlm-checkbox [attr.id]="checkboxAttrId" />');
+		expect(content).toContain('<label for="terms">Terms</label>');
+		expect(content).toContain('<hlm-command-input inputId="search" aria-labelledby="search-label" />');
+	});
+});

--- a/libs/cli/src/generators/migrate-input-id/generator.ts
+++ b/libs/cli/src/generators/migrate-input-id/generator.ts
@@ -1,0 +1,42 @@
+import { formatFiles, type Tree } from '@nx/devkit';
+import { visitFiles } from '../../utils/visit-files';
+import type { MigrateInputIdGeneratorSchema } from './schema';
+
+const inputIdSelectors = ['hlm-checkbox', 'hlm-switch', 'hlm-radio', 'hlm-command-input'];
+const inputIdTagPattern = new RegExp(`<(${inputIdSelectors.join('|')})\\b[^>]*>`, 'g');
+
+export async function migrateInputIdGenerator(tree: Tree, { skipFormat }: MigrateInputIdGeneratorSchema) {
+	replaceLegacyInputIds(tree);
+
+	if (!skipFormat) {
+		await formatFiles(tree);
+	}
+}
+
+function replaceLegacyInputIds(tree: Tree) {
+	visitFiles(tree, '.', (path) => {
+		if (!path.endsWith('.html') && !path.endsWith('.ts')) {
+			return;
+		}
+
+		let content = tree.read(path, 'utf-8');
+
+		if (!content) {
+			return;
+		}
+
+		inputIdTagPattern.lastIndex = 0;
+		content = content.replace(inputIdTagPattern, (tag) => renameLegacyIdInputs(tag));
+
+		tree.write(path, content);
+	});
+}
+
+function renameLegacyIdInputs(tag: string) {
+	return tag
+		.replace(/(\s)\[id\](\s*=)/g, '$1[inputId]$2')
+		.replace(/(\s)bind-id(\s*=)/g, '$1bind-inputId$2')
+		.replace(/(\s)id(\s*=)/g, '$1inputId$2');
+}
+
+export default migrateInputIdGenerator;

--- a/libs/cli/src/generators/migrate-input-id/schema.d.ts
+++ b/libs/cli/src/generators/migrate-input-id/schema.d.ts
@@ -1,0 +1,3 @@
+export interface MigrateInputIdGeneratorSchema {
+	skipFormat?: boolean;
+}

--- a/libs/cli/src/generators/migrate-input-id/schema.json
+++ b/libs/cli/src/generators/migrate-input-id/schema.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"$id": "MigrateInputId",
+	"title": "",
+	"type": "object",
+	"properties": {
+		"skipFormat": {
+			"type": "boolean",
+			"default": false,
+			"description": "Skip formatting files"
+		}
+	},
+	"required": []
+}

--- a/libs/helm/checkbox/src/lib/hlm-checkbox-form.spec.ts
+++ b/libs/helm/checkbox/src/lib/hlm-checkbox-form.spec.ts
@@ -13,7 +13,7 @@ import { HlmCheckbox } from './hlm-checkbox';
 			<label id="test-checkbox" for="checkbox">
 				Airplane mode is: {{ form.value.checkbox ? 'on' : 'off' }}
 				<hlm-checkbox
-					id="checkbox"
+					inputId="checkbox"
 					(checkedChange)="onCheckedChange($event)"
 					formControlName="checkbox"
 					aria-labelledby="test-checkbox"

--- a/libs/helm/checkbox/src/lib/hlm-checkbox.ts
+++ b/libs/helm/checkbox/src/lib/hlm-checkbox.ts
@@ -37,14 +37,13 @@ export const HLM_CHECKBOX_VALUE_ACCESSOR = {
 	host: {
 		class: 'contents peer',
 		'data-slot': 'checkbox',
-		'[attr.id]': 'null',
 		'[attr.aria-label]': 'null',
 		'[attr.aria-labelledby]': 'null',
 		'[attr.data-disabled]': '_disabled() ? "" : null',
 	},
 	template: `
 		<brn-checkbox
-			[id]="id()"
+			[id]="inputId()"
 			[name]="name()"
 			[class]="_computedClass()"
 			[checked]="checked()"
@@ -79,7 +78,7 @@ export class HlmCheckbox implements ControlValueAccessor {
 	);
 
 	/** Used to set the id on the underlying brn element. */
-	public readonly id = input<string | null>(null);
+	public readonly inputId = input<string | null>(null);
 
 	/** Used to set the aria-label attribute on the underlying brn element. */
 	public readonly ariaLabel = input<string | null>(null, { alias: 'aria-label' });

--- a/libs/helm/command/src/lib/hlm-command-input.ts
+++ b/libs/helm/command/src/lib/hlm-command-input.ts
@@ -18,7 +18,7 @@ import { classes } from '@spartan-ng/helm/utils';
 				brnCommandInput
 				data-slot="command-input"
 				class="w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
-				[id]="id()"
+				[id]="inputId()"
 				[placeholder]="placeholder()"
 			/>
 
@@ -29,7 +29,7 @@ import { classes } from '@spartan-ng/helm/utils';
 	`,
 })
 export class HlmCommandInput {
-	public readonly id = input<string | undefined>();
+	public readonly inputId = input<string | undefined>();
 	public readonly placeholder = input<string>('');
 
 	constructor() {

--- a/libs/helm/radio-group/src/lib/hlm-radio.ts
+++ b/libs/helm/radio-group/src/lib/hlm-radio.ts
@@ -23,7 +23,6 @@ import type { ClassValue } from 'clsx';
 	imports: [BrnRadio],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
-		'[attr.id]': 'null',
 		'[attr.aria-label]': 'null',
 		'[attr.aria-labelledby]': 'null',
 		'[attr.aria-describedby]': 'null',
@@ -32,7 +31,7 @@ import type { ClassValue } from 'clsx';
 	},
 	template: `
 		<brn-radio
-			[id]="id()"
+			[id]="inputId()"
 			[class]="_computedClass()"
 			[value]="value()"
 			[required]="required()"
@@ -78,7 +77,7 @@ export class HlmRadio<T = unknown> {
 	);
 
 	/** Used to set the id on the underlying brn element. */
-	public readonly id = input<string | undefined>(undefined);
+	public readonly inputId = input<string | undefined>(undefined);
 
 	/** Used to set the aria-label attribute on the underlying brn element. */
 	public readonly ariaLabel = input<string | undefined>(undefined, { alias: 'aria-label' });
@@ -113,7 +112,8 @@ export class HlmRadio<T = unknown> {
 			if (!this._elementRef.nativeElement || !this._isBrowser) return;
 
 			const labelElement =
-				this._elementRef.nativeElement.closest('label') ?? this._document.querySelector(`label[for="${this.id()}"]`);
+				this._elementRef.nativeElement.closest('label') ??
+				this._document.querySelector(`label[for="${this.inputId()}"]`);
 
 			if (!labelElement) return;
 			this._renderer.setAttribute(labelElement, 'data-disabled', isDisabled ? 'true' : 'false');

--- a/libs/helm/switch/src/lib/hlm-switch.ts
+++ b/libs/helm/switch/src/lib/hlm-switch.ts
@@ -30,7 +30,6 @@ export const HLM_SWITCH_VALUE_ACCESSOR = {
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
 		class: 'contents',
-		'[attr.id]': 'null',
 		'[attr.aria-label]': 'null',
 		'[attr.aria-labelledby]': 'null',
 		'[attr.aria-describedby]': 'null',
@@ -42,7 +41,7 @@ export const HLM_SWITCH_VALUE_ACCESSOR = {
 			(checkedChange)="handleChange($event)"
 			(touched)="_onTouched?.()"
 			[disabled]="_disabled()"
-			[id]="id()"
+			[id]="inputId()"
 			[aria-label]="ariaLabel()"
 			[aria-labelledby]="ariaLabelledby()"
 			[aria-describedby]="ariaDescribedby()"
@@ -72,7 +71,7 @@ export class HlmSwitch implements ControlValueAccessor {
 	});
 
 	/** Used to set the id on the underlying brn element. */
-	public readonly id = input<string | null>(null);
+	public readonly inputId = input<string | null>(null);
 
 	/** Used to set the aria-label attribute on the underlying brn element. */
 	public readonly ariaLabel = input<string | null>(null, { alias: 'aria-label' });

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -1388,7 +1388,7 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "ClassValue",
           },
           {
-            "name": "id",
+            "name": "inputId",
             "required": false,
             "type": "string | null",
           },
@@ -2161,7 +2161,7 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
       "HlmCommandInput": {
         "inputs": [
           {
-            "name": "id",
+            "name": "inputId",
             "required": false,
             "type": "string | undefined",
           },
@@ -4078,7 +4078,7 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "ClassValue",
           },
           {
-            "name": "id",
+            "name": "inputId",
             "required": false,
             "type": "string | undefined",
           },
@@ -5484,7 +5484,7 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "boolean",
           },
           {
-            "name": "id",
+            "name": "inputId",
             "required": false,
             "type": "string | null",
           },


### PR DESCRIPTION
related to #1286

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [x] checkbox
- [ ] collapsible
- [ ] combobox
- [x] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [x] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [x] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

`id` input is inconsistent

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

All old `id` inputs need to be renamed to `inputId`. I guess we should write a migration for the users.

## Other information
