### PR TITLE
fix(pagination): redundant spacing of pagination element

### DIFF
--- a/libs/cli/src/generators/ui/libs/pagination/files/lib/hlm-pagination-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/pagination/files/lib/hlm-pagination-content.ts.template
@@ -9,6 +9,6 @@ import { classes } from '<%- importAlias %>/utils';
 })
 export class HlmPaginationContent {
 	constructor() {
-		classes(() => 'flex flex-row items-center gap-1');
+		classes(() => 'flex flex-row items-center gap-0.5');
 	}
 }

--- a/libs/cli/src/generators/ui/libs/pagination/files/lib/hlm-pagination-ellipsis.ts.template
+++ b/libs/cli/src/generators/ui/libs/pagination/files/lib/hlm-pagination-ellipsis.ts.template
@@ -11,19 +11,18 @@ import { classes } from '<%- importAlias %>/utils';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
 		'data-slot': 'pagination-ellipsis',
+		'aria-hidden': 'true',
 	},
 	template: `
-		<span aria-hidden="true">
-			<ng-icon hlm size="sm" name="lucideEllipsis" />
-			<span class="sr-only">{{ srOnlyText() }}</span>
-		</span>
+		<ng-icon hlm size="sm" name="lucideEllipsis" />
+		<span class="sr-only">{{ srOnlyText() }}</span>
 	`,
 })
 export class HlmPaginationEllipsis {
+	/** Screen reader only text for the ellipsis */
+	public readonly srOnlyText = input<string>('More pages');
+
 	constructor() {
 		classes(() => 'flex size-9 items-center justify-center');
 	}
-
-	/** Screen reader only text for the ellipsis */
-	public readonly srOnlyText = input<string>('More pages');
 }

--- a/libs/cli/src/generators/ui/libs/pagination/files/lib/hlm-pagination-next.ts.template
+++ b/libs/cli/src/generators/ui/libs/pagination/files/lib/hlm-pagination-next.ts.template
@@ -5,7 +5,8 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideChevronRight } from '@ng-icons/lucide';
 import type { ButtonVariants } from '<%- importAlias %>/button';
 import { HlmIcon } from '<%- importAlias %>/icon';
-import { classes } from '<%- importAlias %>/utils';
+import { hlm } from '<%- importAlias %>/utils';
+import type { ClassValue } from 'clsx';
 import { HlmPaginationLink } from './hlm-pagination-link';
 
 @Component({
@@ -16,6 +17,7 @@ import { HlmPaginationLink } from './hlm-pagination-link';
 	template: `
 		<a
 			hlmPaginationLink
+			[class]="_computedClass()"
 			[link]="link()"
 			[queryParams]="queryParams()"
 			[queryParamsHandling]="queryParamsHandling()"
@@ -28,10 +30,7 @@ import { HlmPaginationLink } from './hlm-pagination-link';
 	`,
 })
 export class HlmPaginationNext {
-	constructor() {
-		classes(() => ['gap-1 px-2.5', !this.iconOnly() ? 'sm:pr-2.5' : '']);
-	}
-
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	/** The link to navigate to the next page. */
 	public readonly link = input<RouterLink['routerLink']>();
 	/** The query parameters to pass to the next page. */
@@ -50,4 +49,8 @@ export class HlmPaginationNext {
 	protected readonly _labelClass = computed(() => (this.iconOnly() ? 'sr-only' : 'hidden sm:block'));
 
 	protected readonly _size = computed<ButtonVariants['size']>(() => (this.iconOnly() ? 'icon' : 'default'));
+
+	protected readonly _computedClass = computed(() =>
+		hlm('gap-1 px-2.5', !this.iconOnly() ? 'pr-1.5! sm:pr-2.5' : '', this.userClass()),
+	);
 }

--- a/libs/cli/src/generators/ui/libs/pagination/files/lib/hlm-pagination-previous.ts.template
+++ b/libs/cli/src/generators/ui/libs/pagination/files/lib/hlm-pagination-previous.ts.template
@@ -16,8 +16,8 @@ import { HlmPaginationLink } from './hlm-pagination-link';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		<a
-			[class]="_computedClass()"
 			hlmPaginationLink
+			[class]="_computedClass()"
 			[link]="link()"
 			[queryParams]="queryParams()"
 			[queryParamsHandling]="queryParamsHandling()"

--- a/libs/cli/src/generators/ui/libs/pagination/files/lib/hlm-pagination-previous.ts.template
+++ b/libs/cli/src/generators/ui/libs/pagination/files/lib/hlm-pagination-previous.ts.template
@@ -5,7 +5,8 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideChevronLeft } from '@ng-icons/lucide';
 import type { ButtonVariants } from '<%- importAlias %>/button';
 import { HlmIcon } from '<%- importAlias %>/icon';
-import { classes } from '<%- importAlias %>/utils';
+import { hlm } from '<%- importAlias %>/utils';
+import type { ClassValue } from 'clsx';
 import { HlmPaginationLink } from './hlm-pagination-link';
 
 @Component({
@@ -15,6 +16,7 @@ import { HlmPaginationLink } from './hlm-pagination-link';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		<a
+			[class]="_computedClass()"
 			hlmPaginationLink
 			[link]="link()"
 			[queryParams]="queryParams()"
@@ -28,6 +30,7 @@ import { HlmPaginationLink } from './hlm-pagination-link';
 	`,
 })
 export class HlmPaginationPrevious {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	/** The link to navigate to the previous page. */
 	public readonly link = input<RouterLink['routerLink']>();
 	/** The query parameters to pass to the previous page. */
@@ -44,9 +47,10 @@ export class HlmPaginationPrevious {
 		transform: booleanAttribute,
 	});
 	protected readonly _labelClass = computed(() => (this.iconOnly() ? 'sr-only' : 'hidden sm:block'));
+
 	protected readonly _size = computed<ButtonVariants['size']>(() => (this.iconOnly() ? 'icon' : 'default'));
 
-	constructor() {
-		classes(() => ['gap-1 px-2.5', !this.iconOnly() ? 'sm:pl-2.5' : '']);
-	}
+	protected readonly _computedClass = computed(() =>
+		hlm('gap-1 px-2.5', !this.iconOnly() ? 'pl-1.5! sm:pl-2.5' : '', this.userClass()),
+	);
 }

--- a/libs/cli/src/generators/ui/supported-ui-libraries.json
+++ b/libs/cli/src/generators/ui/supported-ui-libraries.json
@@ -313,7 +313,8 @@
 			"@angular/forms": ">=20.0.0 <22.0.0",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
-			"@angular/router": ">=20.0.0 <22.0.0"
+			"@angular/router": ">=20.0.0 <22.0.0",
+			"clsx": "^2.1.1"
 		}
 	},
 	"popover": {

--- a/libs/helm/pagination/src/lib/hlm-pagination-content.ts
+++ b/libs/helm/pagination/src/lib/hlm-pagination-content.ts
@@ -9,6 +9,6 @@ import { classes } from '@spartan-ng/helm/utils';
 })
 export class HlmPaginationContent {
 	constructor() {
-		classes(() => 'flex flex-row items-center gap-1');
+		classes(() => 'flex flex-row items-center gap-0.5');
 	}
 }

--- a/libs/helm/pagination/src/lib/hlm-pagination-ellipsis.ts
+++ b/libs/helm/pagination/src/lib/hlm-pagination-ellipsis.ts
@@ -11,19 +11,18 @@ import { classes } from '@spartan-ng/helm/utils';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
 		'data-slot': 'pagination-ellipsis',
+		'aria-hidden': 'true',
 	},
 	template: `
-		<span aria-hidden="true">
-			<ng-icon hlm size="sm" name="lucideEllipsis" />
-			<span class="sr-only">{{ srOnlyText() }}</span>
-		</span>
+		<ng-icon hlm size="sm" name="lucideEllipsis" />
+		<span class="sr-only">{{ srOnlyText() }}</span>
 	`,
 })
 export class HlmPaginationEllipsis {
+	/** Screen reader only text for the ellipsis */
+	public readonly srOnlyText = input<string>('More pages');
+
 	constructor() {
 		classes(() => 'flex size-9 items-center justify-center');
 	}
-
-	/** Screen reader only text for the ellipsis */
-	public readonly srOnlyText = input<string>('More pages');
 }

--- a/libs/helm/pagination/src/lib/hlm-pagination-next.ts
+++ b/libs/helm/pagination/src/lib/hlm-pagination-next.ts
@@ -5,7 +5,8 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideChevronRight } from '@ng-icons/lucide';
 import type { ButtonVariants } from '@spartan-ng/helm/button';
 import { HlmIcon } from '@spartan-ng/helm/icon';
-import { classes } from '@spartan-ng/helm/utils';
+import { hlm } from '@spartan-ng/helm/utils';
+import type { ClassValue } from 'clsx';
 import { HlmPaginationLink } from './hlm-pagination-link';
 
 @Component({
@@ -16,6 +17,7 @@ import { HlmPaginationLink } from './hlm-pagination-link';
 	template: `
 		<a
 			hlmPaginationLink
+			[class]="_computedClass()"
 			[link]="link()"
 			[queryParams]="queryParams()"
 			[queryParamsHandling]="queryParamsHandling()"
@@ -28,10 +30,7 @@ import { HlmPaginationLink } from './hlm-pagination-link';
 	`,
 })
 export class HlmPaginationNext {
-	constructor() {
-		classes(() => ['gap-1 px-2.5', !this.iconOnly() ? 'sm:pr-2.5' : '']);
-	}
-
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	/** The link to navigate to the next page. */
 	public readonly link = input<RouterLink['routerLink']>();
 	/** The query parameters to pass to the next page. */
@@ -50,4 +49,8 @@ export class HlmPaginationNext {
 	protected readonly _labelClass = computed(() => (this.iconOnly() ? 'sr-only' : 'hidden sm:block'));
 
 	protected readonly _size = computed<ButtonVariants['size']>(() => (this.iconOnly() ? 'icon' : 'default'));
+
+	protected readonly _computedClass = computed(() =>
+		hlm('gap-1 px-2.5', !this.iconOnly() ? 'pr-1.5! sm:pr-2.5' : '', this.userClass()),
+	);
 }

--- a/libs/helm/pagination/src/lib/hlm-pagination-previous.ts
+++ b/libs/helm/pagination/src/lib/hlm-pagination-previous.ts
@@ -5,7 +5,8 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideChevronLeft } from '@ng-icons/lucide';
 import type { ButtonVariants } from '@spartan-ng/helm/button';
 import { HlmIcon } from '@spartan-ng/helm/icon';
-import { classes } from '@spartan-ng/helm/utils';
+import { hlm } from '@spartan-ng/helm/utils';
+import type { ClassValue } from 'clsx';
 import { HlmPaginationLink } from './hlm-pagination-link';
 
 @Component({
@@ -16,6 +17,7 @@ import { HlmPaginationLink } from './hlm-pagination-link';
 	template: `
 		<a
 			hlmPaginationLink
+			[class]="_computedClass()"
 			[link]="link()"
 			[queryParams]="queryParams()"
 			[queryParamsHandling]="queryParamsHandling()"
@@ -28,6 +30,7 @@ import { HlmPaginationLink } from './hlm-pagination-link';
 	`,
 })
 export class HlmPaginationPrevious {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	/** The link to navigate to the previous page. */
 	public readonly link = input<RouterLink['routerLink']>();
 	/** The query parameters to pass to the previous page. */
@@ -44,9 +47,10 @@ export class HlmPaginationPrevious {
 		transform: booleanAttribute,
 	});
 	protected readonly _labelClass = computed(() => (this.iconOnly() ? 'sr-only' : 'hidden sm:block'));
+
 	protected readonly _size = computed<ButtonVariants['size']>(() => (this.iconOnly() ? 'icon' : 'default'));
 
-	constructor() {
-		classes(() => ['gap-1 px-2.5', !this.iconOnly() ? 'sm:pl-2.5' : '']);
-	}
+	protected readonly _computedClass = computed(() =>
+		hlm('gap-1 px-2.5', !this.iconOnly() ? 'pl-1.5! sm:pl-2.5' : '', this.userClass()),
+	);
 }

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -3791,6 +3791,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
       "HlmPaginationNext": {
         "inputs": [
           {
+            "name": "class",
+            "required": false,
+            "type": "ClassValue",
+          },
+          {
             "name": "link",
             "required": false,
             "type": "RouterLink['routerLink']",
@@ -3827,6 +3832,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
       },
       "HlmPaginationPrevious": {
         "inputs": [
+          {
+            "name": "class",
+            "required": false,
+            "type": "ClassValue",
+          },
           {
             "name": "link",
             "required": false,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [x] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?
- Pagination next & previous button have the wrong spacing, so the width of these button are wrong now ( pic 1 & 2)
- Pagination ellipsis don't be aligned center (pic 3)
- Wrong gap between each pagination element (pic 4)
<img width="1057" height="711" alt="before" src="https://github.com/user-attachments/assets/76cc30ca-ffa8-4f00-aad6-62584e51ffda" />

## What is the new behavior?

- Revert computedClass back to apply direct to <a> tag instead of host
- Remove span
- Change gap-1 to gap-0.5

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
