### PR TITLE
fix: allow undefined in value model signals for autocomplete, combobox, and select

### DIFF
--- a/libs/brain/autocomplete/src/lib/brn-autocomplete-clear.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete-clear.ts
@@ -11,9 +11,10 @@ export class BrnAutocompleteClear {
 	private readonly _viewContainerRef = inject(ViewContainerRef);
 
 	/** Determine if the autocomplete has a value or search text */
-	private readonly _shouldShowClear = computed(
-		() => this._autocomplete.value() !== null || this._autocomplete.search() !== '',
-	);
+	private readonly _shouldShowClear = computed(() => {
+		const value = this._autocomplete.value();
+		return (value !== null && value !== undefined) || this._autocomplete.search() !== '';
+	});
 
 	constructor() {
 		effect(() => {

--- a/libs/brain/autocomplete/src/lib/brn-autocomplete-search.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete-search.ts
@@ -77,7 +77,7 @@ export class BrnAutocompleteSearch<T> implements BrnAutocompleteBase<T>, Control
 	});
 
 	/** The selected value of the autocomplete. */
-	public readonly value = model<string | null>(null);
+	public readonly value = model<string | undefined | null>(null);
 
 	/** The current search query. */
 	public readonly search = model<string>('');
@@ -103,7 +103,7 @@ export class BrnAutocompleteSearch<T> implements BrnAutocompleteBase<T>, Control
 
 	private readonly _autocompleteInput = signal<BrnAutocompleteInput<T> | undefined>(undefined);
 
-	protected _onChange?: ChangeFn<string | null>;
+	protected _onChange?: ChangeFn<string | undefined | null>;
 	protected _onTouched?: TouchFn;
 
 	public readonly labelableId = computed(() => this._autocompleteInput()?.id());
@@ -209,11 +209,11 @@ export class BrnAutocompleteSearch<T> implements BrnAutocompleteBase<T>, Control
 	}
 
 	/** CONTROL VALUE ACCESSOR */
-	writeValue(value: string | null): void {
+	writeValue(value: string | undefined | null): void {
 		this.value.set(value);
 	}
 
-	registerOnChange(fn: ChangeFn<string | null>): void {
+	registerOnChange(fn: ChangeFn<string | undefined | null>): void {
 		this._onChange = fn;
 	}
 

--- a/libs/brain/autocomplete/src/lib/brn-autocomplete.token.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete.token.ts
@@ -19,7 +19,7 @@ export interface BrnAutocompleteBase<T> {
 	disabled: Signal<boolean>;
 	disabledState: Signal<boolean>;
 	keyManager: ActiveDescendantKeyManager<BrnAutocompleteItem<T>>;
-	value: ModelSignal<T | null> | ModelSignal<string | null>;
+	value: ModelSignal<T | undefined | null> | ModelSignal<string | undefined | null>;
 	visibleItems: Signal<boolean>;
 	isExpanded: Signal<boolean>;
 	searchInputWrapperWidth: Signal<number | null>;
@@ -47,7 +47,7 @@ export function injectBrnAutocompleteBase<T>(): BrnAutocompleteBase<T> {
 }
 
 // config
-export type AutocompleteItemEqualToValue<T> = (itemValue: T, selectedValue: T | null) => boolean;
+export type AutocompleteItemEqualToValue<T> = (itemValue: T, selectedValue: T | undefined | null) => boolean;
 export type AutocompleteItemToString<T> = (itemValue: T) => string;
 
 export interface BrnAutocompleteConfig<T> {
@@ -58,7 +58,7 @@ export interface BrnAutocompleteConfig<T> {
 
 function getDefaultConfig<T>(): BrnAutocompleteConfig<T> {
 	return {
-		isItemEqualToValue: (itemValue: T, selectedValue: T | null) => Object.is(itemValue, selectedValue),
+		isItemEqualToValue: (itemValue: T, selectedValue: T | undefined | null) => Object.is(itemValue, selectedValue),
 		itemToString: undefined,
 		autoHighlight: false,
 	};

--- a/libs/brain/autocomplete/src/lib/brn-autocomplete.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete.ts
@@ -77,7 +77,7 @@ export class BrnAutocomplete<T> implements BrnAutocompleteBase<T>, ControlValueA
 	});
 
 	/** The selected value of the autocomplete. */
-	public readonly value = model<T | null>(null);
+	public readonly value = model<T | undefined | null>(null);
 
 	/** The current search query. */
 	public readonly search = model<string>('');
@@ -103,7 +103,7 @@ export class BrnAutocomplete<T> implements BrnAutocompleteBase<T>, ControlValueA
 
 	private readonly _autocompleteInput = signal<BrnAutocompleteInput<T> | undefined>(undefined);
 
-	protected _onChange?: ChangeFn<T | null>;
+	protected _onChange?: ChangeFn<T | undefined | null>;
 	protected _onTouched?: TouchFn;
 
 	public readonly labelableId = computed(() => this._autocompleteInput()?.id());
@@ -206,11 +206,11 @@ export class BrnAutocomplete<T> implements BrnAutocompleteBase<T>, ControlValueA
 	}
 
 	/** CONTROL VALUE ACCESSOR */
-	writeValue(value: T | null): void {
+	writeValue(value: T | undefined | null): void {
 		this.value.set(value);
 	}
 
-	registerOnChange(fn: ChangeFn<T | null>): void {
+	registerOnChange(fn: ChangeFn<T | undefined | null>): void {
 		this._onChange = fn;
 	}
 

--- a/libs/brain/combobox/src/lib/brn-combobox-multiple.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-multiple.ts
@@ -107,7 +107,7 @@ export class BrnComboboxMultiple<T> implements BrnComboboxBase<T>, ControlValueA
 
 	public readonly hasValue = computed(() => {
 		const value = this.value();
-		if (value == null) return false;
+		if (value === null || value === undefined) return false;
 		return value.length > 0;
 	});
 

--- a/libs/brain/combobox/src/lib/brn-combobox-multiple.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-multiple.ts
@@ -103,7 +103,7 @@ export class BrnComboboxMultiple<T> implements BrnComboboxBase<T>, ControlValueA
 	});
 
 	/** The selected values of the combobox. */
-	public readonly value = model<T[] | null>(null);
+	public readonly value = model<T[] | undefined | null>(null);
 
 	public readonly hasValue = computed(() => {
 		const value = this.value();
@@ -143,7 +143,7 @@ export class BrnComboboxMultiple<T> implements BrnComboboxBase<T>, ControlValueA
 
 	public readonly labelableId = computed(() => this._comboboxChipInput()?.id());
 
-	protected _onChange?: ChangeFn<T[] | null>;
+	protected _onChange?: ChangeFn<T[] | undefined | null>;
 	protected _onTouched?: TouchFn;
 
 	constructor() {
@@ -270,11 +270,11 @@ export class BrnComboboxMultiple<T> implements BrnComboboxBase<T>, ControlValueA
 	}
 
 	/** CONTROL VALUE ACCESSOR */
-	public writeValue(value: T[] | null): void {
+	public writeValue(value: T[] | undefined | null): void {
 		this.value.set(value);
 	}
 
-	public registerOnChange(fn: ChangeFn<T[] | null>): void {
+	public registerOnChange(fn: ChangeFn<T[] | undefined | null>): void {
 		this._onChange = fn;
 	}
 

--- a/libs/brain/combobox/src/lib/brn-combobox-values.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-values.ts
@@ -13,7 +13,7 @@ export class BrnComboboxValues<T> {
 	protected readonly _values = computed<T[] | null>(() => {
 		const values = this._combobox.value();
 
-		if (values == null) {
+		if (values === null || values === undefined) {
 			return null;
 		}
 

--- a/libs/brain/combobox/src/lib/brn-combobox.token.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox.token.ts
@@ -25,7 +25,7 @@ export interface BrnComboboxBase<T> {
 	disabled: Signal<boolean>;
 	disabledState: Signal<boolean>;
 	keyManager: ActiveDescendantKeyManager<BrnComboboxItem<T>>;
-	value: ModelSignal<T | null> | ModelSignal<T[] | null>;
+	value: ModelSignal<T | undefined | null> | ModelSignal<T[] | undefined | null>;
 	visibleItems: Signal<boolean>;
 	isExpanded: Signal<boolean>;
 	searchInputWrapperWidth: Signal<number | null>;
@@ -79,7 +79,7 @@ export type ComboboxFilter<T> = (
 	itemToString?: ComboboxItemToString<T>,
 ) => boolean;
 
-export type ComboboxItemEqualToValue<T> = (itemValue: T, selectedValue: T | null) => boolean;
+export type ComboboxItemEqualToValue<T> = (itemValue: T, selectedValue: T | undefined | null) => boolean;
 
 export type ComboboxItemToString<T> = (itemValue: T) => string;
 
@@ -102,7 +102,7 @@ function getDefaultConfig<T>(): BrnComboboxConfig<T> {
 		},
 		filter: (itemValue: T, search: string, collator: Intl.Collator, itemToString?: ComboboxItemToString<T>) =>
 			comboboxContainsFilter(itemValue, search, collator, itemToString),
-		isItemEqualToValue: (itemValue: T, selectedValue: T | null) => Object.is(itemValue, selectedValue),
+		isItemEqualToValue: (itemValue: T, selectedValue: T | undefined | null) => Object.is(itemValue, selectedValue),
 		itemToString: undefined,
 		autoHighlight: false,
 		closeOnSelect: true,

--- a/libs/brain/combobox/src/lib/brn-combobox.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox.ts
@@ -99,9 +99,9 @@ export class BrnCombobox<T> implements BrnComboboxBase<T>, ControlValueAccessor 
 	});
 
 	/** The selected value of the combobox. */
-	public readonly value = model<T | null>(null);
+	public readonly value = model<T | undefined | null>(null);
 
-	public readonly hasValue = computed(() => this.value() !== null);
+	public readonly hasValue = computed(() => this.value() !== null && this.value() !== undefined);
 
 	/** The current search query. */
 	public readonly search = model<string>('');
@@ -135,7 +135,7 @@ export class BrnCombobox<T> implements BrnComboboxBase<T>, ControlValueAccessor 
 
 	public readonly labelableId = computed(() => this._comboboxInput()?.id());
 
-	protected _onChange?: ChangeFn<T | null>;
+	protected _onChange?: ChangeFn<T | undefined | null>;
 	protected _onTouched?: TouchFn;
 
 	constructor() {
@@ -227,11 +227,11 @@ export class BrnCombobox<T> implements BrnComboboxBase<T>, ControlValueAccessor 
 	}
 
 	/** CONTROL VALUE ACCESSOR */
-	public writeValue(value: T | null): void {
+	public writeValue(value: T | undefined | null): void {
 		this.value.set(value);
 	}
 
-	public registerOnChange(fn: ChangeFn<T | null>): void {
+	public registerOnChange(fn: ChangeFn<T | undefined | null>): void {
 		this._onChange = fn;
 	}
 

--- a/libs/brain/core/src/helpers/resolve-value-label.ts
+++ b/libs/brain/core/src/helpers/resolve-value-label.ts
@@ -1,12 +1,12 @@
 export function stringifyAsLabel(item: any, itemToStringLabel?: (item: any) => string) {
-	if (itemToStringLabel && item != null) {
+	if (itemToStringLabel && item !== null && item !== undefined) {
 		return itemToStringLabel(item) ?? '';
 	}
 	if (item && typeof item === 'object') {
-		if ('label' in item && item.label != null) {
+		if ('label' in item && item.label !== null && item.label !== undefined) {
 			return String(item.label);
 		}
-		if ('value' in item) {
+		if ('value' in item && item.value !== null && item.value !== undefined) {
 			return String(item.value);
 		}
 	}
@@ -14,7 +14,7 @@ export function stringifyAsLabel(item: any, itemToStringLabel?: (item: any) => s
 }
 
 export function serializeValue(value: unknown): string {
-	if (value == null) {
+	if (value === null || value === undefined) {
 		return '';
 	}
 	if (typeof value === 'string') {

--- a/libs/brain/select/src/lib/brn-select-multiple.ts
+++ b/libs/brain/select/src/lib/brn-select-multiple.ts
@@ -70,7 +70,7 @@ export class BrnSelectMultiple<T> implements BrnSelectBase<T>, ControlValueAcces
 
 	public readonly hasValue = computed(() => {
 		const value = this.value();
-		if (value == null) return false;
+		if (value === null || value === undefined) return false;
 		return value.length > 0;
 	});
 

--- a/libs/brain/select/src/lib/brn-select-multiple.ts
+++ b/libs/brain/select/src/lib/brn-select-multiple.ts
@@ -66,7 +66,7 @@ export class BrnSelectMultiple<T> implements BrnSelectBase<T>, ControlValueAcces
 	public readonly disabledState = this._disabled.asReadonly();
 
 	/** The selected value of the select. */
-	public readonly value = model<T[] | null>(null);
+	public readonly value = model<T[] | undefined | null>(null);
 
 	public readonly hasValue = computed(() => {
 		const value = this.value();
@@ -100,7 +100,7 @@ export class BrnSelectMultiple<T> implements BrnSelectBase<T>, ControlValueAcces
 
 	public readonly labelableId = computed(() => this._selectTrigger()?.id());
 
-	protected _onChange?: ChangeFn<T[] | null>;
+	protected _onChange?: ChangeFn<T[] | undefined | null>;
 	protected _onTouched?: TouchFn;
 
 	constructor() {
@@ -193,11 +193,11 @@ export class BrnSelectMultiple<T> implements BrnSelectBase<T>, ControlValueAcces
 	}
 
 	/** CONTROL VALUE ACCESSOR */
-	public writeValue(value: T[] | null): void {
+	public writeValue(value: T[] | undefined | null): void {
 		this.value.set(value);
 	}
 
-	public registerOnChange(fn: ChangeFn<T[] | null>): void {
+	public registerOnChange(fn: ChangeFn<T[] | undefined | null>): void {
 		this._onChange = fn;
 	}
 

--- a/libs/brain/select/src/lib/brn-select-multiple.ts
+++ b/libs/brain/select/src/lib/brn-select-multiple.ts
@@ -127,7 +127,9 @@ export class BrnSelectMultiple<T> implements BrnSelectBase<T>, ControlValueAcces
 
 					untracked(() => {
 						const index =
-							lastValue !== null ? items.findIndex((item) => this.isItemEqualToValue()(item.value(), lastValue)) : -1;
+							lastValue !== null && lastValue !== undefined
+								? items.findIndex((item) => this.isItemEqualToValue()(item.value(), lastValue))
+								: -1;
 
 						if (index !== -1) {
 							this.keyManager.setActiveItem(index);

--- a/libs/brain/select/src/lib/brn-select-value-template.ts
+++ b/libs/brain/select/src/lib/brn-select-value-template.ts
@@ -13,7 +13,7 @@ export class BrnSelectValueTemplate<T> {
 	protected readonly _value = computed<T | null>(() => {
 		const value = this._select.value();
 
-		if (value === null) {
+		if (value === null || value === undefined) {
 			return null;
 		}
 
@@ -23,7 +23,7 @@ export class BrnSelectValueTemplate<T> {
 	constructor() {
 		effect(() => {
 			const value = this._value();
-			if (value !== null) {
+			if (value !== null && value !== undefined) {
 				this._viewContainerRef.clear();
 				this._viewContainerRef.createEmbeddedView(this._templateRef, {
 					$implicit: value,

--- a/libs/brain/select/src/lib/brn-select-values.ts
+++ b/libs/brain/select/src/lib/brn-select-values.ts
@@ -10,10 +10,10 @@ export class BrnSelectValues<T> {
 
 	private readonly _select = injectBrnSelectBase<T>();
 
-	protected readonly _values = computed<T[] | null>(() => {
+	protected readonly _values = computed<T[] | undefined | null>(() => {
 		const values = this._select.value();
 
-		if (values === null) {
+		if (values === null || values === undefined) {
 			return null;
 		}
 

--- a/libs/brain/select/src/lib/brn-select.token.ts
+++ b/libs/brain/select/src/lib/brn-select.token.ts
@@ -17,7 +17,7 @@ export interface BrnSelectBase<T> {
 	disabledState: Signal<boolean>;
 	itemToString: InputSignal<SelectItemToString<T> | undefined>;
 	keyManager: ActiveDescendantKeyManager<BrnSelectItem<T>>;
-	value: ModelSignal<T | null> | ModelSignal<T[] | null>;
+	value: ModelSignal<T | undefined | null> | ModelSignal<T[] | undefined | null>;
 	hasValue: Signal<boolean>;
 	isExpanded: Signal<boolean>;
 	triggerWidth: Signal<number | null>;
@@ -45,7 +45,7 @@ export function injectBrnSelectBase<T>(): BrnSelectBase<T> {
 	return inject(BrnSelectBaseToken) as BrnSelectBase<T>;
 }
 
-export type SelectItemEqualToValue<T> = (itemValue: T, selectedValue: T | null) => boolean;
+export type SelectItemEqualToValue<T> = (itemValue: T, selectedValue: T | undefined | null) => boolean;
 export type SelectItemToString<T> = (itemValue: T) => string;
 
 export interface BrnSelectConfig<T> {
@@ -55,7 +55,7 @@ export interface BrnSelectConfig<T> {
 
 function getDefaultConfig<T>(): BrnSelectConfig<T> {
 	return {
-		isItemEqualToValue: (itemValue: T, selectedValue: T | null) => Object.is(itemValue, selectedValue),
+		isItemEqualToValue: (itemValue: T, selectedValue: T | undefined | null) => Object.is(itemValue, selectedValue),
 		itemToString: undefined,
 	};
 }

--- a/libs/brain/select/src/lib/brn-select.ts
+++ b/libs/brain/select/src/lib/brn-select.ts
@@ -118,7 +118,9 @@ export class BrnSelect<T> implements BrnSelectBase<T>, ControlValueAccessor {
 
 					untracked(() => {
 						const index =
-							value !== null ? items.findIndex((item) => this.isItemEqualToValue()(item.value(), value)) : -1;
+							value !== null && value !== undefined
+								? items.findIndex((item) => this.isItemEqualToValue()(item.value(), value))
+								: -1;
 
 						if (index !== -1) {
 							this.keyManager.setActiveItem(index);

--- a/libs/brain/select/src/lib/brn-select.ts
+++ b/libs/brain/select/src/lib/brn-select.ts
@@ -62,9 +62,9 @@ export class BrnSelect<T> implements BrnSelectBase<T>, ControlValueAccessor {
 	public readonly disabledState = this._disabled.asReadonly();
 
 	/** The selected value of the select. */
-	public readonly value = model<T | null>(null);
+	public readonly value = model<T | undefined | null>(null);
 
-	public readonly hasValue = computed(() => this.value() !== null);
+	public readonly hasValue = computed(() => this.value() !== null && this.value() !== undefined);
 
 	/** A function to compare an item with the selected value. */
 	public readonly isItemEqualToValue = input<SelectItemEqualToValue<T>>(this._config.isItemEqualToValue);
@@ -92,7 +92,7 @@ export class BrnSelect<T> implements BrnSelectBase<T>, ControlValueAccessor {
 
 	public readonly labelableId = computed(() => this._selectTrigger()?.id());
 
-	protected _onChange?: ChangeFn<T | null>;
+	protected _onChange?: ChangeFn<T | undefined | null>;
 	protected _onTouched?: TouchFn;
 
 	constructor() {
@@ -178,11 +178,11 @@ export class BrnSelect<T> implements BrnSelectBase<T>, ControlValueAccessor {
 	}
 
 	/** CONTROL VALUE ACCESSOR */
-	public writeValue(value: T | null): void {
+	public writeValue(value: T | undefined | null): void {
 		this.value.set(value);
 	}
 
-	public registerOnChange(fn: ChangeFn<T | null>): void {
+	public registerOnChange(fn: ChangeFn<T | undefined | null>): void {
 		this._onChange = fn;
 	}
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [x] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [x] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [x] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1387

## What is the new behavior?

Update the value model signals in `autocomplete`, `combobox`, and `select` primitives to accept `undefined` in addition to null.
This ensures better compatibility with various data sources and forms where `undefined` might be a valid state.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Autocomplete, combobox, and select (single & multiple) controls now accept an additional "unset" state (undefined alongside null), making cleared/uninitialized selections and form integration more flexible while preserving selection/search/open/close behavior.
  * Internal handling and rendering now use stricter empty-value checks, improving consistency of displayed labels and clear-button visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->