### PR TITLE
fix(dialog,alert-dialog): prevent content width collapse in CDK overlay pane

### DIFF
--- a/libs/cli/src/generators/ui/libs/alert-dialog/files/lib/hlm-alert-dialog-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/alert-dialog/files/lib/hlm-alert-dialog-content.ts.template
@@ -16,7 +16,7 @@ export class HlmAlertDialogContent {
 	constructor() {
 		classes(
 			() =>
-				'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 mx-auto grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:mx-0 sm:max-w-lg',
+				'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 mx-auto grid w-[calc(100vw-2rem)] gap-4 rounded-lg border p-6 shadow-lg data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:mx-0 sm:max-w-lg',
 		);
 	}
 }

--- a/libs/cli/src/generators/ui/libs/dialog/files/lib/hlm-dialog-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/dialog/files/lib/hlm-dialog-content.ts.template
@@ -46,7 +46,7 @@ export class HlmDialogContent {
 
 	constructor() {
 		classes(() => [
-			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 mx-auto grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:mx-0 sm:max-w-lg',
+			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 mx-auto grid w-[calc(100vw-2rem)] gap-4 rounded-lg border p-6 shadow-lg data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:mx-0 sm:max-w-lg',
 			this._dynamicComponentClass,
 		]);
 	}

--- a/libs/helm/alert-dialog/src/lib/hlm-alert-dialog-content.ts
+++ b/libs/helm/alert-dialog/src/lib/hlm-alert-dialog-content.ts
@@ -16,7 +16,7 @@ export class HlmAlertDialogContent {
 	constructor() {
 		classes(
 			() =>
-				'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 mx-auto grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:mx-0 sm:max-w-lg',
+				'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 mx-auto grid w-[calc(100vw-2rem)] gap-4 rounded-lg border p-6 shadow-lg data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:mx-0 sm:max-w-lg',
 		);
 	}
 }

--- a/libs/helm/dialog/src/lib/hlm-dialog-content.ts
+++ b/libs/helm/dialog/src/lib/hlm-dialog-content.ts
@@ -46,7 +46,7 @@ export class HlmDialogContent {
 
 	constructor() {
 		classes(() => [
-			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 mx-auto grid w-full max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-6 shadow-lg data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:mx-0 sm:max-w-lg',
+			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative z-50 mx-auto grid w-[calc(100vw-2rem)] gap-4 rounded-lg border p-6 shadow-lg data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:mx-0 sm:max-w-lg',
 			this._dynamicComponentClass,
 		]);
 	}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

> No new tests: this is a one-line Tailwind class-string change in two primitives. The helm libraries have no existing unit coverage for these class strings, and the regression is visual. The existing Jest suites for `helm-dialog`, `helm-alert-dialog`, and `cli` still pass (28 suites / 148 tests). Docs do not mention the affected class string, so no doc updates are needed.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] alert-dialog
- [x] dialog

### Others

- [x] cli

## What is the current behavior?

Closes #1320

`hlm-dialog-content` and `hlm-alert-dialog-content` ship the class string
`w-full max-w-[calc(100%-2rem)] … sm:max-w-lg`. These elements render inside
Angular CDK's `.cdk-overlay-pane`, a flex item in `.cdk-global-overlay-wrapper`
with `width: auto`. `w-full` on a child of an auto-width flex item resolves to
min-content, and `sm:max-w-lg` is only a ceiling — it cannot raise the width.

Result: any dialog whose content has intrinsic width below 32rem renders at
its min-content width instead of `sm:max-w-lg` (32rem / 512px). In the
reporter's repro the content rendered at ~196px.

## What is the new behavior?

Replaces `w-full max-w-[calc(100%-2rem)]` with `w-[calc(100vw-2rem)]` in both
primitives (CLI templates + helm packages). Width now resolves against the
viewport, so `sm:max-w-lg` functions as intended. Dialogs render at 32rem on
desktop and `100vw - 2rem` on mobile regardless of content width.

The `sm:max-w-lg` ceiling is retained so existing consumer overrides via
`sm:max-w-*` (e.g. `sm:!max-w-[750px]` on the `Dynamic Component` dialog
story) continue to expand dialogs beyond 32rem.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

### Desktop

#### Before

<img width="2736" height="1824" alt="dialog-desktop-before" src="https://github.com/user-attachments/assets/3072ed9b-299c-4551-b630-f79440621741" />

#### After

<img width="2736" height="1824" alt="dialog-desktop-after" src="https://github.com/user-attachments/assets/fa3743b9-bc0b-49c3-b8de-6a14de5e6d2f" />

### Mobile

#### Before

<img width="1290" height="2796" alt="dialog-mobile-before" src="https://github.com/user-attachments/assets/6ab0435b-776e-4bef-b62e-f002fee9662b" />

#### After

<img width="1290" height="2796" alt="dialog-mobile-after" src="https://github.com/user-attachments/assets/94b45c56-1339-413d-83af-cc54019baeae" />
