### PR TITLE
fix(cli): transform spartan classes for hlm-table object literals

### DIFF
--- a/libs/cli/src/generators/base/lib/styles/transform-style-map.test.ts
+++ b/libs/cli/src/generators/base/lib/styles/transform-style-map.test.ts
@@ -468,4 +468,46 @@ export class HlmButton {
 `);
 		});
 	});
+
+	describe('object literal property values', () => {
+		it('replaces spartan classes in HlmTableVariantDefault', async () => {
+			const tableStyleMap: StyleMap = {
+				'spartan-table-container': 'w-full overflow-auto',
+				'spartan-table': 'w-full caption-bottom text-sm',
+				'spartan-table-header': '[&_tr]:border-b',
+				'spartan-table-body': '[&_tr:last-child]:border-0',
+				'spartan-table-footer': 'bg-muted/50 font-medium [&>tr]:last:border-b-0',
+				'spartan-table-row': 'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+				'spartan-table-head': 'text-muted-foreground h-10 px-2 text-left align-middle font-medium',
+				'spartan-table-cell': 'p-2 align-middle',
+				'spartan-table-caption': 'text-muted-foreground mt-4 text-sm',
+			};
+
+			const source = `
+export const HlmTableVariantDefault = {
+	tableContainer: 'spartan-table-container',
+	table: 'spartan-table',
+	thead: 'spartan-table-header',
+	tbody: 'spartan-table-body',
+	tfoot: 'spartan-table-footer',
+	tr: 'spartan-table-row has-aria-expanded:bg-muted/50',
+	th: 'spartan-table-head',
+	td: 'spartan-table-cell',
+	caption: 'spartan-table-caption',
+};
+`;
+
+			const result = await applyTransform(source, tableStyleMap);
+
+			expect(result).not.toContain('spartan-table-container');
+			expect(result).not.toContain('spartan-table-header');
+			expect(result).not.toContain('spartan-table-body');
+			expect(result).not.toContain('spartan-table-footer');
+			expect(result).not.toContain('spartan-table-row');
+			expect(result).not.toContain('spartan-table-head');
+			expect(result).not.toContain('spartan-table-cell');
+			expect(result).not.toContain('spartan-table-caption');
+			expect(result).not.toMatch(/\bspartan-table\b/);
+		});
+	});
 });

--- a/libs/cli/src/generators/base/lib/styles/transform-style-map.ts
+++ b/libs/cli/src/generators/base/lib/styles/transform-style-map.ts
@@ -24,6 +24,7 @@ export const transformStyleMap: TransformerStyle<SourceFile> = async ({ sourceFi
 	applyToHtmlInStrings(sourceFile, styleMap, matchedClasses);
 	applyToRawHtml(sourceFile, styleMap, matchedClasses);
 	applyToCvaCalls(sourceFile, styleMap, matchedClasses);
+	applyToObjectLiteralStrings(sourceFile, styleMap, matchedClasses);
 
 	return sourceFile;
 };
@@ -205,6 +206,17 @@ function removeEmptyArgumentsFromHlm(call: CallExpression) {
 
 function mergeClasses(newClasses: string, existing: string) {
 	return twMerge(newClasses, existing);
+}
+
+function applyToObjectLiteralStrings(sourceFile: SourceFile, styleMap: StyleMap, matchedClasses: Set<string>) {
+	sourceFile.forEachDescendant((node) => {
+		if (!Node.isPropertyAssignment(node)) return;
+
+		const initializer = node.getInitializer();
+		if (!initializer || !isStringLiteralLike(initializer)) return;
+
+		applyStyle(initializer, styleMap, matchedClasses);
+	});
 }
 
 function applyToCvaCalls(sourceFile: SourceFile, styleMap: StyleMap, matchedClasses: Set<string>) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [x] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Table spartan classes are not replaced

```ts
export const HlmTableVariantDefault: HlmTableVariant = {
	tableContainer: 'spartan-table-container',
	table: 'spartan-table',
	thead: 'spartan-table-header',
	tbody: 'spartan-table-body',
	tfoot: 'spartan-table-footer',
	tr: 'spartan-table-row has-aria-expanded:bg-muted/50',
	th: 'spartan-table-head',
	td: 'spartan-table-cell',
	caption: 'spartan-table-caption',
};
```

## What is the new behavior?

Replaces the spartan classes for each style with the tailwind classes

```ts
export const HlmTableVariantDefault: HlmTableVariant = {
  tableContainer: 'relative w-full overflow-x-auto',
  table: 'w-full caption-bottom text-sm',
  thead: '[&_tr]:border-b',
  tbody: '[&_tr:last-child]:border-0',
  tfoot: 'bg-muted/50 border-t font-medium [&>tr]:last:border-b-0',
  tr: 'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
  th: 'text-foreground h-10 px-2 text-start align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pe-0',
  td: 'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pe-0',
  caption: 'text-muted-foreground mt-4 text-sm',
};
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
