### PR TITLE
fix: correct sidebar shadow and align vega button to shadcn

### DIFF
--- a/libs/registry/src/styles/style-luma.css
+++ b/libs/registry/src/styles/style-luma.css
@@ -1054,7 +1054,7 @@
 	}
 
 	.spartan-sidebar-menu-button-variant-outline {
-		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))];
+		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--sidebar-accent)];
 	}
 
 	.spartan-sidebar-menu-button-size-default {

--- a/libs/registry/src/styles/style-lyra.css
+++ b/libs/registry/src/styles/style-lyra.css
@@ -1095,7 +1095,7 @@
 	}
 
 	.spartan-sidebar-menu-button-variant-outline {
-		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))];
+		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--sidebar-accent)];
 	}
 
 	.spartan-sidebar-menu-button-size-default {

--- a/libs/registry/src/styles/style-maia.css
+++ b/libs/registry/src/styles/style-maia.css
@@ -1120,7 +1120,7 @@
 	}
 
 	.spartan-sidebar-menu-button-variant-outline {
-		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))];
+		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--sidebar-accent)];
 	}
 
 	.spartan-sidebar-menu-button-size-default {

--- a/libs/registry/src/styles/style-mira.css
+++ b/libs/registry/src/styles/style-mira.css
@@ -1122,7 +1122,7 @@
 	}
 
 	.spartan-sidebar-menu-button-variant-outline {
-		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))];
+		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--sidebar-accent)];
 	}
 
 	.spartan-sidebar-menu-button-size-default {

--- a/libs/registry/src/styles/style-nova.css
+++ b/libs/registry/src/styles/style-nova.css
@@ -1120,7 +1120,7 @@
 	}
 
 	.spartan-sidebar-menu-button-variant-outline {
-		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))];
+		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--sidebar-accent)];
 	}
 
 	.spartan-sidebar-menu-button-size-default {

--- a/libs/registry/src/styles/style-vega.css
+++ b/libs/registry/src/styles/style-vega.css
@@ -159,7 +159,7 @@
 	}
 
 	&.spartan-button-variant-secondary {
-		@apply bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground;
+		@apply bg-secondary text-secondary-foreground aria-expanded:bg-secondary aria-expanded:text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)];
 	}
 
 	&.spartan-button-variant-ghost {
@@ -187,7 +187,7 @@
 	}
 
 	&.spartan-button-size-lg {
-		@apply h-10 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3;
+		@apply h-10 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2;
 	}
 
 	&.spartan-button-size-icon-xs {
@@ -1116,7 +1116,7 @@
 	}
 
 	&.spartan-sidebar-menu-button-variant-outline {
-		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))];
+		@apply bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--sidebar-accent)];
 	}
 
 	&.spartan-sidebar-menu-button-size-default {


### PR DESCRIPTION
## Summary

Fixes an invalid CSS shadow on the sidebar menu button and brings the vega button into exact parity with the shadcn vega preset.

### 1. Sidebar shadow `hsl()` typo (all 6 themes)

`.spartan-sidebar-menu-button-variant-outline` wrapped the shadow color in `hsl()`:

```diff
- shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]
+ shadow-[0_0_0_1px_var(--sidebar-border)]      hover:shadow-[0_0_0_1px_var(--sidebar-accent)]
```

`--sidebar-border` / `--sidebar-accent` are already `oklch()` color values, so `hsl(oklch(...))` is invalid and the browser drops the box-shadow entirely. The bare `var()` reference matches shadcn's sidebar.

> Note: this class is not currently wired up by the live `hlm-sidebar-menu-button` directive (which inlines its own `shadow-sidebar-border`), so the fix is latent correctness rather than a visible change today. It pays off when the component is migrated onto the style-class system.

### 2. vega button parity with shadcn (vega only)

- secondary variant hover: `bg-secondary/80` -> `bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)]`
- `size-lg` inline-icon padding: `pr-3/pl-3` -> `pr-2/pl-2`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar menu button outline styling with refined shadow and color application across all design themes.
  * Adjusted secondary button hover state color for better visual consistency.
  * Refined button size adjustments for improved spacing and padding alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->