### PR TITLE
Security: Missing rel="noopener noreferrer" on external link with target="_blank"

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(button)/button--anchor.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(button)/button--anchor.example.ts
@@ -5,7 +5,7 @@ import { HlmButtonImports } from '@spartan-ng/helm/button';
 	selector: 'spartan-button-anchor',
 	imports: [HlmButtonImports],
 	template: `
-		<a hlmBtn target="_blank" variant="link" href="https://github.com/spartan-ng/spartan">Star on GitHub</a>
+		<a hlmBtn target="_blank" variant="link" href="https://github.com/spartan-ng/spartan" rel="noopener noreferrer">Star on GitHub</a>
 	`,
 })
 export class ButtonAnchor {}


### PR DESCRIPTION
## Summary

Security: Missing rel="noopener noreferrer" on external link with target="_blank"

## Problem

**Severity**: `Medium` | **File**: `apps/app/src/app/pages/(components)/components/(button)/button--anchor.example.ts:L9`

The button anchor example opens an external link to GitHub in a new tab but does not include rel="noopener noreferrer", which could allow the opened page to access the window.opener object and potentially manipulate the original page (tabnabbing attack).

## Solution

Add rel="noopener noreferrer" to the anchor tag: <a hlmBtn target="_blank" variant="link" href="https://github.com/spartan-ng/spartan" rel="noopener noreferrer">Star on GitHub</a>

## Changes

- `apps/app/src/app/pages/(components)/components/(button)/button--anchor.example.ts` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security protections for external links that open in new browser tabs. The application now includes additional safeguards to prevent potential security vulnerabilities when users click links designed to open in separate windows, protecting both the application and user browsing sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spartan-ng/spartan/pull/1358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->