### PR TITLE
fix(accordion): prevent NG0600 when focus changes during change detection

### DIFF
--- a/libs/brain/accordion/src/lib/brn-accordion-trigger.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-trigger.ts
@@ -1,5 +1,5 @@
 import type { FocusableOption } from '@angular/cdk/a11y';
-import { computed, DestroyRef, Directive, ElementRef, inject, isDevMode } from '@angular/core';
+import { computed, DestroyRef, Directive, ElementRef, inject, isDevMode, untracked } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { fromEvent } from 'rxjs';
 import { injectBrnAccordion, injectBrnAccordionItem } from './brn-accordion-token';
@@ -51,7 +51,9 @@ export class BrnAccordionTrigger implements FocusableOption {
 		fromEvent(this._el.nativeElement, 'focus')
 			.pipe(takeUntilDestroyed())
 			.subscribe(() => {
-				this._accordion.setActiveItem(this);
+				// Focus can land here mid-render, and setActiveItem writes the key manager's signals.
+				// untracked keeps that from throwing NG0600 (those signals aren't read by any view). #1371
+				untracked(() => this._accordion.setActiveItem(this));
 			});
 	}
 

--- a/libs/brain/accordion/src/lib/brn-accordion.spec.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.spec.ts
@@ -1,0 +1,129 @@
+import { FocusMonitor, type FocusOrigin } from '@angular/cdk/a11y';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { render, screen } from '@testing-library/angular';
+import { config, type Observable, Subject } from 'rxjs';
+import { BrnAccordion } from './brn-accordion';
+import { BrnAccordionContent } from './brn-accordion-content';
+import { BrnAccordionItem } from './brn-accordion-item';
+import { BrnAccordionTrigger } from './brn-accordion-trigger';
+
+// A signal write that throws inside an RxJS subscriber is reported via RxJS' unhandled-error
+// channel, not thrown synchronously, so capture it there and flush the macrotask it uses.
+async function collectUnhandledErrors(body: () => void | Promise<void>): Promise<unknown[]> {
+	const unhandled: unknown[] = [];
+	const previousOnUnhandledError = config.onUnhandledError;
+	config.onUnhandledError = (error) => unhandled.push(error);
+	try {
+		await body();
+	} finally {
+		// Flush the macrotask RxJS uses to surface unhandled subscriber errors, then restore -
+		// in a finally so a throwing body still captures (not leaks) any queued error.
+		await new Promise((resolve) => setTimeout(resolve));
+		config.onUnhandledError = previousOnUnhandledError;
+	}
+	return unhandled;
+}
+
+function ng0600Errors(errors: unknown[]): unknown[] {
+	return errors.filter((error) => String((error as Error)?.message ?? error).includes('NG0600'));
+}
+
+// Lets a test push focus-origin changes on demand, standing in for the real FocusMonitor.
+class FakeFocusMonitor {
+	public readonly origin$ = new Subject<FocusOrigin>();
+	monitor(): Observable<FocusOrigin> {
+		return this.origin$;
+	}
+	stopMonitoring(): void {
+		/* noop */
+	}
+}
+
+// probe() is bound in the template, so it runs during render. When armed it fires onRender,
+// letting a test reproduce a focus/blur event arriving mid-change-detection.
+abstract class ProbeHost {
+	public readonly armed = signal(false);
+	public onRender: () => void = () => {
+		/* set by the test */
+	};
+
+	probe(): string {
+		if (this.armed()) {
+			this.onRender();
+		}
+		return '';
+	}
+}
+
+@Component({
+	imports: [BrnAccordion, BrnAccordionItem, BrnAccordionTrigger, BrnAccordionContent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div brnAccordion>
+			<div brnAccordionItem isOpened>
+				<h3>
+					<button brnAccordionTrigger>Item</button>
+				</h3>
+				<brn-accordion-content>{{ probe() }}</brn-accordion-content>
+			</div>
+		</div>
+	`,
+})
+class AccordionBlurDuringRenderSpec extends ProbeHost {}
+
+@Component({
+	imports: [BrnAccordion, BrnAccordionItem, BrnAccordionTrigger, BrnAccordionContent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div brnAccordion>
+			<div brnAccordionItem isOpened>
+				<h3>
+					<button brnAccordionTrigger>One</button>
+				</h3>
+				<brn-accordion-content>{{ probe() }}</brn-accordion-content>
+			</div>
+			<div brnAccordionItem>
+				<h3>
+					<button brnAccordionTrigger data-testid="other-trigger">Two</button>
+				</h3>
+				<brn-accordion-content>Two</brn-accordion-content>
+			</div>
+		</div>
+	`,
+})
+class AccordionTriggerFocusDuringRenderSpec extends ProbeHost {}
+
+describe('BrnAccordion', () => {
+	// #1371: disabling a focused child blurs it during CD, so the FocusMonitor emits mid-render.
+	it('does not throw NG0600 when the focus monitor emits during change detection', async () => {
+		const focusMonitor = new FakeFocusMonitor();
+
+		const errors = await collectUnhandledErrors(async () => {
+			const { fixture, detectChanges } = await render(AccordionBlurDuringRenderSpec, {
+				providers: [{ provide: FocusMonitor, useValue: focusMonitor }],
+			});
+
+			// Focus first, then emit a blur (origin null) during the next render.
+			focusMonitor.origin$.next('program');
+			fixture.componentInstance.onRender = () => focusMonitor.origin$.next(null);
+			fixture.componentInstance.armed.set(true);
+			detectChanges();
+		});
+
+		expect(ng0600Errors(errors)).toEqual([]);
+	});
+
+	// Sibling of #1371: a trigger focused mid-render syncs CDK's key manager, which writes signals.
+	it('does not throw NG0600 when a trigger receives focus during change detection', async () => {
+		const errors = await collectUnhandledErrors(async () => {
+			const { fixture, detectChanges } = await render(AccordionTriggerFocusDuringRenderSpec);
+
+			const otherTrigger = screen.getByTestId('other-trigger');
+			fixture.componentInstance.onRender = () => otherTrigger.dispatchEvent(new FocusEvent('focus'));
+			fixture.componentInstance.armed.set(true);
+			detectChanges();
+		});
+
+		expect(ng0600Errors(errors)).toEqual([]);
+	});
+});

--- a/libs/brain/accordion/src/lib/brn-accordion.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.ts
@@ -59,7 +59,9 @@ export class BrnAccordion implements AfterContentInit, OnDestroy {
 			.skipPredicate((item) => item.disabled),
 	);
 
-	private readonly _focused = signal<boolean>(false);
+	// Not a signal: FocusMonitor can fire mid-render (a disabled child blurs during change
+	// detection) and a signal write there throws NG0600. Only read imperatively in keydown. #1371
+	private _focused = false;
 	private readonly _openItemIds = signal<number[]>([]);
 	public readonly openItemIds = this._openItemIds.asReadonly();
 	public readonly state = computed(() => (this._openItemIds().length > 0 ? 'open' : 'closed'));
@@ -87,7 +89,9 @@ export class BrnAccordion implements AfterContentInit, OnDestroy {
 			this._keyManager()?.onKeydown(event);
 			this.preventDefaultEvents(event);
 		});
-		this._focusMonitor.monitor(this._el, true).subscribe((origin) => this._focused.set(origin !== null));
+		this._focusMonitor.monitor(this._el, true).subscribe((origin) => {
+			this._focused = origin !== null;
+		});
 	}
 
 	ngOnDestroy(): void {
@@ -153,7 +157,7 @@ export class BrnAccordion implements AfterContentInit, OnDestroy {
 
 	private preventDefaultEvents(event: KeyboardEvent) {
 		if (event.defaultPrevented) return;
-		if (!this._focused()) return;
+		if (!this._focused) return;
 		if (!('key' in event)) return;
 
 		const keys: readonly string[] =


### PR DESCRIPTION
## Closes #1371

### Problem
When a focused element inside an accordion is disabled mid-render (e.g. a button in `hlm-accordion-content` that sets `[disabled]="true"` on click), the browser synchronously blurs it during change detection. The accordion's `FocusMonitor` subscription reacts to that blur and writes a signal while Angular is rendering, throwing:

```
ERROR RuntimeError: NG0600: Writing to signals is not allowed while Angular renders the template
```

### Fix
- **`BrnAccordion`**: `_focused` is now a plain field instead of a signal. It was only ever read imperatively from the keydown handler, so it never needed to be reactive, and a plain-field write during CD is allowed.
- **`BrnAccordionTrigger`**: a trigger can also receive focus mid-render (focus restoration when a focused sibling is disabled/removed), and `setActiveItem` writes CDK key-manager signals. Those signals aren't read by any view, so the write is safe - wrapped it in `untracked` to let it through without crashing change detection.

### Tests
Added `brn-accordion.spec.ts` with two regression tests covering both paths (the FocusMonitor subscription and the trigger's `setActiveItem`). Both fail with the real `NG0600` error when the fix is reverted and pass with it applied. jsdom can't reproduce the browser's native disable-blur step, so the tests inject the mid-render emission at the same point the real FocusMonitor does (`subject.next(null)` / a `focus` event during render). Keyboard navigation remains covered by the existing cypress e2e.

Full brain suite passes; build and lint are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed accordion rendering errors that could occur when focus lands during mid-render/change-detection cycles.

* **Tests**
  * Added regression tests covering focus-event scenarios to ensure no reoccurrence of the issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->