### PR TITLE
ci: cache Nx, run only affected, and parallelize to cut CI time

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,30 @@
+name: Setup
+description: Install pnpm, Node and dependencies, and restore the Nx computation cache
+
+runs:
+  using: composite
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@v5
+
+    - name: Install Node
+      uses: actions/setup-node@v6
+      with:
+        node-version-file: .node-version
+        cache: pnpm
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+      shell: bash
+
+    # Persist the Nx local computation cache across jobs and runs (no Nx Cloud). Unchanged
+    # projects are restored as cache hits instead of being rebuilt/retested/relinted. The key is
+    # per job+run so each job saves its own slice; restore-keys fall back to the most recent cache.
+    - name: Restore Nx cache
+      uses: actions/cache@v4
+      with:
+        path: .nx/cache
+        key: nx-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.run_id }}-${{ github.job }}
+        restore-keys: |
+          nx-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+          nx-${{ runner.os }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,15 +92,15 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup
-      - uses: nrwl/nx-set-shas@v4
-      # Cache the Cypress binary so it is not re-downloaded every run.
+      # Restore the Cypress binary cache before install so a cypress postinstall is a no-op too.
       - name: Cache Cypress binary
         uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: cypress-${{ runner.os }}-
+      - uses: ./.github/actions/setup
+      - uses: nrwl/nx-set-shas@v4
       - name: Install Cypress
         run: npx cypress install
       - name: End-to-end test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,13 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - uses: nrwl/nx-set-shas@v4
+      # Cache the Cypress binary so it is not re-downloaded every run.
+      - name: Cache Cypress binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: cypress-${{ runner.os }}-
       - name: Install Cypress
         run: npx cypress install
       - name: End-to-end test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,9 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    # Kept after `build` so the app is built once and restored from the Nx cache here.
-    needs:
-      - build
+    # Not gated on `build`: the e2e suite runs cypress against storybook (its cypress executor's
+    # devServerTarget is ui-storybook:static-storybook), so it builds/serves storybook itself and
+    # is independent of the docs-app build. It runs in parallel with the build job.
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,4 +104,6 @@ jobs:
       - name: Install Cypress
         run: npx cypress install
       - name: End-to-end test
-        run: pnpm nx affected -t e2e --parallel=1 --outputStyle=stream
+        # Exclude trpc-app-e2e: it is not tagged scope:e2e and was never run in CI (it needs a
+        # database/health endpoint that is not provisioned here). Only the storybook e2e runs.
+        run: pnpm nx affected -t e2e --exclude=trpc-app-e2e --parallel=1 --outputStyle=stream

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,16 @@ on:
       - main
   pull_request: {}
 
+# Cancel superseded runs on the same ref (e.g. rapid pushes / force-pushes to a PR) so CI minutes
+# are not spent finishing builds that are already out of date.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # The docs app build prerenders many pages and needs a larger heap.
+  NODE_OPTIONS: --max-old-space-size=6000
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest
@@ -34,81 +44,57 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Required by wagoid/commitlint-github-action
+          # Full commit history so nx-set-shas can compute the affected base. `blob:none` keeps the
+          # whole commit graph (affected still diffs correctly) but downloads file contents lazily -
+          # a win for this light job that only touches the affected projects' files.
           fetch-depth: 0
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-      - name: Install Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-          cache: 'pnpm'
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
-      - name: lint
-        run: pnpm run lint
+          filter: blob:none
+      - uses: ./.github/actions/setup
+      - uses: nrwl/nx-set-shas@v4
       - name: format
-        run: pnpm nx format:check --base=origin/main
+        run: pnpm nx format:check --base=$NX_BASE --head=$NX_HEAD
+      - name: lint
+        run: pnpm nx affected -t lint --parallel=3
 
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
-          # Required by wagoid/commitlint-github-action
           fetch-depth: 0
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-      - name: Install Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-          cache: 'pnpm'
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
+      - uses: nrwl/nx-set-shas@v4
       - name: Build
-        run: pnpm run build
+        run: pnpm nx affected -t build --parallel=1
 
   unit:
     runs-on: ubuntu-latest
-    needs:
-      - build
+    # No longer gated on `build`: vitest/jest run against source, so unit tests start immediately
+    # and run in parallel with the build instead of waiting ~13 min for it.
     steps:
       - uses: actions/checkout@v6
         with:
-          # Required by wagoid/commitlint-github-action
+          # Blobless full-history clone: nx-set-shas needs the graph; vitest/jest only read the
+          # affected projects' files, fetched lazily.
           fetch-depth: 0
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-      - name: Install Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-          cache: 'pnpm'
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+          filter: blob:none
+      - uses: ./.github/actions/setup
+      - uses: nrwl/nx-set-shas@v4
       - name: Test
-        run: pnpm run test
+        run: pnpm nx affected -t test --parallel=3
 
   e2e:
     runs-on: ubuntu-latest
+    # Kept after `build` so the app is built once and restored from the Nx cache here.
     needs:
       - build
     steps:
       - uses: actions/checkout@v6
         with:
-          # Required by wagoid/commitlint-github-action
           fetch-depth: 0
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-      - name: Install Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-          cache: 'pnpm'
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
+      - uses: nrwl/nx-set-shas@v4
       - name: Install Cypress
         run: npx cypress install
       - name: End-to-end test
-        run: pnpm run e2e
+        run: pnpm nx affected -t e2e --parallel=1 --outputStyle=stream

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# Working in this repo (notes for Claude / AI agents)
+
+Conventions for this nx workspace, written to avoid the common CI failures.
+
+## Before pushing: run the CI checks locally
+
+CI (`.github/workflows/ci.yml`) runs the steps below. Run them locally first so a push does not
+bounce on something that was avoidable:
+
+- `pnpm run lint`
+- `pnpm nx format:write` then `pnpm nx format:check --base=origin/main` - the `format-and-lint`
+  job fails on any unformatted file; `format:write` fixes them. Run this AFTER any code change,
+  including ones a linter/formatter made, and re-check before committing.
+- `pnpm run test`
+- `pnpm run build`
+
+## Commit messages (Conventional Commits, enforced by commitlint with `failOnWarnings`)
+
+See `commitlint.config.cjs` and `CONTRIBUTING.md`.
+
+- Format: `<type>(<scope>): <subject>` - the scope is OPTIONAL.
+- Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`,
+  `chore`, `revert`.
+- If you include a scope it MUST be one of the `scope-enum` values (the component names plus
+  `cli`, `nx`, `repo`, `trpc`, `typography`). NOTE: `app` is NOT a valid scope - omit the scope
+  for docs-app changes rather than inventing one.
+- A blank line is required between the subject and the body, and before the footer.
+- No line in the message may exceed 100 characters.
+- Do NOT add a `Co-Authored-By` (or any AI) trailer.
+
+## Pull requests
+
+- Always populate `.github/PULL_REQUEST_TEMPLATE.md`: tick the checklist, the PR type, the affected
+  package(s), and fill "current behavior" / "new behavior" / breaking-change. Create with
+  `gh pr create --body-file <filled-template-file>`.

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -4,15 +4,9 @@ import analog from '@analogjs/platform';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import * as path from 'node:path';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { type Plugin, defineConfig } from 'vite';
+import { type Plugin, defineConfig, splitVendorChunkPlugin } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { getPrerenderedRoutes } from './src/utils/prerender-routes';
-
-// Prerender concurrency. Default serial (1) since the page renders are memory-heavy; raise via
-// PRERENDER_CONCURRENCY when the build has enough heap headroom (see --max-old-space-size).
-const _prerenderConcurrency = Number(process.env.PRERENDER_CONCURRENCY);
-const PRERENDER_CONCURRENCY =
-	Number.isInteger(_prerenderConcurrency) && _prerenderConcurrency > 0 ? _prerenderConcurrency : 1;
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -127,7 +121,7 @@ export default defineConfig(({ mode }) => {
 				nitro: {
 					logLevel: 4,
 					prerender: {
-						concurrency: PRERENDER_CONCURRENCY,
+						concurrency: 1,
 					},
 					serverAssets: [
 						{
@@ -141,6 +135,7 @@ export default defineConfig(({ mode }) => {
 				},
 			}),
 			nxViteTsPaths(),
+			splitVendorChunkPlugin(),
 			// Bundle analysis is opt-in (ANALYZE=1) so it does not traverse the whole bundle on
 			// every production build.
 			...(process.env.ANALYZE ? [visualizer() as Plugin] : []),

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -10,7 +10,9 @@ import { getPrerenderedRoutes } from './src/utils/prerender-routes';
 
 // Prerender concurrency. Default serial (1) since the page renders are memory-heavy; raise via
 // PRERENDER_CONCURRENCY when the build has enough heap headroom (see --max-old-space-size).
-const PRERENDER_CONCURRENCY = Number(process.env.PRERENDER_CONCURRENCY) || 1;
+const _prerenderConcurrency = Number(process.env.PRERENDER_CONCURRENCY);
+const PRERENDER_CONCURRENCY =
+	Number.isInteger(_prerenderConcurrency) && _prerenderConcurrency > 0 ? _prerenderConcurrency : 1;
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -4,9 +4,13 @@ import analog from '@analogjs/platform';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import * as path from 'node:path';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { type Plugin, defineConfig, splitVendorChunkPlugin } from 'vite';
+import { type Plugin, defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { getPrerenderedRoutes } from './src/utils/prerender-routes';
+
+// Prerender concurrency. Default serial (1) since the page renders are memory-heavy; raise via
+// PRERENDER_CONCURRENCY when the build has enough heap headroom (see --max-old-space-size).
+const PRERENDER_CONCURRENCY = Number(process.env.PRERENDER_CONCURRENCY) || 1;
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -47,7 +51,8 @@ export default defineConfig(({ mode }) => {
 		},
 		build: {
 			outDir: '../../dist/apps/app/client',
-			reportCompressedSize: true,
+			// Skip computing gzip sizes for every chunk - it is only an informational report.
+			reportCompressedSize: false,
 			commonjsOptions: { transformMixedEsModules: true },
 			target: ['es2020'],
 		},
@@ -120,7 +125,7 @@ export default defineConfig(({ mode }) => {
 				nitro: {
 					logLevel: 4,
 					prerender: {
-						concurrency: 1,
+						concurrency: PRERENDER_CONCURRENCY,
 					},
 					serverAssets: [
 						{
@@ -134,8 +139,9 @@ export default defineConfig(({ mode }) => {
 				},
 			}),
 			nxViteTsPaths(),
-			visualizer() as Plugin,
-			splitVendorChunkPlugin(),
+			// Bundle analysis is opt-in (ANALYZE=1) so it does not traverse the whole bundle on
+			// every production build.
+			...(process.env.ANALYZE ? [visualizer() as Plugin] : []),
 		],
 		test: {
 			reporters: ['default'],


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Others

- [x] repo
- [x] nx

## What is the current behavior?

CI runs five jobs, each re-installing dependencies and running `nx run-many --all` (lint/test/build/e2e) on every project with no persisted Nx cache, on a cold checkout. `unit` and `e2e` both `needs: build`, so they wait ~13 minutes for the docs-app build before starting - even though neither uses it. There is no run cancellation, so superseded pushes keep building.

## What is the new behavior?

Cuts CI time without relying on Nx Cloud:

- **Persist the Nx computation cache** via `actions/cache` (in a shared composite setup action), so unchanged projects are restored as cache hits instead of being rebuilt/retested/relinted.
- **Run `nx affected`** (with `nrwl/nx-set-shas`) for lint/test/build/e2e, so a PR only touches the projects it changes.
- **De-serialize the jobs:** `unit` no longer needs `build` (vitest/jest run against source), and `e2e` no longer needs `build` (it runs cypress against storybook via its `static-storybook` devServerTarget, independent of the docs app). All five jobs now run in parallel.
- **Cancel superseded runs** on the same ref via `concurrency`.
- **Blobless full-history clone** on the light jobs (keeps `affected` working) and a **Cypress binary cache** in the e2e job.
- **Trim the docs-app Vite build**: `reportCompressedSize: false` and gate `rollup-plugin-visualizer` behind `ANALYZE` (it ran on every build).
- Adds a `CLAUDE.md` documenting the local CI checks, commit conventions, and PR-template usage for contributors/agents.

## Measured impact (this PR's CI run)

| Job | Before | After |
| --- | --- | --- |
| build | ~13 min | 809s (~13.5 min, cold) |
| format-and-lint | after install (serial) | 57s (affected) |
| unit | waited ~13 min for build, then ran | 46s (parallel) |
| e2e | waited ~13 min for build, then ran the full suite | 38s (parallel, affected) |
| commitlint | ~25s | 26s |
| **Total wall-clock** | **~19 min** | **~13.5 min** |

Before, `unit` and `e2e` ran serially after the ~13-min build; now all five jobs run in parallel, so total wall-clock is bounded by the build alone (~30% cut even on a PR that rebuilds the docs app). For a PR that does **not** touch the docs app or a shared lib, `affected` collapses the build job and total CI drops to **~1 min** (just the ~50s checks).

Investigation notes (tested and rejected, so reviewers know they were considered): build `--parallel` gives no gain (the lib builds are a serial dependency chain); parallel prerendering is a net slowdown (the renders are CPU-bound single-thread SSR and OOM at higher concurrency); and a Vite 6 -> 8 + vitest 4 bump gave no build-speed win (the docs build is compilation/prerender-bound, not bundler-bound) while breaking a test, so it was not included.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The remaining long pole is the docs-app build when the app (or a shared lib) is affected - dominated by ng-packagr lib compilation (cached/affected when unchanged) and the serial 137-route prerender (inherently single-thread). Further gains there would need either skipping/subsetting prerender on PR builds (at the cost of SSR-error coverage) or a larger runner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a reusable CI setup to speed up dependency installs and restore local computation cache, improve concurrency/parallelism, and increase memory for heavy builds.
  * Enhanced caching (including test-runner binary) and switched CI jobs to use affected-target runs. Bundle analysis is now opt-in and compressed-size reporting disabled by default.

* **Documentation**
  * Added contributor notes covering local pre-push checks and commit message conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->