### PR TITLE
fix(field): add explicit undefined to optional type annotation

### DIFF
--- a/libs/cli/src/generators/ui/libs/field/files/lib/hlm-field-error.ts.template
+++ b/libs/cli/src/generators/ui/libs/field/files/lib/hlm-field-error.ts.template
@@ -34,7 +34,7 @@ export class HlmFieldError implements OnDestroy {
 	private readonly _field = inject(BrnField, { optional: true });
 	private readonly _a11y = inject(BrnFieldA11yService, { optional: true, host: true });
 
-	private _registeredId?: string;
+	private _registeredId?: string | undefined;
 
 	private readonly _hasParentField = !!this._field;
 

--- a/libs/helm/field/src/lib/hlm-field-error.ts
+++ b/libs/helm/field/src/lib/hlm-field-error.ts
@@ -34,7 +34,7 @@ export class HlmFieldError implements OnDestroy {
 	private readonly _field = inject(BrnField, { optional: true });
 	private readonly _a11y = inject(BrnFieldA11yService, { optional: true, host: true });
 
-	private _registeredId?: string;
+	private _registeredId?: string | undefined;
 
 	private readonly _hasParentField = !!this._field;
 


### PR DESCRIPTION
Update type annotation to be compatible with TypeScript's exactOptionalPropertyTypes option.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [x] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

When using the cli to add the field component to a project that has the `exactOptionalPropertyTypes` option enabled, the following TypeScript error occurs:

"Type 'undefined' is not assignable to type 'string' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the type of the target."

## What is the new behavior?

The error no longer occurs after adding the field component to a project using `exactOptionalPropertyTypes`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type definitions for improved code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->