### PR TITLE
fix(dropdown-menu): prevent submenu collapse and mouseenter reopen after close

### DIFF
--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-trigger.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-trigger.ts
@@ -1,5 +1,5 @@
 import { CdkMenuTrigger } from '@angular/cdk/menu';
-import { computed, Directive, effect, inject, input } from '@angular/core';
+import { computed, Directive, effect, ElementRef, inject, input } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { createMenuPosition, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
 import { injectHlmDropdownMenuConfig } from './hlm-dropdown-menu-token';
@@ -19,6 +19,7 @@ import { injectHlmDropdownMenuConfig } from './hlm-dropdown-menu-token';
 })
 export class HlmDropdownMenuTrigger {
 	private readonly _cdkTrigger = inject(CdkMenuTrigger, { host: true });
+	private readonly _elementRef = inject(ElementRef<HTMLElement>);
 	private readonly _config = injectHlmDropdownMenuConfig();
 
 	public readonly align = input<MenuAlign>(this._config.align);
@@ -41,6 +42,42 @@ export class HlmDropdownMenuTrigger {
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();
+		});
+
+		this._preventMouseenterReopenAfterClose();
+		this._refocusTriggerOnSubmenuClose();
+	}
+
+	// CDK's mouseenter handler reopens a just-closed submenu within the same macrotask.
+	// Suppress open() for one macrotask after close to block the unintended reopen.
+	private _preventMouseenterReopenAfterClose(): void {
+		const trigger = this._cdkTrigger;
+		const originalOpen = trigger.open.bind(trigger);
+		let suppressOpen = false;
+
+		trigger.closed.pipe(takeUntilDestroyed()).subscribe(() => {
+			suppressOpen = true;
+			setTimeout(() => {
+				suppressOpen = false;
+			});
+		});
+
+		trigger.open = () => {
+			if (suppressOpen) return;
+			originalOpen();
+		};
+	}
+
+	// Without focusParentTrigger, submenu close drops focus to document.body,
+	// causing menuStack.hasFocus to resolve false and collapsing the entire tree.
+	// Refocusing the trigger after the DOM settles keeps hasFocus true.
+	private _refocusTriggerOnSubmenuClose(): void {
+		this._cdkTrigger.closed.pipe(takeUntilDestroyed()).subscribe(() => {
+			setTimeout(() => {
+				if (document.activeElement === document.body || document.activeElement === null) {
+					this._elementRef.nativeElement.focus();
+				}
+			});
 		});
 	}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [x] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In dropdown menus that use submenu triggers **without** `cdkTargetMenuAim`, two bugs occur:

1. Clicking a submenu trigger to close it immediately reopens the submenu — CDK's
   internal mouseenter handler fires within the same macrotask while the mouse is
   still over the trigger.

2. Hovering from an open submenu to another menu item collapses the **entire**
   dropdown tree, not just the submenu. CDK closes the submenu overlay without
   returning focus to the parent trigger, focus falls to `document.body`,
   `menuStack.hasFocus` resolves `false`, and the root trigger calls `closeAll()`.


Closes https://github.com/spartan-ng/spartan/issues/1333

## What is the new behavior?

- Hovering away from an open submenu closes only the submenu; the parent dropdown
  remains open.
- Clicking a submenu trigger to close it stays closed; it does not immediately
  reopen via mouseenter.
- All other interactions (click outside, Escape, hover-to-switch between submenus,
  keyboard navigation) are unaffected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

For a demonstration, please click on this issue: https://github.com/spartan-ng/spartan/issues/1333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown menu focus handling to prevent focus loss when closing submenus
  * Fixed unintended submenu re-opening after closure
  * Enhanced menu tree stability to maintain context when navigating between menu items

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spartan-ng/spartan/pull/1370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->