### PR TITLE
feat: add agent skill bundle and cli info command

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Each primitive is made up off an un-styled `brain` library, which provides all f
 
 There's also a `libs/cli` folder, which contains the Nx-plugin & Angular CLI code that allows users to add spartan/ui to their Nx or Angular workspace in a simple way.
 
+The `skills/spartan` folder contains the spartan agent skill - procedural knowledge that teaches AI coding assistants how to build spartan/ui correctly. Users install it with `npx skills add spartan-ng/spartan`. See [the Skills docs](https://www.spartan.ng/documentation/skills).
+
 ### Install Dependencies
 
 Run `pnpm install` to install the dependencies of this project.

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/cli.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/cli.page.ts
@@ -72,6 +72,26 @@ export const routeMeta: RouteMeta = {
 				of the rest.
 			</p>
 
+			<spartan-section-sub-heading id="inspect-project">Inspect Your Project</spartan-section-sub-heading>
+			<p class="${hlmP}">
+				Print a read-only summary of your spartan setup - the
+				<code class="${hlmCode}">components.json</code>
+				config, package versions, detected icon library and styles file, and which components are installed versus
+				available:
+			</p>
+			<spartan-cli-tabs
+				class="mt-4"
+				nxCode="npx nx g @spartan-ng/cli:info --json"
+				ngCode="ng g @spartan-ng/cli:info --json"
+			/>
+			<p class="${hlmP}">
+				Add
+				<code class="${hlmCode}">--json</code>
+				for machine-readable output. This is what the
+				<a href="/documentation/skills" class="${hlmCode} underline">spartan agent skill</a>
+				uses to gather project context.
+			</p>
+
 			<spartan-section-sub-heading id="what-happens">What the CLI Does</spartan-section-sub-heading>
 			<p class="${hlmP}">When you add a component, the CLI automatically:</p>
 

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/mcp.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/mcp.page.ts
@@ -186,7 +186,7 @@ export const routeMeta: RouteMeta = {
 			</ul>
 
 			<spartan-page-bottom-nav>
-				<spartan-page-bottom-nav-link href="/components" label="Components" />
+				<spartan-page-bottom-nav-link href="skills" label="Skills" />
 				<spartan-page-bottom-nav-link direction="previous" href="update-guide" label="Update Guide" />
 			</spartan-page-bottom-nav>
 		</section>

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/skills.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/skills.page.ts
@@ -1,0 +1,112 @@
+import type { RouteMeta } from '@analogjs/router';
+import { Component } from '@angular/core';
+import { MainSection } from '@spartan-ng/app/app/shared/layout/main-section';
+import { PageBottomNav } from '@spartan-ng/app/app/shared/layout/page-bottom-nav/page-bottom-nav';
+import { PageBottomNavLink } from '@spartan-ng/app/app/shared/layout/page-bottom-nav/page-bottom-nav-link';
+import { PageNav } from '@spartan-ng/app/app/shared/layout/page-nav/page-nav';
+import { SectionIntro } from '@spartan-ng/app/app/shared/layout/section-intro';
+import { SectionSubHeading } from '@spartan-ng/app/app/shared/layout/section-sub-heading';
+import { metaWith } from '@spartan-ng/app/app/shared/meta/meta.util';
+import { hlmCode, hlmP } from '@spartan-ng/helm/typography';
+import { Code } from '../../../../shared/code/code';
+
+export const routeMeta: RouteMeta = {
+	data: { breadcrumb: 'Skills' },
+	meta: metaWith(
+		'spartan - Skills',
+		'Give coding agents the context to build spartan UI correctly with the spartan agent skill.',
+	),
+	title: 'spartan - Skills',
+};
+
+@Component({
+	selector: 'spartan-skills',
+	imports: [MainSection, SectionIntro, PageBottomNav, PageBottomNavLink, PageNav, SectionSubHeading, Code],
+	template: `
+		<section spartanMainSection>
+			<spartan-section-intro
+				name="Skills"
+				lead="Give your coding agent the procedural knowledge to build spartan UI correctly."
+			/>
+
+			<p class="${hlmP}">
+				The
+				<code class="${hlmCode}">spartan</code>
+				skill is an
+				<a href="https://skills.sh" class="${hlmCode} underline" target="_blank" rel="noreferrer">agent skill</a>
+				that teaches AI coding assistants (Claude Code, Cursor, Copilot, and others) how spartan/ui works: the
+				Brain/Helm two-layer architecture, the CLI generators, component composition rules, theming, and how to discover
+				components before writing code. It activates automatically on any project with a
+				<code class="${hlmCode}">components.json</code>
+				file.
+			</p>
+
+			<spartan-section-sub-heading id="installation">Installation</spartan-section-sub-heading>
+			<p class="${hlmP}">Install the skill into your project with a single command:</p>
+			<spartan-code class="mt-4" language="sh" code="npx skills add spartan-ng/spartan" />
+			<p class="${hlmP}">
+				This copies the skill into your agent's skills directory (for Claude Code,
+				<code class="${hlmCode}">.claude/skills/spartan</code>
+				). Add the
+				<code class="${hlmCode}">-g</code>
+				flag to install it globally instead.
+			</p>
+
+			<spartan-section-sub-heading id="what-it-does">What it does</spartan-section-sub-heading>
+			<ul class="my-4 ml-6 list-disc [&>li]:mt-2">
+				<li>
+					<strong>Project context:</strong>
+					runs
+					<code class="${hlmCode}">@spartan-ng/cli:info --json</code>
+					to read your config, versions, and installed components before generating code.
+				</li>
+				<li>
+					<strong>Component discovery:</strong>
+					uses the
+					<a href="/documentation/mcp" class="${hlmCode} underline">MCP server</a>
+					and the docs to confirm APIs and examples instead of guessing.
+				</li>
+				<li>
+					<strong>Composition rules:</strong>
+					enforces the Brain/Helm patterns - semantic colors, field-based forms, correct overlay/group nesting, and
+					<code class="${hlmCode}">&#64;ng-icons</code>
+					usage.
+				</li>
+				<li>
+					<strong>CLI usage:</strong>
+					knows when to run
+					<code class="${hlmCode}">init</code>
+					,
+					<code class="${hlmCode}">ui</code>
+					,
+					<code class="${hlmCode}">ui-theme</code>
+					, and
+					<code class="${hlmCode}">healthcheck</code>
+					, with the right Nx or Angular CLI invocation.
+				</li>
+			</ul>
+
+			<spartan-section-sub-heading id="project-context">Project context command</spartan-section-sub-heading>
+			<p class="${hlmP}">
+				The skill relies on a read-only
+				<code class="${hlmCode}">info</code>
+				generator that prints your project context as JSON. You can run it yourself:
+			</p>
+			<spartan-code class="mt-4" language="sh" code="npx nx g @spartan-ng/cli:info --json" />
+			<p class="${hlmP}">
+				It reports the workspace type, the
+				<code class="${hlmCode}">components.json</code>
+				config (components path, import alias, generate strategy), package versions, the detected icon library and
+				styles file, and the lists of installed and available components.
+			</p>
+
+			<spartan-page-bottom-nav>
+				<spartan-page-bottom-nav-link href="/components" label="Components" />
+				<spartan-page-bottom-nav-link direction="previous" href="mcp" label="MCP Server" />
+			</spartan-page-bottom-nav>
+		</section>
+
+		<spartan-page-nav />
+	`,
+})
+export default class SkillsPage {}

--- a/apps/app/src/app/shared/components/navigation-items.ts
+++ b/apps/app/src/app/shared/components/navigation-items.ts
@@ -110,6 +110,7 @@ export const sidenavItems: NavItem[] = [
 			{ label: 'Health Checks', url: '/health-checks' },
 			{ label: 'Update Guide', url: '/update-guide' },
 			{ label: 'MCP Server', url: '/mcp', new: true },
+			{ label: 'Skills', url: '/skills', new: true },
 		],
 	},
 	{

--- a/libs/cli/generators.json
+++ b/libs/cli/generators.json
@@ -10,6 +10,11 @@
 			"schema": "./src/generators/init/schema.json",
 			"description": "Initialize a Spartan NG project with necessary configurations and dependencies."
 		},
+		"info": {
+			"factory": "./src/generators/info/generator",
+			"schema": "./src/generators/info/schema.json",
+			"description": "Print the project context (config, versions, installed components) as JSON or text."
+		},
 		"migrate-brain-accordion-trigger": {
 			"factory": "./src/generators/migrate-brain-accordion-trigger/generator",
 			"schema": "./src/generators/migrate-brain-accordion-trigger/schema.json",
@@ -126,6 +131,11 @@
 			"factory": "./src/generators/init/compat",
 			"schema": "./src/generators/init/schema.json",
 			"description": "Initialize a Spartan NG project with necessary configurations and dependencies."
+		},
+		"info": {
+			"factory": "./src/generators/info/compat",
+			"schema": "./src/generators/info/schema.json",
+			"description": "Print the project context (config, versions, installed components) as JSON or text."
 		},
 		"migrate-brain-accordion-trigger": {
 			"factory": "./src/generators/migrate-brain-accordion-trigger/compat",

--- a/libs/cli/src/generators/info/compat.ts
+++ b/libs/cli/src/generators/info/compat.ts
@@ -1,0 +1,8 @@
+import { convertNxGenerator } from '@nx/devkit';
+import { infoGenerator } from './generator';
+import type { InfoGeneratorSchema } from './schema';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default convertNxGenerator((tree: any, schema: InfoGeneratorSchema & { angularCli?: boolean }) =>
+	infoGenerator(tree, { ...schema, angularCli: true }),
+);

--- a/libs/cli/src/generators/info/generator.spec.ts
+++ b/libs/cli/src/generators/info/generator.spec.ts
@@ -1,0 +1,94 @@
+import { type Tree, writeJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import supportedUiLibraries from '../ui/supported-ui-libraries.json';
+import { infoGenerator } from './generator';
+import { collectSpartanInfo } from './lib/collect-info';
+
+const availableComponents = Object.keys(supportedUiLibraries);
+
+describe('info generator', () => {
+	let tree: Tree;
+
+	beforeEach(() => {
+		tree = createTreeWithEmptyWorkspace();
+
+		writeJson(tree, 'components.json', {
+			componentsPath: 'libs/ui',
+			buildable: true,
+			generateAs: 'entrypoint',
+			importAlias: '@spartan-ng/helm',
+		});
+
+		writeJson(tree, 'package.json', {
+			dependencies: {
+				'@angular/core': '^20.0.0',
+				'@angular/cdk': '^20.0.0',
+				'@spartan-ng/brain': '0.0.1-alpha.704',
+				tailwindcss: '^3.4.0',
+				'@ng-icons/core': '^29.0.0',
+			},
+			devDependencies: {
+				'@spartan-ng/cli': '0.0.1-alpha.704',
+			},
+		});
+
+		tree.write('src/styles.css', '@import "tailwindcss";');
+
+		// A component that imports a Helm button and a Brain dialog.
+		tree.write(
+			'libs/feature/src/example.component.ts',
+			`
+			import { HlmButton } from '@spartan-ng/helm/button';
+			import { BrnDialog } from '@spartan-ng/brain/dialog';
+			import { HlmAlertDialog } from '@spartan-ng/helm/alert-dialog';
+			`,
+		);
+	});
+
+	it('reports the resolved config', () => {
+		const info = collectSpartanInfo(tree, availableComponents);
+
+		expect(info.config.found).toBe(true);
+		expect(info.config.componentsPath).toBe('libs/ui');
+		expect(info.config.importAlias).toBe('@spartan-ng/helm');
+		expect(info.config.generateAs).toBe('entrypoint');
+		expect(info.workspaceType).toBe('nx');
+	});
+
+	it('reports dependency versions and tooling', () => {
+		const info = collectSpartanInfo(tree, availableComponents);
+
+		expect(info.versions.angular).toBe('^20.0.0');
+		expect(info.versions.tailwind).toBe('^3.4.0');
+		expect(info.versions.spartanBrain).toBe('0.0.1-alpha.704');
+		expect(info.versions.spartanCli).toBe('0.0.1-alpha.704');
+		expect(info.iconLibrary).toBe('@ng-icons');
+		expect(info.tailwindCssFile).toBe('src/styles.css');
+	});
+
+	it('detects installed components from helm and brain imports', () => {
+		const info = collectSpartanInfo(tree, availableComponents);
+
+		expect(info.installedComponents).toContain('button');
+		expect(info.installedComponents).toContain('dialog');
+		expect(info.installedComponents).toContain('alert-dialog');
+		expect(info.availableComponents.length).toBeGreaterThan(0);
+	});
+
+	it('falls back to defaults when components.json is missing', () => {
+		const bareTree = createTreeWithEmptyWorkspace();
+		const info = collectSpartanInfo(bareTree, availableComponents);
+
+		expect(info.config.found).toBe(false);
+		expect(info.config.componentsPath).toBe('libs/ui');
+		expect(info.config.importAlias).toBe('@spartan-ng/helm');
+		expect(info.installedComponents).toEqual([]);
+	});
+
+	it('runs read-only and does not create or modify components.json', async () => {
+		const bareTree = createTreeWithEmptyWorkspace();
+		await infoGenerator(bareTree, { json: true });
+
+		expect(bareTree.exists('components.json')).toBe(false);
+	});
+});

--- a/libs/cli/src/generators/info/generator.ts
+++ b/libs/cli/src/generators/info/generator.ts
@@ -2,7 +2,10 @@ import { logger, type Tree } from '@nx/devkit';
 import { collectSpartanInfo, type SpartanInfo } from './lib/collect-info';
 import type { InfoGeneratorSchema } from './schema';
 
-export async function infoGenerator(tree: Tree, options: InfoGeneratorSchema & { angularCli?: boolean }) {
+export async function infoGenerator(
+	tree: Tree,
+	options: InfoGeneratorSchema & { angularCli?: boolean },
+): Promise<void> {
 	const availablePrimitives: Record<string, unknown> = await import('../ui/supported-ui-libraries.json').then(
 		(m) => m.default,
 	);

--- a/libs/cli/src/generators/info/generator.ts
+++ b/libs/cli/src/generators/info/generator.ts
@@ -1,0 +1,55 @@
+import { logger, type Tree } from '@nx/devkit';
+import { collectSpartanInfo, type SpartanInfo } from './lib/collect-info';
+import type { InfoGeneratorSchema } from './schema';
+
+export async function infoGenerator(tree: Tree, options: InfoGeneratorSchema & { angularCli?: boolean }) {
+	const availablePrimitives: Record<string, unknown> = await import('../ui/supported-ui-libraries.json').then(
+		(m) => m.default,
+	);
+
+	const info = collectSpartanInfo(tree, Object.keys(availablePrimitives), { angularCli: options.angularCli });
+
+	if (options.json) {
+		// Print machine-readable JSON only, so agents and tooling can parse stdout directly.
+		logger.info(JSON.stringify(info, null, 2));
+	} else {
+		printHumanReadable(info);
+	}
+
+	// `info` is read-only: it never modifies the workspace, so there is no task to return.
+}
+
+function printHumanReadable(info: SpartanInfo): void {
+	const lines: string[] = [];
+	lines.push('Spartan project info');
+	lines.push('');
+	lines.push(`  Workspace:        ${info.workspaceType}`);
+	lines.push(`  Config found:     ${info.config.found ? 'yes' : 'no (using defaults)'}`);
+	lines.push(`  Components path:   ${info.config.componentsPath}`);
+	lines.push(`  Import alias:      ${info.config.importAlias}`);
+	if (info.config.generateAs) {
+		lines.push(`  Generate as:       ${info.config.generateAs}`);
+	}
+	lines.push('');
+	lines.push('  Versions');
+	lines.push(`    @angular/core:   ${info.versions.angular ?? '-'}`);
+	lines.push(`    @angular/cdk:    ${info.versions.angularCdk ?? '-'}`);
+	lines.push(`    tailwindcss:     ${info.versions.tailwind ?? '-'}`);
+	lines.push(`    @spartan-ng/brain: ${info.versions.spartanBrain ?? '-'}`);
+	lines.push(`    @spartan-ng/cli:   ${info.versions.spartanCli ?? '-'}`);
+	lines.push('');
+	lines.push(`  Icon library:      ${info.iconLibrary ?? '-'}`);
+	lines.push(`  Styles file:       ${info.tailwindCssFile ?? '-'}`);
+	lines.push('');
+	lines.push(
+		`  Installed (${info.installedComponents.length}/${info.availableComponents.length}): ${
+			info.installedComponents.length ? info.installedComponents.join(', ') : '-'
+		}`,
+	);
+	lines.push('');
+	lines.push('  Tip: run with --json to get machine-readable output for AI agents.');
+
+	logger.info(lines.join('\n'));
+}
+
+export default infoGenerator;

--- a/libs/cli/src/generators/info/lib/collect-info.ts
+++ b/libs/cli/src/generators/info/lib/collect-info.ts
@@ -74,7 +74,8 @@ function readDependencies(tree: Tree): Record<string, string> {
 		return {};
 	}
 	const packageJson = readJson(tree, 'package.json');
-	return { ...packageJson.dependencies, ...packageJson.devDependencies };
+	// `dependencies` last so a production version wins over a duplicate in `devDependencies`.
+	return { ...packageJson.devDependencies, ...packageJson.dependencies };
 }
 
 function detectIconLibrary(dependencies: Record<string, string>): string | null {
@@ -88,13 +89,15 @@ function detectStyleFile(tree: Tree): string | null {
 function detectInstalledComponents(tree: Tree, importAlias: string, availableComponents: string[]): string[] {
 	// Map a normalized entrypoint name back to its canonical component name (e.g. "alertdialog" -> "alert-dialog").
 	const byNormalized = new Map(availableComponents.map((name) => [normalize(name), name]));
-	const prefixes = ['@spartan-ng/brain/', '@spartan-ng/helm/', `${importAlias}/`];
+	// Dedupe in case importAlias is the default `@spartan-ng/helm`.
+	const prefixes = [...new Set(['@spartan-ng/brain/', '@spartan-ng/helm/', `${importAlias}/`])];
 	const found = new Set<string>();
 
 	const importRegex = /from\s*['"]([^'"]+)['"]/g;
 
+	// Only TypeScript files carry import statements; HTML templates never match this regex.
 	visitNotIgnoredFiles(tree, '.', (filePath) => {
-		if (!/\.(ts|html)$/.test(filePath)) {
+		if (!filePath.endsWith('.ts')) {
 			return;
 		}
 		const contents = tree.read(filePath, 'utf-8');

--- a/libs/cli/src/generators/info/lib/collect-info.ts
+++ b/libs/cli/src/generators/info/lib/collect-info.ts
@@ -1,0 +1,158 @@
+import { readJson, type Tree, visitNotIgnoredFiles } from '@nx/devkit';
+import { AngularCliConfigSchema, NXConfigSchema } from '../../../utils/config';
+
+export interface SpartanInfo {
+	/** The kind of workspace the project lives in. */
+	workspaceType: 'nx' | 'angular-cli' | 'unknown';
+	/** The resolved `components.json` configuration (defaults applied when missing). */
+	config: {
+		found: boolean;
+		componentsPath: string;
+		importAlias: string;
+		buildable?: boolean;
+		generateAs?: 'library' | 'entrypoint';
+	};
+	/** Versions of the relevant packages as declared in `package.json`. */
+	versions: {
+		angular: string | null;
+		angularCdk: string | null;
+		tailwind: string | null;
+		spartanBrain: string | null;
+		spartanHelm: string | null;
+		spartanCli: string | null;
+	};
+	/** The detected icon library family, if any (Spartan uses `@ng-icons`). */
+	iconLibrary: string | null;
+	/** Best-effort path to the global stylesheet that imports the Tailwind preset. */
+	tailwindCssFile: string | null;
+	/** Resolved filesystem destinations the CLI writes to. */
+	resolvedPaths: {
+		components: string;
+	};
+	/** Spartan components detected in the workspace (by import usage and directory layout). */
+	installedComponents: string[];
+	/** Every component the CLI can generate. */
+	availableComponents: string[];
+}
+
+const DEFAULT_COMPONENTS_PATH = 'libs/ui';
+const DEFAULT_IMPORT_ALIAS = '@spartan-ng/helm';
+
+const STYLE_FILE_CANDIDATES = [
+	'src/styles.css',
+	'src/styles.scss',
+	'src/styles.less',
+	'src/tailwind.css',
+	'src/global.css',
+	'styles.css',
+];
+
+const normalize = (value: string): string => value.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+function readConfig(tree: Tree, angularCli: boolean): SpartanInfo['config'] {
+	if (!tree.exists('components.json')) {
+		return { found: false, componentsPath: DEFAULT_COMPONENTS_PATH, importAlias: DEFAULT_IMPORT_ALIAS };
+	}
+
+	const raw = readJson(tree, 'components.json');
+	const schema = angularCli ? AngularCliConfigSchema : NXConfigSchema;
+	const parsed = schema.safeParse(raw);
+	// When validation succeeds use the parsed (defaulted) values, otherwise surface whatever we can read.
+	const source: Record<string, unknown> = parsed.success ? parsed.data : (raw ?? {});
+
+	return {
+		found: true,
+		componentsPath: typeof source.componentsPath === 'string' ? source.componentsPath : DEFAULT_COMPONENTS_PATH,
+		importAlias: typeof source.importAlias === 'string' ? source.importAlias : DEFAULT_IMPORT_ALIAS,
+		buildable: typeof source.buildable === 'boolean' ? source.buildable : undefined,
+		generateAs: source.generateAs === 'library' || source.generateAs === 'entrypoint' ? source.generateAs : undefined,
+	};
+}
+
+function readDependencies(tree: Tree): Record<string, string> {
+	if (!tree.exists('package.json')) {
+		return {};
+	}
+	const packageJson = readJson(tree, 'package.json');
+	return { ...packageJson.dependencies, ...packageJson.devDependencies };
+}
+
+function detectIconLibrary(dependencies: Record<string, string>): string | null {
+	return Object.keys(dependencies).some((dep) => dep.startsWith('@ng-icons/')) ? '@ng-icons' : null;
+}
+
+function detectStyleFile(tree: Tree): string | null {
+	return STYLE_FILE_CANDIDATES.find((candidate) => tree.exists(candidate)) ?? null;
+}
+
+function detectInstalledComponents(tree: Tree, importAlias: string, availableComponents: string[]): string[] {
+	// Map a normalized entrypoint name back to its canonical component name (e.g. "alertdialog" -> "alert-dialog").
+	const byNormalized = new Map(availableComponents.map((name) => [normalize(name), name]));
+	const prefixes = ['@spartan-ng/brain/', '@spartan-ng/helm/', `${importAlias}/`];
+	const found = new Set<string>();
+
+	const importRegex = /from\s*['"]([^'"]+)['"]/g;
+
+	visitNotIgnoredFiles(tree, '.', (filePath) => {
+		if (!/\.(ts|html)$/.test(filePath)) {
+			return;
+		}
+		const contents = tree.read(filePath, 'utf-8');
+		if (!contents) {
+			return;
+		}
+
+		for (const match of contents.matchAll(importRegex)) {
+			const moduleSpecifier = match[1];
+			const prefix = prefixes.find((p) => moduleSpecifier.startsWith(p) && moduleSpecifier.length > p.length);
+			if (!prefix) {
+				continue;
+			}
+			const subpath = moduleSpecifier.slice(prefix.length).split('/')[0];
+			const component = byNormalized.get(normalize(subpath));
+			if (component) {
+				found.add(component);
+			}
+		}
+	});
+
+	return [...found].sort();
+}
+
+export function collectSpartanInfo(
+	tree: Tree,
+	availableComponents: string[],
+	options: { angularCli?: boolean } = {},
+): SpartanInfo {
+	const angularCli = options.angularCli ?? false;
+	const config = readConfig(tree, angularCli);
+	const dependencies = readDependencies(tree);
+
+	const workspaceType: SpartanInfo['workspaceType'] = angularCli
+		? 'angular-cli'
+		: tree.exists('nx.json')
+			? 'nx'
+			: tree.exists('angular.json')
+				? 'angular-cli'
+				: 'unknown';
+
+	return {
+		workspaceType,
+		config,
+		versions: {
+			angular: dependencies['@angular/core'] ?? null,
+			angularCdk: dependencies['@angular/cdk'] ?? null,
+			tailwind: dependencies['tailwindcss'] ?? null,
+			spartanBrain: dependencies['@spartan-ng/brain'] ?? null,
+			spartanHelm: dependencies['@spartan-ng/helm'] ?? null,
+			spartanCli: dependencies['@spartan-ng/cli'] ?? null,
+		},
+		iconLibrary: detectIconLibrary(dependencies),
+		tailwindCssFile: detectStyleFile(tree),
+		resolvedPaths: {
+			components: config.componentsPath,
+		},
+		installedComponents: detectInstalledComponents(tree, config.importAlias, availableComponents),
+		availableComponents: [...availableComponents].sort(),
+	};
+}

--- a/libs/cli/src/generators/info/schema.d.ts
+++ b/libs/cli/src/generators/info/schema.d.ts
@@ -1,0 +1,3 @@
+export interface InfoGeneratorSchema {
+	json?: boolean;
+}

--- a/libs/cli/src/generators/info/schema.json
+++ b/libs/cli/src/generators/info/schema.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"$id": "Info",
+	"title": "Spartan project info",
+	"type": "object",
+	"properties": {
+		"json": {
+			"type": "boolean",
+			"default": false,
+			"description": "Output the project context as machine-readable JSON (for AI agents and tooling)."
+		}
+	},
+	"required": []
+}

--- a/skills/spartan/SKILL.md
+++ b/skills/spartan/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: spartan
+description: >-
+  Manages spartan/ui, the Angular UI library - adding, composing, fixing, debugging, and styling UI
+  with the Brain (headless primitives) and Helm (styled) layers. Provides project context, component
+  APIs, and usage examples. Applies when working with spartan/ui, @spartan-ng/brain, @spartan-ng/helm,
+  the @spartan-ng/cli generators, or any Angular project with a components.json file. Also triggers
+  for "spartan init", "add a spartan component", or "set up spartan/ui".
+user-invocable: false
+allowed-tools:
+  - Bash(npx nx g @spartan-ng/cli:*)
+  - Bash(pnpm nx g @spartan-ng/cli:*)
+  - Bash(ng g @spartan-ng/cli:*)
+---
+
+# spartan/ui
+
+spartan/ui is an Angular UI library. It uses a **two-layer architecture**:
+
+- **Brain (`@spartan-ng/brain`)** - accessible, unstyled primitives (Angular directives/components),
+  installed from npm. This is the behavior and accessibility layer.
+- **Helm (`@spartan-ng/helm`)** - the styled layer (Tailwind + class-variance-authority). Helm code
+  is **copied into the user's project** by the CLI so they own and can customize it.
+
+You compose Helm directives/components onto host elements; Helm wires up the matching Brain
+primitive under the hood. Always prefer existing components over hand-written markup.
+
+All CLI commands run through the workspace's runner. Detect it from the project:
+
+- **Nx workspace** (has `nx.json`): `npx nx g @spartan-ng/cli:<generator>` (or `pnpm nx g ...`).
+- **Angular CLI workspace** (has `angular.json`, no `nx.json`): `ng g @spartan-ng/cli:<generator>`.
+
+## Current project context
+
+Before generating any code, gather the project context:
+
+```bash
+npx nx g @spartan-ng/cli:info --json     # Nx
+ng g @spartan-ng/cli:info --json         # Angular CLI
+```
+
+This is read-only and prints JSON with:
+
+- `workspaceType` - `nx` | `angular-cli` (decides which runner to use above).
+- `config.componentsPath` - where Helm components are copied (e.g. `libs/ui`).
+- `config.importAlias` - the import prefix for Helm, default `@spartan-ng/helm`.
+- `config.generateAs` - `library` | `entrypoint` (Nx layout choice).
+- `versions` - Angular, Angular CDK, Tailwind, `@spartan-ng/brain`, `@spartan-ng/cli`.
+- `iconLibrary` - `@ng-icons` when present.
+- `tailwindCssFile` - the global stylesheet that imports the preset.
+- `installedComponents` - components already present (do not re-add these).
+- `availableComponents` - everything the CLI can generate.
+
+If `components.json` does not exist, the project is not set up yet - run `@spartan-ng/cli:init`
+first (it installs dependencies and the theme). `components.json` itself is created when you add the
+first component with `ui` (see `cli.md`).
+
+## Principles
+
+1. **Use existing components first.** Check `installedComponents`, then `availableComponents`. Find
+   docs via the MCP server (`spartan_components_list` / `spartan_components_get`) or the live docs at
+   `https://www.spartan.ng/components/<name>`. See `mcp.md`.
+2. **Compose, do not reinvent.** Build dashboards, forms, and dialogs from existing Helm + Brain
+   pieces rather than custom markup.
+3. **Use built-in variants before custom styles.** Buttons, badges, alerts, etc. ship `variant` and
+   `size` inputs - use them instead of overriding classes.
+4. **Use semantic colors, never raw values.** `bg-primary text-primary-foreground`, not
+   `bg-blue-500`. See `rules/styling.md`.
+
+## Critical rules
+
+Read the rule file before doing the related work:
+
+- **`rules/styling.md`** - the `hlm()` util, semantic color tokens, layout-only classes,
+  `gap-*` over `space-*`, `size-*`, dark mode, no manual z-index on overlays.
+- **`rules/forms.md`** - compose forms with `hlmField` (label, control, error, description) and
+  `hlmFieldSet` / `hlmFieldLegend` on native `<fieldset>`/`<legend>`; option sets (2-7 choices) use
+  `hlm-toggle-group`.
+- **`rules/composition.md`** - items belong inside their group; dialogs/sheets need a title;
+  full Card composition; tabs triggers inside `hlm-tabs-list`; avatar always has a fallback;
+  use `Alert`/`Empty`/`Skeleton`/`Badge`/`Separator`/`Spinner` instead of custom markup.
+- **`rules/icons.md`** - icons are `<ng-icon hlm name="lucide...">`; register with `provideIcons`;
+  no manual sizing classes inside components - use the `size` input.
+- **`rules/brain-vs-helm.md`** - the two-layer model (one headless library, Brain, plus the styled
+  Helm layer); when to reach for Brain directly vs Helm, and how composition works via directives.
+- **`cli.md`** - every generator (`init`, `ui`, `ui-theme`, `healthcheck`, `info`, `migrate-*`),
+  with Nx and Angular CLI invocations.
+- **`registry.md`** - the Brain-npm + Helm-copy-in distribution model, `components.json`, and the
+  fixed component catalog (the shipped CLI uses no remote or custom registry).
+- **`customization.md`** - theming via the `hlm-tailwind-preset.css`, CSS variables, the `ui-theme`
+  generator, and extending copied Helm components.
+- **`mcp.md`** - using the `@spartan-ng/mcp` tools, resources, and prompts for discovery.
+
+## Key patterns
+
+```html
+<!-- Buttons: use variant/size inputs, not custom classes -->
+<button hlmBtn variant="destructive" size="lg">Delete</button>
+
+<!-- Icon in a button: ng-icon + hlm, no sizing classes -->
+<button hlmBtn size="icon" variant="ghost">
+	<ng-icon hlm name="lucideTrash" size="sm" />
+</button>
+
+<!-- Loading state: compose a spinner, there is no isLoading input -->
+<button hlmBtn [disabled]="loading()">
+	@if (loading()) {
+	<hlm-spinner />
+	} Save
+</button>
+
+<!-- Layout: gap, not space-* ; size-* when width == height -->
+<div class="flex items-center gap-2">
+	<span hlmBadge variant="secondary">beta</span>
+</div>
+```
+
+## Component selection
+
+| Need                   | Component(s)                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------- |
+| Action / button        | `button` (`hlmBtn`), `button-group`                                                         |
+| Text/number input      | `input`, `textarea`, `input-otp`, `input-group`, `native-select`                            |
+| Choice input           | `select`, `combobox`, `autocomplete`, `radio-group`, `checkbox`, `switch`, `slider`         |
+| Toggle 2-7 options     | `toggle-group`                                                                              |
+| Form layout/validation | `field`, `label`                                                                            |
+| Data display           | `table`, `card`, `badge`, `avatar`, `kbd`, `item`                                           |
+| Navigation             | `sidebar`, `navigation-menu`, `breadcrumb`, `tabs`, `pagination`                            |
+| Overlays               | `dialog`, `sheet`, `alert-dialog`, `popover`, `hover-card`, `tooltip`                       |
+| Menus                  | `dropdown-menu`, `context-menu`, `menubar`, `command`                                       |
+| Feedback               | `sonner` (toasts), `alert`, `progress`, `skeleton`, `spinner`                               |
+| Layout/containers      | `card`, `separator`, `resizable`, `scroll-area`, `accordion`, `collapsible`, `aspect-ratio` |
+| Empty states           | `empty`                                                                                     |
+| Dates                  | `calendar`, `date-picker`                                                                   |
+| Icons                  | `icon` (`@ng-icons`)                                                                        |
+| Typography             | `typography`                                                                                |
+
+## Workflow
+
+1. **Get context.** Run `@spartan-ng/cli:info --json`. If the project is not set up, run `:init`,
+   then add components with `:ui` (the first `:ui` run creates `components.json`).
+2. **Check what is installed.** Do not re-add anything in `installedComponents`.
+3. **Find the component.** Use the MCP tools or `https://www.spartan.ng/components/<name>` for the
+   API and examples (`mcp.md`). Never guess selectors - confirm them.
+4. **Add it.** `npx nx g @spartan-ng/cli:ui --name=<component>` (Nx) or
+   `ng g @spartan-ng/cli:ui --name=<component>` (Angular CLI). This installs the Brain dependency and
+   copies the Helm code. Omit `--name` to get an interactive multiselect.
+5. **Compose correctly.** Import the `*Imports` const (e.g. `HlmDialogImports`) or the individual
+   classes from the import alias, add them to the standalone component's `imports`, and follow the
+   composition rules.
+6. **Register icons.** Any `<ng-icon>` you use must be passed to `provideIcons(...)` (see
+   `rules/icons.md`).
+7. **Verify.** After bigger changes or upgrades, run `@spartan-ng/cli:healthcheck` to catch
+   deprecated patterns and fix imports.
+8. **Theme/customize.** Edit the copied Helm files and the CSS variables; do not fork Brain.
+
+## Quick reference
+
+```bash
+# Initialize (creates components.json, wires Tailwind + preset)
+npx nx g @spartan-ng/cli:init
+ng g @spartan-ng/cli:init
+
+# Project context as JSON
+npx nx g @spartan-ng/cli:info --json
+
+# Add components (interactive, or pass --name)
+npx nx g @spartan-ng/cli:ui
+npx nx g @spartan-ng/cli:ui --name=dialog
+
+# Generate theme variables
+npx nx g @spartan-ng/cli:ui-theme
+
+# Scan + auto-fix deprecated APIs/imports after an upgrade
+npx nx g @spartan-ng/cli:healthcheck --autoFix
+```

--- a/skills/spartan/cli.md
+++ b/skills/spartan/cli.md
@@ -1,0 +1,92 @@
+# CLI reference (`@spartan-ng/cli`)
+
+The CLI is an Nx plugin that also runs as Angular CLI schematics. Pick the invocation that matches
+the workspace (`info --json` reports `workspaceType`):
+
+- **Nx** (`nx.json` present): `npx nx g @spartan-ng/cli:<generator>` (or `pnpm nx g ...`).
+- **Angular CLI** (`angular.json`, no `nx.json`): `ng g @spartan-ng/cli:<generator>`.
+
+Install the plugin first: `npm i -D @spartan-ng/cli`.
+
+## Core generators
+
+### `init`
+
+One-time setup. Installs the required dependencies and runs the theme generator (Tailwind + the
+spartan preset and CSS variables).
+
+```bash
+npx nx g @spartan-ng/cli:init
+ng g @spartan-ng/cli:init
+```
+
+`components.json` is not written by `init`; it is created on the first `ui` run, which prompts for
+the components path (e.g. `libs/ui`), the import alias (default `@spartan-ng/helm`), and on Nx
+whether libraries are buildable and the `generateAs` strategy.
+
+### `ui`
+
+Adds components. Installs the Brain dependency from npm and copies the Helm code into
+`componentsPath`. Run with no name for an interactive multiselect, or target one component:
+
+```bash
+npx nx g @spartan-ng/cli:ui                 # interactive multiselect (choose 'all' or specific)
+npx nx g @spartan-ng/cli:ui --name=dialog   # add a single component
+ng g @spartan-ng/cli:ui --name=button
+```
+
+Dependent components are pulled in automatically.
+
+### `ui-theme`
+
+Generates the CSS theme variables (light + dark) into your stylesheet.
+
+```bash
+npx nx g @spartan-ng/cli:ui-theme
+ng g @spartan-ng/cli:ui-theme
+```
+
+### `info`
+
+Read-only. Prints project context. Add `--json` for machine-readable output (use this for agents).
+
+```bash
+npx nx g @spartan-ng/cli:info --json
+ng g @spartan-ng/cli:info --json
+```
+
+Fields: `workspaceType`, `config` (`componentsPath`, `importAlias`, `buildable`, `generateAs`),
+`versions`, `iconLibrary`, `tailwindCssFile`, `installedComponents`, `availableComponents`.
+
+### `healthcheck`
+
+Scans the workspace for deprecated APIs, outdated imports, and breaking changes; can auto-fix.
+
+```bash
+npx nx g @spartan-ng/cli:healthcheck            # report only
+npx nx g @spartan-ng/cli:healthcheck --autoFix  # apply fixes
+ng g @spartan-ng/cli:healthcheck --autoFix
+```
+
+Run it after upgrading `@spartan-ng` packages.
+
+## Migration generators
+
+The `migrate-*` family upgrades specific components/APIs (e.g. `migrate-brain-imports`,
+`migrate-helm-imports`, `migrate-module-imports`, `migrate-naming-conventions`, `migrate-select`,
+`migrate-icon`, and more - see `generators.json` for the full list). In normal use you do not invoke
+these directly - run `healthcheck`, which scans for the same problems and applies the fixes
+automatically. Invoke a single migration only when targeting a specific upgrade:
+
+```bash
+npx nx g @spartan-ng/cli:migrate-helm-imports
+```
+
+## Typical sequence
+
+```bash
+npm i -D @spartan-ng/cli
+npx nx g @spartan-ng/cli:init
+npx nx g @spartan-ng/cli:ui-theme
+npx nx g @spartan-ng/cli:ui --name=button
+```

--- a/skills/spartan/customization.md
+++ b/skills/spartan/customization.md
@@ -1,0 +1,88 @@
+# Theming and customization
+
+## Setup
+
+spartan/ui requires Tailwind CSS (v4 recommended; v3 is not guaranteed). The global stylesheet needs
+the Tailwind layers and the spartan preset.
+
+```css
+/* src/styles.css */
+@layer theme, base, components, utilities;
+@import 'tailwindcss/theme.css' layer(theme);
+@import 'tailwindcss/preflight.css' layer(base);
+@import 'tailwindcss/utilities.css';
+```
+
+```css
+/* src/styles.css - add the spartan preset (bundles tw-animate-css + the CDK overlay styles) */
+@import '@spartan-ng/brain/hlm-tailwind-preset.css';
+```
+
+## Theme variables
+
+Colors are driven by CSS variables (OKLCH) in `:root` (light) and `.dark` (dark). Generate them with
+the CLI:
+
+```bash
+npx nx g @spartan-ng/cli:ui-theme
+ng g @spartan-ng/cli:ui-theme
+```
+
+Or add them manually. The semantic tokens are: `background`, `foreground`, `card`/`card-foreground`,
+`popover`/`popover-foreground`, `primary`/`primary-foreground`, `secondary`/`secondary-foreground`,
+`muted`/`muted-foreground`, `accent`/`accent-foreground`, `destructive`, `border`, `input`, `ring`,
+plus `--radius` and the `sidebar*` family. Reference them in templates via the matching Tailwind
+classes (`bg-primary`, `text-muted-foreground`, `border-border`, ...). See `rules/styling.md`.
+
+```css
+:root {
+	color-scheme: light;
+	--radius: 0.625rem;
+	--background: oklch(1 0 0);
+	--foreground: oklch(0.145 0 0);
+	--primary: oklch(0.205 0 0);
+	--primary-foreground: oklch(0.985 0 0);
+	/* ...rest of the tokens... */
+}
+
+.dark {
+	color-scheme: dark;
+	--background: oklch(0.145 0 0);
+	--foreground: oklch(0.985 0 0);
+	/* ...dark overrides... */
+}
+```
+
+## Adding a custom color
+
+Define the variable in both `:root` and `.dark`, then expose it to Tailwind with `@theme inline` so
+`bg-warning` / `text-warning-foreground` work:
+
+```css
+:root {
+	--warning: oklch(0.84 0.16 84);
+	--warning-foreground: oklch(0.28 0.07 46);
+}
+.dark {
+	--warning: oklch(0.41 0.11 46);
+	--warning-foreground: oklch(0.99 0.02 95);
+}
+
+@theme inline {
+	--color-warning: var(--warning);
+	--color-warning-foreground: var(--warning-foreground);
+}
+```
+
+## Dark mode
+
+Dark mode is class-based: toggle the `dark` class on the `<html>` (or root) element and the
+variables switch automatically. No component changes are needed. Typically a small service persists
+the choice to `localStorage` and respects the system color scheme.
+
+## Customizing components
+
+Because Helm code is copied into your project, customize by editing those files directly - adjust the
+`class-variance-authority` variants, change classes, or add inputs. Do not fork or edit the Brain
+packages. After spartan upgrades, run `@spartan-ng/cli:healthcheck --autoFix` to reconcile
+deprecated APIs.

--- a/skills/spartan/mcp.md
+++ b/skills/spartan/mcp.md
@@ -1,0 +1,76 @@
+# Using the spartan MCP server
+
+`@spartan-ng/mcp` is a Model Context Protocol server that exposes spartan's component docs, APIs,
+examples, blocks, and accessibility info (sourced from `https://www.spartan.ng` with a local cache).
+When it is connected, use it for discovery instead of guessing selectors or fetching pages by hand.
+
+## Configuration
+
+No install (recommended):
+
+```json
+{
+	"mcpServers": {
+		"spartan-ui": { "command": "npx", "args": ["-y", "@spartan-ng/mcp"] }
+	}
+}
+```
+
+Global install:
+
+```bash
+npm install -g @spartan-ng/mcp
+```
+
+```json
+{
+	"mcpServers": { "spartan-ui": { "command": "spartan-mcp" } }
+}
+```
+
+## Tools
+
+Components and analysis:
+
+- `spartan_components_list` - all components with their docs URLs.
+- `spartan_components_get` - fetch a component page; `extract: "code" | "api"`.
+- `spartan_components_dependencies` - npm/CDK/peer-component dependencies for a component.
+- `spartan_accessibility_check` - ARIA/keyboard/WCAG notes for a component.
+
+Blocks (prebuilt multi-component layouts - `sidebar`, `login`, `signup`, `calendar`):
+
+- `spartan_blocks_list`, `spartan_blocks_get` (`format: "html" | "text"`), `spartan_blocks_dependencies`.
+
+Docs and meta:
+
+- `spartan_docs_get` - a docs topic (installation, cli, theming, dark-mode, ...);
+  `extract: "none" | "code" | "headings" | "links"`.
+- `spartan_meta` - topics/components/blocks index for autocomplete.
+
+Health and cache:
+
+- `spartan_health_check`, `spartan_health_instructions`, `spartan_health_command`.
+- `spartan_cache_status`, `spartan_cache_clear`, `spartan_cache_rebuild`,
+  `spartan_cache_switch_version`, `spartan_cache_list_versions`.
+
+## Resources
+
+- `spartan://components/list`
+- `spartan://component/{name}/api`
+- `spartan://component/{name}/examples`
+- `spartan://component/{name}/full`
+
+## Prompts
+
+`spartan-get-started`, `spartan-compare-apis`, `spartan-implement-feature`, `spartan-troubleshoot`,
+`spartan-list-components`.
+
+## Recommended flow
+
+1. `spartan_components_get` with `extract: "api"` to confirm selectors and inputs.
+2. `spartan_components_get` with `extract: "code"` for a working example.
+3. `spartan_components_dependencies` if you need to know what else gets installed.
+4. Then add via the CLI (`@spartan-ng/cli:ui --name=<component>`).
+
+If the MCP server is not connected, fall back to `https://www.spartan.ng/components/<name>` and the
+`@spartan-ng/cli:info --json` output.

--- a/skills/spartan/registry.md
+++ b/skills/spartan/registry.md
@@ -1,0 +1,51 @@
+# Distribution and registry
+
+## The spartan model
+
+spartan/ui is **not** a single installed UI library. It uses a two-layer model:
+
+- **Brain** primitives are real npm packages (`@spartan-ng/brain/<name>`), installed into
+  `node_modules`. You do not edit them.
+- **Helm** styled components are **copied into your project** (under `componentsPath`) by the CLI.
+  You own this code and customize it freely.
+
+This is why there is no "upgrade my installed components" button: Brain updates via npm + the
+`healthcheck` migrations, while Helm code is yours to edit and re-generate.
+
+## `components.json`
+
+`components.json` is written at the project root on the first `ui` run (not by `init`). It is the
+project marker the skill triggers on and the source of paths/aliases.
+
+```json
+{
+	"componentsPath": "libs/ui",
+	"importAlias": "@spartan-ng/helm",
+	"buildable": true,
+	"generateAs": "library"
+}
+```
+
+- `componentsPath` - where Helm code is copied.
+- `importAlias` - the import prefix for the copied Helm components (default `@spartan-ng/helm`).
+- `buildable` - Nx only: whether generated libraries are buildable.
+- `generateAs` - Nx only: `library` (one Nx library per component) or `entrypoint` (secondary
+  entrypoints under a single library).
+
+The Angular CLI variant only uses `componentsPath` and `importAlias`.
+
+Read these values via `@spartan-ng/cli:info --json` rather than parsing the file yourself - the
+`info` command applies defaults and reports `installedComponents`.
+
+## Available components
+
+The CLI ships a fixed catalog of components (the `availableComponents` in `info --json`). Add any of
+them with `ui --name=<component>`. The shipped CLI does not wire up any remote or custom registry;
+components come only from this bundled catalog.
+
+## Custom usage
+
+When generating into a non-default layout, pass `--directory` to `ui`, or set `componentsPath` /
+`importAlias` in `components.json` before running. Do not invent registry URLs or remote sources -
+if a user asks for a component that is not in `availableComponents`, tell them it is not in the
+catalog rather than guessing.

--- a/skills/spartan/rules/brain-vs-helm.md
+++ b/skills/spartan/rules/brain-vs-helm.md
@@ -1,0 +1,59 @@
+# Brain vs Helm
+
+spartan has a single headless library, **Brain**. There is no choice between competing primitive
+libraries and no per-variant API switch - every component has one API. Each spartan component is
+built from **two layers**:
+
+| Layer     | Package                    | Role                                                                           | Distribution                                              |
+| --------- | -------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| **Brain** | `@spartan-ng/brain/<name>` | Headless behavior + accessibility (Angular directives/components). No styling. | Installed from npm.                                       |
+| **Helm**  | `@spartan-ng/helm/<name>`  | Tailwind styling layered on top of Brain.                                      | Copied into your project by the CLI; you own and edit it. |
+
+## Which one do I use?
+
+- **Use Helm by default.** It is the styled component. When you "add a dialog," you use
+  `HlmDialogImports`, which already composes the Brain dialog internally.
+- **Use Brain directly** only when you need fully custom styling and want the behavior/accessibility
+  without spartan's look - i.e. you are building your own styled layer. Then import from
+  `@spartan-ng/brain/<name>` and apply your own classes.
+- **Never edit Brain.** It is an npm dependency. Customize by editing the copied Helm files or the
+  theme variables.
+
+## Composition uses directives
+
+Composition is done with **directives applied to host elements** and **structural directives** for
+portals/content - there is no wrapper prop that swaps the rendered element.
+
+- Triggers are directives you put on your own element: `<button hlmDialogTrigger hlmBtn>` makes a
+  styled button act as the dialog trigger.
+- Content is projected into structural directives: `<hlm-dialog-content *hlmDialogPortal>`,
+  `<hlm-select-content *hlmSelectPortal>`, `<hlm-sheet-content *hlmSheetPortal>`.
+- To restyle a trigger or item, you change the classes/variant on your host element directly - no
+  wrapper prop needed.
+
+## Imports
+
+Each component publishes an `*Imports` barrel (e.g. `HlmDialogImports`, `HlmSelectImports`,
+`HlmCardImports`) plus the individual classes. Add the barrel to a standalone component's `imports`
+array:
+
+```ts
+import { HlmDialogImports } from '@spartan-ng/helm/dialog';
+
+@Component({
+  imports: [HlmDialogImports],
+  // ...
+})
+```
+
+The entrypoint name matches the component name in kebab-case (e.g. `@spartan-ng/helm/alert-dialog`,
+`@spartan-ng/brain/toggle-group`). When unsure, confirm the exact path from the component docs or
+MCP rather than guessing.
+
+## Per-component notes
+
+- **select / toggle-group / radio-group / accordion / tabs**: the Brain layer owns
+  keyboard/selection behavior; you compose Helm items inside the Helm group as shown in
+  `rules/composition.md`.
+- **dialog / sheet / popover / tooltip / menus**: rely on the Angular CDK overlay (a peer
+  dependency). Do not manage z-index yourself (see `rules/styling.md`).

--- a/skills/spartan/rules/composition.md
+++ b/skills/spartan/rules/composition.md
@@ -1,0 +1,105 @@
+# Component composition
+
+Most spartan components are made of several directives/components that must be nested correctly.
+Import the per-component `*Imports` const (e.g. `HlmDialogImports`, `HlmCardImports`) and add it to
+your standalone component's `imports`. Always confirm selectors via the docs or MCP before writing
+templates - the examples below are canonical but APIs evolve.
+
+## Items belong inside their group
+
+- `hlm-select-item` goes inside `hlm-select-content` (and optionally `hlm-select-group`).
+- `button[hlmToggleGroupItem]` goes inside `hlm-toggle-group`.
+- `button[hlmTabsTrigger]` goes inside `hlm-tabs-list`.
+- Accordion: `hlm-accordion-trigger` and `hlm-accordion-content` go inside `hlm-accordion-item`,
+  which goes inside `hlm-accordion`.
+
+## Overlays need a title
+
+Dialog, Sheet, and Alert Dialog must have a title for accessibility. If the design hides it, keep it
+present and apply `class="sr-only"`.
+
+```html
+<hlm-dialog>
+	<button hlmDialogTrigger hlmBtn>Edit profile</button>
+	<hlm-dialog-content *hlmDialogPortal class="sm:max-w-[425px]">
+		<hlm-dialog-header>
+			<h3 hlmDialogTitle>Edit profile</h3>
+			<p hlmDialogDescription>Make changes to your profile here.</p>
+		</hlm-dialog-header>
+		<div class="py-4">
+			<input hlmInput placeholder="Name" />
+		</div>
+		<hlm-dialog-footer>
+			<button hlmBtn hlmDialogClose>Save changes</button>
+		</hlm-dialog-footer>
+	</hlm-dialog-content>
+</hlm-dialog>
+```
+
+Sheet mirrors this (`hlmSheetTrigger`, `*hlmSheetPortal`, `hlm-sheet-content`, `hlm-sheet-header`,
+`hlmSheetTitle`). The `side` input (`top | bottom | left | right`) goes on the root `<hlm-sheet>`
+element, not on the content: `<hlm-sheet side="right">`.
+
+## Full Card composition
+
+Use the structural pieces rather than styling a bare `div`.
+
+```html
+<section hlmCard>
+	<div hlmCardHeader>
+		<h3 hlmCardTitle>Create project</h3>
+		<p hlmCardDescription>Deploy in one click.</p>
+	</div>
+	<div hlmCardContent>...</div>
+	<div hlmCardFooter class="justify-between">
+		<button hlmBtn variant="ghost">Cancel</button>
+		<button hlmBtn>Create</button>
+	</div>
+</section>
+```
+
+## Tabs
+
+```html
+<hlm-tabs tab="account">
+	<hlm-tabs-list>
+		<button hlmTabsTrigger="account">Account</button>
+		<button hlmTabsTrigger="password">Password</button>
+	</hlm-tabs-list>
+	<div hlmTabsContent="account">...</div>
+	<div hlmTabsContent="password">...</div>
+</hlm-tabs>
+```
+
+## Avatar always has a fallback
+
+```html
+<hlm-avatar>
+	<img hlmAvatarImage src="/avatar.jpg" alt="Jane Doe" />
+	<span hlmAvatarFallback>JD</span>
+</hlm-avatar>
+```
+
+## Buttons have no loading input
+
+There is no `isLoading`/`isPending` input on `hlmBtn`. Compose a `hlm-spinner` and disable the
+button:
+
+```html
+<button hlmBtn [disabled]="saving()">
+	@if (saving()) {
+	<hlm-spinner />
+	} Save
+</button>
+```
+
+## Use components, not custom markup
+
+- Callouts / inline messages -> `hlmAlert` (with `hlmAlertTitle` / `hlmAlertDescription`).
+- Empty states -> `hlm-empty` (`hlmEmptyMedia`, `hlmEmptyTitle`, `hlmEmptyDescription`).
+- Toasts -> the `sonner` component: place `<hlm-toaster />` once, then call `toast(...)` from
+  `@spartan-ng/brain/sonner` (`toast.success`, `toast.error`, etc.).
+- Dividers -> `hlm-separator`, not `<hr>`.
+- Loading placeholders -> `hlmSkeleton`, not custom pulsing divs.
+- Status pills -> `hlmBadge`, not custom styled spans.
+- Loading indicator -> `hlm-spinner`.

--- a/skills/spartan/rules/forms.md
+++ b/skills/spartan/rules/forms.md
@@ -1,7 +1,7 @@
 # Forms and inputs
 
-spartan/ui composes forms from the `field` component plus the relevant control. It works with both
-template-driven and reactive Angular forms.
+spartan/ui composes forms from the `field` component plus the relevant control. It works with
+template-driven forms, reactive forms, and Angular's Signal Forms.
 
 Import the pieces from `@spartan-ng/helm/field` (the `HlmFieldImports` const exports them together)
 and the control from its own entrypoint (e.g. `@spartan-ng/helm/input`).
@@ -23,6 +23,38 @@ display, and tracks validation state.
 ```
 
 `hlmField` supports `orientation="vertical | horizontal | responsive"`.
+
+## Signal Forms
+
+The same `hlmField` and controls work with Angular's Signal Forms. Build the model with
+`form()` from `@angular/forms/signals`, bind the control with `[formField]`, and wrap the `<form>`
+with `[formRoot]`. Errors come from the field's `errors()` signal rather than the control's
+`invalid`/`touched` flags:
+
+```ts
+import { form, FormField, FormRoot, minLength, required } from '@angular/forms/signals';
+
+protected readonly model = signal({ email: '' });
+readonly emailForm = form(this.model, (path) => {
+	required(path.email, { message: 'Enter your email.' });
+	minLength(path.email, 5, { message: 'That email looks too short.' });
+});
+```
+
+```html
+<form [formRoot]="emailForm">
+	<div hlmField>
+		<label hlmFieldLabel for="email">Email</label>
+		<input hlmInput id="email" [formField]="emailForm.email" />
+		@for (error of emailForm.email().errors(); track error) {
+		<hlm-field-error [validator]="error.kind">{{ error.message }}</hlm-field-error>
+		}
+	</div>
+</form>
+```
+
+Import `FormRoot` and `FormField` alongside `HlmFieldImports`. Everything below (fieldsets, control
+choice, error display) applies regardless of which forms API you use.
 
 ## Group related controls
 

--- a/skills/spartan/rules/forms.md
+++ b/skills/spartan/rules/forms.md
@@ -1,0 +1,81 @@
+# Forms and inputs
+
+spartan/ui composes forms from the `field` component plus the relevant control. It works with both
+template-driven and reactive Angular forms.
+
+Import the pieces from `@spartan-ng/helm/field` (the `HlmFieldImports` const exports them together)
+and the control from its own entrypoint (e.g. `@spartan-ng/helm/input`).
+
+## Use `hlmField`, not raw `div`s
+
+Wrap each control in `hlmField`. It provides the label, control slot, description, and error
+display, and tracks validation state.
+
+```html
+<div hlmField>
+	<label hlmFieldLabel for="email">Email</label>
+	<input hlmInput id="email" [formControl]="email" />
+	<p hlmFieldDescription>We'll never share your email.</p>
+	@if (email.invalid && email.touched) {
+	<hlm-field-error>Enter a valid email address.</hlm-field-error>
+	}
+</div>
+```
+
+`hlmField` supports `orientation="vertical | horizontal | responsive"`.
+
+## Group related controls
+
+For sets of related checkboxes or radios, use the fieldset pieces so the group has a single legend
+and shared validation:
+
+`hlmFieldSet` and `hlmFieldLegend` are directives on the native `<fieldset>` and `<legend>`
+elements:
+
+```html
+<fieldset hlmFieldSet>
+	<legend hlmFieldLegend>Notifications</legend>
+	<div hlmFieldGroup>
+		<div hlmField orientation="horizontal">
+			<hlm-checkbox id="email-opt" />
+			<label hlmFieldLabel for="email-opt">Email</label>
+		</div>
+		<div hlmField orientation="horizontal">
+			<hlm-checkbox id="sms-opt" />
+			<label hlmFieldLabel for="sms-opt">SMS</label>
+		</div>
+	</div>
+</fieldset>
+```
+
+## Option sets (2-7 choices): `toggle-group`
+
+When the user picks from a small, fixed set of mutually exclusive options, prefer `hlm-toggle-group`
+over a row of buttons or a select.
+
+```html
+<hlm-toggle-group type="single" [(value)]="size">
+	<button hlmToggleGroupItem value="sm">Small</button>
+	<button hlmToggleGroupItem value="md">Medium</button>
+	<button hlmToggleGroupItem value="lg">Large</button>
+</hlm-toggle-group>
+```
+
+Use `type="multiple"` when more than one option can be active.
+
+## Choose the right control
+
+- Free text -> `input` / `textarea`
+- One-time codes -> `input-otp`
+- Input with leading/trailing affordances (icon, button, prefix) -> `input-group`
+- Single choice from many -> `select`, `combobox`, or `autocomplete`
+- Single choice from few -> `radio-group` or `toggle-group`
+- Boolean -> `switch` or `checkbox`
+- Numeric range -> `slider`
+- Native dropdown -> `native-select`
+
+## Validation display
+
+Show errors through the `<hlm-field-error>` component (not ad-hoc text), gated on the control being
+invalid and touched/dirty. The field reflects invalid state to its host so the label and control
+style consistently.

--- a/skills/spartan/rules/icons.md
+++ b/skills/spartan/rules/icons.md
@@ -1,0 +1,56 @@
+# Icons
+
+spartan/ui renders icons with [`@ng-icons`](https://ng-icons.github.io/ng-icons). The default set is
+Lucide (`@ng-icons/lucide`). The `icon` component (`@spartan-ng/helm/icon`) provides the `hlm`
+directive that sizes and styles icons consistently.
+
+## The element
+
+Icons are an `<ng-icon>` element with the `hlm` directive and a `name`:
+
+```html
+<ng-icon hlm name="lucideChevronRight" size="sm" />
+```
+
+## Register every icon
+
+Icon names are not global - each icon you reference must be provided to the component (or app) via
+`provideIcons`. Import the symbol from its set and register it:
+
+```ts
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronRight, lucideTrash } from '@ng-icons/lucide';
+import { HlmIcon } from '@spartan-ng/helm/icon';
+
+@Component({
+	selector: 'app-example',
+	imports: [NgIcon, HlmIcon],
+	providers: [provideIcons({ lucideChevronRight, lucideTrash })],
+	template: `
+		<ng-icon hlm name="lucideChevronRight" size="sm" />
+	`,
+})
+export class ExampleComponent {}
+```
+
+If an icon does not render, the usual cause is a missing `provideIcons` entry.
+
+## Sizing: use the `size` input
+
+Size icons with the `hlm` directive's `size` input (`xs | sm | base | lg | xl`), not Tailwind sizing
+classes, when the icon is inside a component. This keeps icons aligned with the component's metrics.
+
+```html
+<button hlmBtn size="icon" variant="ghost">
+	<ng-icon hlm name="lucideX" size="sm" />
+</button>
+```
+
+For free-standing decorative icons you may set color with a semantic class
+(`class="text-muted-foreground"`), but still prefer the `size` input over `w-*`/`h-*`.
+
+## Installing the icon component
+
+`npx nx g @spartan-ng/cli:ui --name=icon` (or `ng g ...`) installs `@ng-icons/core`,
+`@ng-icons/lucide`, and the Helm icon styles.

--- a/skills/spartan/rules/styling.md
+++ b/skills/spartan/rules/styling.md
@@ -83,6 +83,60 @@ import { hlm } from '@spartan-ng/helm/utils';
 const cls = hlm('rounded-md border px-3 py-2', active() && 'bg-accent', userClass());
 ```
 
+## Make your own component override-friendly
+
+When you build a component or directive in the "hlm-like" fashion, let callers pass classes that
+merge cleanly over your base styles. There are two patterns, both used across the hlm components.
+
+### Preferred: `classes()`
+
+Call `classes()` from `@spartan-ng/helm/utils` in the constructor. It applies your base classes to
+the host element and automatically merges (via `hlm()`) any `class` the consumer puts on the host,
+with the consumer's classes winning conflicts. No `class` input or binding needed, and it works
+the same on components and directives:
+
+```ts
+import { Component } from '@angular/core';
+import { classes } from '@spartan-ng/helm/utils';
+
+@Component({
+	selector: 'app-badge',
+	template: '<ng-content />',
+})
+export class AppBadge {
+	constructor() {
+		classes(() => 'inline-flex items-center rounded-md border px-2 py-0.5');
+	}
+}
+```
+
+A consumer writes `<app-badge class="bg-primary text-primary-foreground">` and it merges
+automatically. Because it manages the host `class` directly, it avoids clashing with other class
+bindings.
+
+### Explicit: a `class` input merged with `hlm()`
+
+When you need to fold the user's class into a `computed` alongside conditional classes, take a
+`class`-aliased input and bind the merged result yourself. Put the user's class last so it wins:
+
+```ts
+import { Component, computed, input } from '@angular/core';
+import { hlm } from '@spartan-ng/helm/utils';
+import type { ClassValue } from 'clsx';
+
+@Component({
+	selector: 'app-badge',
+	template: '<ng-content />',
+	host: { '[class]': '_computedClass()' },
+})
+export class AppBadge {
+	public readonly userClass = input<ClassValue>('', { alias: 'class' });
+	protected readonly _computedClass = computed(() =>
+		hlm('inline-flex items-center rounded-md border px-2 py-0.5', this.userClass()),
+	);
+}
+```
+
 ## Overlays: no manual z-index
 
 Dialog, Sheet, Popover, Tooltip, Dropdown, and other overlay components manage stacking via the

--- a/skills/spartan/rules/styling.md
+++ b/skills/spartan/rules/styling.md
@@ -1,0 +1,89 @@
+# Styling rules
+
+spartan/ui styles with Tailwind. The styled (Helm) layer is built with
+[class-variance-authority](https://cva.style) and merged with the `hlm()` utility.
+
+## Semantic colors only
+
+Never use raw Tailwind palette values (`bg-blue-500`, `text-gray-700`) on spartan components. Use the
+semantic tokens defined by the preset and CSS variables. Each has a paired `-foreground` for content
+placed on top of it:
+
+`background` / `foreground`, `card` / `card-foreground`, `popover` / `popover-foreground`,
+`primary` / `primary-foreground`, `secondary` / `secondary-foreground`,
+`muted` / `muted-foreground`, `accent` / `accent-foreground`,
+`destructive` / `destructive-foreground`, plus the standalone `border`, `input`, and `ring`, and the
+`sidebar*` family.
+
+```html
+<!-- Good -->
+<div class="bg-card text-card-foreground border-border border">...</div>
+<div class="bg-primary text-primary-foreground">...</div>
+
+<!-- Bad -->
+<div class="border-gray-200 bg-white text-black">...</div>
+<div class="bg-blue-600 text-white">...</div>
+```
+
+These tokens automatically flip in dark mode, so you never write dark-mode color overrides by hand.
+
+## Prefer built-in variants
+
+Components expose `variant` and `size` inputs. Use them instead of re-styling with classes.
+
+```html
+<button hlmBtn variant="outline" size="sm">Cancel</button>
+<span hlmBadge variant="secondary">beta</span>
+<div hlmAlert variant="destructive">...</div>
+```
+
+Button variants: `default | destructive | outline | secondary | ghost | link`.
+Button sizes: `default | xs | sm | lg | icon | icon-xs | icon-sm | icon-lg`.
+
+## `class` is for layout only
+
+Use the `class` attribute to position and space components (flex, grid, gap, margins, widths). Do
+not use it to override a component's own colors, typography, or internal padding - change the copied
+Helm file or a CSS variable instead.
+
+## Spacing: `gap-*`, not `space-*`
+
+Use `flex`/`grid` with `gap-*` for spacing between items. Avoid `space-x-*` / `space-y-*`.
+
+```html
+<!-- Good -->
+<div class="flex flex-col gap-4">...</div>
+<!-- Bad -->
+<div class="space-y-4">...</div>
+```
+
+## `size-*` for equal dimensions
+
+When width and height are equal, use `size-*` rather than `w-* h-*`.
+
+```html
+<div class="size-8 rounded-full">...</div>
+<!-- not w-8 h-8 -->
+```
+
+## Use `truncate`
+
+Use the `truncate` shorthand instead of manually combining `overflow-hidden text-ellipsis
+whitespace-nowrap`.
+
+## The `hlm()` utility
+
+When you compute classes in TypeScript, merge them with `hlm()` from `@spartan-ng/helm/utils` (it
+wraps `clsx` + `tailwind-merge`, so later classes win conflicts). Do not concatenate class strings
+by hand.
+
+```ts
+import { hlm } from '@spartan-ng/helm/utils';
+
+const cls = hlm('rounded-md border px-3 py-2', active() && 'bg-accent', userClass());
+```
+
+## Overlays: no manual z-index
+
+Dialog, Sheet, Popover, Tooltip, Dropdown, and other overlay components manage stacking via the
+Angular CDK overlay. Do not set `z-index` on them manually.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -131,10 +131,10 @@
 			"@spartan-ng/helm/tooltip": ["libs/helm/tooltip/src/index.ts"],
 			"@spartan-ng/helm/typography": ["libs/helm/typography/src/index.ts"],
 			"@spartan-ng/helm/utils": ["libs/helm/utils/src/index.ts"],
+			"@spartan-ng/mcp": ["libs/mcp/src/index.ts"],
 			"@spartan-ng/registry": ["libs/registry/src/index.ts"],
 			"@spartan-ng/tools": ["libs/tools/src/index.ts"],
-			"@spartan-ng/trpc": ["libs/trpc/src/index.ts"],
-			"@spartan-ng/mcp": ["libs/mcp/src/index.ts"]
+			"@spartan-ng/trpc": ["libs/trpc/src/index.ts"]
 		}
 	},
 	"exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [x] repo
- [x] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

spartan/ui has an MCP server and a CLI, but no agent "skill" - the procedural knowledge an AI coding
assistant needs to use spartan correctly (the Brain/Helm two-layer model, composition rules, the CLI
commands). Without it, assistants tend to hand-roll incorrect Angular markup. There is also no
machine-readable way for a tool to read a project's spartan setup; the CLI only exposes the
human-oriented `healthcheck`.

Closes #

## What is the new behavior?

- Adds a [skills.sh](https://skills.sh)-compatible agent skill at `skills/spartan` (installable with
  `npx skills add spartan-ng/spartan`). It contains a `SKILL.md` plus reference files
  (`rules/{styling,forms,composition,icons,brain-vs-helm}.md`, `cli.md`, `registry.md`,
  `customization.md`, `mcp.md`) that teach an agent the Brain (headless) + Helm (styled) layers,
  composition rules, semantic-color styling, form composition, icon setup, the CLI, theming, and the
  MCP server. Every selector, input, import path, command, and flag was verified against source.
- Adds a new read-only `@spartan-ng/cli:info` generator (Nx generator + Angular schematic). It prints
  project context - the `components.json` config, package versions, detected icon library and styles
  file, and the installed vs. available components - as text, or as machine-readable JSON with
  `--json`. The skill uses this to gather project context. Covered by unit tests.
- Documents both on the docs site: a new "Skills" page, an "Inspect Your Project" section on the CLI
  page, and a README mention.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The `:info` command is read-only - it never creates or modifies `components.json`. The skill's
`SKILL.md` uses the `allowed-tools` frontmatter field (the Claude Code / skills.sh convention); some
editors' agent schemas do not recognize that key, which is expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `info` CLI generator to inspect project context and output machine-readable JSON.
  * New "Skills" documentation route, a "Inspect Your Project" section in docs, and a "Skills" link in the side navigation.

* **Documentation**
  * Extensive Spartan skill docs added: README note, CLI reference, customization, MCP integration, registry, composition rules (forms, icons, styling, brain vs helm).

* **Tests**
  * Added tests covering the new `info` generator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->