### PR TITLE
fix(app): serve public data assets in dev so SSR $fetch resolves

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -9,7 +9,13 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 import { getPrerenderedRoutes } from './src/utils/prerender-routes';
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
+	// In dev the Analog Nitro server builds its public-asset manifest from `output.publicDir`
+	// (default: dist/<app>/analog/public), which `nx serve` never populates - the docs JSON is
+	// generated into src/public (Vite's publicDir) instead. Point Nitro at the same source dir so a
+	// server-side $fetch('/data/..') from our page loaders resolves without a prior production build.
+	const isServe = command === 'serve';
+
 	return {
 		root: __dirname,
 		publicDir: 'src/public',
@@ -120,6 +126,7 @@ export default defineConfig(({ mode }) => {
 				},
 				nitro: {
 					logLevel: 4,
+					...(isServe ? { output: { publicDir: path.resolve(__dirname, 'src/public') } } : {}),
 					prerender: {
 						concurrency: 1,
 					},


### PR DESCRIPTION
The components page loader does a server-side $fetch('/data/*.json') for the generated docs JSON. In a production build Nitro serves those from its output.publicDir, but in dev the Analog Nitro plugin never points output.publicDir at the real public dir, so the in-process $fetch 404s ("Cannot find any route matching") until a production build has populated dist. The files are generated into src/public, where Vite serves them to the browser, but Nitro can't see them.

Point Nitro's output.publicDir at src/public during 'serve' so its dev public-asset manifest is built from the same files Vite serves. Production builds are unchanged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development build configuration to ensure public assets are correctly resolved when running the development server, enhancing the local development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->