### PR TITLE
test(repo): fix contradictory documentation in classes utility tests

### DIFF
--- a/libs/helm/utils/src/lib/hlm.spec.ts
+++ b/libs/helm/utils/src/lib/hlm.spec.ts
@@ -35,7 +35,7 @@ describe('classes', () => {
 		expect(element.className).toBe('bg-red-500 text-white existing-class');
 	});
 
-	it('should handle class merging and deduplication', async () => {
+	it('should prioritize existing element classes over classes added via the utility', async () => {
 		await TestBed.configureTestingModule({}).compileComponents();
 
 		const element = document.createElement('div');
@@ -51,7 +51,7 @@ describe('classes', () => {
 		// Wait for afterRenderEffect to run
 		await new Promise((resolve) => setTimeout(resolve, 0));
 
-		// twMerge should resolve bg conflict, keeping the last one (bg-red-500)
+		// The existing class (bg-blue-500) takes precedence over the utility class (bg-red-500)
 		expect(element.className).toBe('text-white bg-blue-500 p-2');
 	});
 
@@ -323,7 +323,7 @@ describe('classes', () => {
 		expect(testElement.className).not.toContain('text-gray-600'); // First source still loses
 	});
 
-	it('should handle SSR scenario with pre-rendered classes correctly', async () => {
+	it('should handle SSR scenario by preserving pre-rendered classes', async () => {
 		await TestBed.configureTestingModule({}).compileComponents();
 
 		// Simulate SSR scenario: element already has classes from server rendering
@@ -333,7 +333,7 @@ describe('classes', () => {
 		const elementRef = new ElementRef(element);
 
 		TestBed.runInInjectionContext(() => {
-			// Component hydrates and applies classes that should replace the SSR classes
+			// Component hydrates; added classes should merge, but existing SSR classes take precedence on conflict
 			classes(() => 'm-2 bg-red-500 text-black', { elementRef });
 		});
 
@@ -341,14 +341,16 @@ describe('classes', () => {
 
 		const classNames = element.className.split(' ').filter((c) => c.length > 0);
 
-		// Should have new classes from the source, not old SSR classes
-		expect(classNames).toContain('bg-blue-500');
-		expect(classNames).toContain('text-white');
+		// Should contain the non-conflicting new class
 		expect(classNames).toContain('m-2');
 
-		// Should not have conflicting SSR classes (twMerge should handle these)
-		expect(classNames).not.toContain('bg-red-500'); // Blue takes precedence
-		expect(classNames).not.toContain('text-black'); // Replaced by text-white
+		// Should preserve the existing SSR classes
+		expect(classNames).toContain('bg-blue-500');
+		expect(classNames).toContain('text-white');
+
+		// Should not contain the conflicting hydration classes because existing classes win
+		expect(classNames).not.toContain('bg-red-500');
+		expect(classNames).not.toContain('text-black');
 
 		// Should preserve truly external classes that don't conflict
 		expect(classNames).toContain('some-external-class');


### PR DESCRIPTION
Corrects comments and test descriptions in hlm.spec.ts to accurately reflect that existing/SSR classes take precedence over classes applied via the utility. Closes #1222

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Others

- [ ] trpc
- [ ] nx
- [x] repo
- [ ] cli

## What is the current behavior?

The unit tests for the ``classes()`` utility in ``hlm.spec.ts`` contained contradictory comments and descriptions. Specifically, the tests implied that classes added via the utility would replace existing element classes/SSR classes, whereas the actual logic (and the maintainer's intent) is that existing element classes take precedence.

Closes #1222 

## What is the new behavior?
The test descriptions and internal comments have been updated to accurately reflect the library's precedence logic. This ensures that future contributors are not confused by the test suite and that the documentation matches the actual implementation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No