### PR TITLE
fix(calendar): calendar range element style

### DIFF
--- a/libs/brain/calendar/src/lib/mode/brn-calendar-range.ts
+++ b/libs/brain/calendar/src/lib/mode/brn-calendar-range.ts
@@ -279,6 +279,11 @@ export class BrnCalendarRange<T> implements BrnCalendarBase<T> {
 			return false;
 		}
 
-		return this._dateAdapter.isAfter(date, start) && this._dateAdapter.isBefore(date, end);
+		return (
+			this._dateAdapter.isAfter(date, start) &&
+			this._dateAdapter.isBefore(date, end) &&
+			!this._dateAdapter.isSameDay(date, start) &&
+			!this._dateAdapter.isSameDay(date, end)
+		);
 	}
 }

--- a/libs/helm/calendar/src/lib/hlm-calendar-range.ts
+++ b/libs/helm/calendar/src/lib/hlm-calendar-range.ts
@@ -128,7 +128,7 @@ import type { ClassValue } from 'clsx';
 							@for (date of week; track _dateAdapter.getTime(date)) {
 								<td
 									brnCalendarCell
-									class="data-[selected]:data-[outside]:bg-accent/50 data-[selected]:bg-accent has-data-[range-start]:after:bg-muted has-data-[range-end]:after:bg-muted relative h-8 w-8 p-0 text-center text-sm focus-within:relative focus-within:z-20 has-data-[range-end]:after:absolute has-data-[range-end]:after:inset-y-0 has-data-[range-end]:after:left-0 has-data-[range-end]:after:w-4 has-data-[range-start]:after:absolute has-data-[range-start]:after:inset-y-0 has-data-[range-start]:after:right-0 has-data-[range-start]:after:w-4 [&:first-child:has([data-range-between])>button]:rounded-l-md [&:last-child:has([data-range-between])>button]:rounded-r-md"
+									class="data-[selected]:data-[outside]:bg-accent/50 data-[selected]:bg-accent has-data-[range-start]:after:bg-accent has-data-[range-end]:after:bg-accent relative h-8 w-8 p-0 text-center text-sm focus-within:relative focus-within:z-20 has-data-[range-end]:after:absolute has-data-[range-end]:after:inset-y-0 has-data-[range-end]:after:left-0 has-data-[range-end]:after:w-4 has-data-[range-start]:after:absolute has-data-[range-start]:after:inset-y-0 has-data-[range-start]:after:right-0 has-data-[range-start]:after:w-4 [&:first-child:has([data-range-between])>button]:rounded-l-md [&:last-child:has([data-range-between])>button]:rounded-r-md"
 								>
 									<button brnCalendarCellButton [date]="date" [class]="_btnClass">
 										{{ _dateAdapter.getDate(date) }}

--- a/libs/helm/calendar/src/lib/hlm-calendar-range.ts
+++ b/libs/helm/calendar/src/lib/hlm-calendar-range.ts
@@ -128,7 +128,7 @@ import type { ClassValue } from 'clsx';
 							@for (date of week; track _dateAdapter.getTime(date)) {
 								<td
 									brnCalendarCell
-									class="data-[selected]:data-[outside]:bg-accent/50 data-[selected]:bg-accent relative h-8 w-8 p-0 text-center text-sm focus-within:relative focus-within:z-20 first:data-[selected]:rounded-l-md last:data-[selected]:rounded-r-md [&:has([aria-selected].day-range-end)]:rounded-r-md"
+									class="data-[selected]:data-[outside]:bg-accent/50 data-[selected]:bg-accent has-data-[range-start]:after:bg-muted has-data-[range-end]:after:bg-muted relative h-8 w-8 p-0 text-center text-sm focus-within:relative focus-within:z-20 has-data-[range-end]:after:absolute has-data-[range-end]:after:inset-y-0 has-data-[range-end]:after:left-0 has-data-[range-end]:after:w-4 has-data-[range-start]:after:absolute has-data-[range-start]:after:inset-y-0 has-data-[range-start]:after:right-0 has-data-[range-start]:after:w-4 [&:first-child:has([data-range-between])>button]:rounded-l-md [&:last-child:has([data-range-between])>button]:rounded-r-md"
 								>
 									<button brnCalendarCellButton [date]="date" [class]="_btnClass">
 										{{ _dateAdapter.getDate(date) }}
@@ -201,13 +201,11 @@ export class HlmCalendarRange<T> {
 
 	protected readonly _btnClass = hlm(
 		buttonVariants({ variant: 'ghost' }),
-		'size-8 p-0 font-normal aria-selected:opacity-100',
+		'relative z-10 size-8 border-0 p-0 font-normal aria-selected:opacity-100',
 		'data-[outside]:text-muted-foreground data-[outside]:aria-selected:text-muted-foreground',
 		'data-[today]:bg-accent data-[today]:text-accent-foreground',
 		'data-[selected]:bg-primary data-[selected]:text-primary-foreground data-[selected]:focus:bg-primary data-[selected]:focus:text-primary-foreground',
 		'data-[disabled]:text-muted-foreground data-[disabled]:opacity-50',
-		'data-[range-start]:rounded-l-md',
-		'data-[range-end]:rounded-r-md',
 		'data-[range-between]:bg-accent data-[range-between]:text-accent-foreground data-[range-between]:rounded-none',
 		'dark:hover:text-accent-foreground',
 	);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [x] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

1. Have a wrong gap between each item in range
2. Base on latest Shadcn style, first and last child in range also have border radius
3. End date of range have the wrong style at the first time render

<img width="930" height="468" alt="calendar-range" src="https://github.com/user-attachments/assets/2110c7eb-00da-4113-8fe1-27e3c49dfff5" />


## What is the new behavior?

1. Have a wrong gap between each item in range => It have the border style inherited from button, so I set `border-0` to remove it
3. End date of range have the wrong style at the first time render
=> I found a bug in func `isBetweenRange` make range end date have both `data-range-end` and `data-range-between`, so it will apply style of range-between to range-end

<img width="1070" height="331" alt="image" src="https://github.com/user-attachments/assets/b15fdb6d-f928-42e9-8a31-ff38dfd8ec57" />

Preview:

<img width="695" height="776" alt="image" src="https://github.com/user-attachments/assets/9594a992-9451-468a-8048-d30f705cb4e0" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined date range selection logic to exclude start and end date endpoints from calculations.

* **Style**
  * Improved visual presentation of calendar date range markers with enhanced styling and better edge rounding for range boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spartan-ng/spartan/pull/1367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->