### PR TITLE
feat: update duplicate outputs, replace ngModel

### DIFF
--- a/libs/brain/checkbox/src/lib/brn-checkbox.ts
+++ b/libs/brain/checkbox/src/lib/brn-checkbox.ts
@@ -102,19 +102,17 @@ export class BrnCheckbox implements ControlValueAccessor, AfterContentInit, OnDe
 	 * The checked state of the checkbox.
 	 * Can be bound with [(checked)] for two-way binding.
 	 */
-	public readonly checked = input<boolean>(false);
+	public readonly checkedInput = input<boolean, BooleanInput>(false, { alias: 'checked', transform: booleanAttribute });
+	public readonly checked = linkedSignal(this.checkedInput);
 
 	/** Emits when checked state changes. */
 	public readonly checkedChange = output<boolean>();
-
-	/** Internal writable mirror of the {@link checked} input, updated via {@link toggle} and {@link writeValue}. */
-	protected readonly _checked = linkedSignal(this.checked);
 
 	/**
 	 * Read-only signal of current checkbox state.
 	 * Use this when you only need to read state without changing it.
 	 */
-	public readonly isChecked = this._checked.asReadonly();
+	public readonly isChecked = this.checked.asReadonly();
 
 	/*
 	 * The indeterminate state of the checkbox.
@@ -128,7 +126,7 @@ export class BrnCheckbox implements ControlValueAccessor, AfterContentInit, OnDe
 	 */
 	protected readonly _dataState = computed(() => {
 		if (this.indeterminate()) return 'indeterminate';
-		return this._checked() ? 'checked' : 'unchecked';
+		return this.checked() ? 'checked' : 'unchecked';
 	});
 
 	/**
@@ -137,7 +135,7 @@ export class BrnCheckbox implements ControlValueAccessor, AfterContentInit, OnDe
 	 */
 	protected readonly _ariaChecked = computed(() => {
 		if (this.indeterminate()) return 'mixed';
-		return this._checked() ? 'true' : 'false';
+		return this.checked() ? 'true' : 'false';
 	});
 
 	/**
@@ -272,10 +270,10 @@ export class BrnCheckbox implements ControlValueAccessor, AfterContentInit, OnDe
 		this._onTouched();
 		this.touched.emit();
 
-		const newChecked = this.indeterminate() ? true : !this._checked();
+		const newChecked = this.indeterminate() ? true : !this.checked();
 		this.indeterminate.set(false);
 		this.checkedChange.emit(newChecked);
-		this._checked.set(newChecked);
+		this.checked.set(newChecked);
 		this._onChange(newChecked);
 	}
 
@@ -329,7 +327,7 @@ export class BrnCheckbox implements ControlValueAccessor, AfterContentInit, OnDe
 	 * @param value - New checkbox state (true/false/'indeterminate')
 	 */
 	writeValue(value: boolean): void {
-		this._checked.set(value);
+		this.checked.set(value);
 	}
 
 	/**

--- a/libs/brain/checkbox/src/lib/brn-checkbox.ts
+++ b/libs/brain/checkbox/src/lib/brn-checkbox.ts
@@ -102,16 +102,19 @@ export class BrnCheckbox implements ControlValueAccessor, AfterContentInit, OnDe
 	 * The checked state of the checkbox.
 	 * Can be bound with [(checked)] for two-way binding.
 	 */
-	public readonly checked = model<boolean>(false);
+	public readonly checked = input<boolean>(false);
 
 	/** Emits when checked state changes. */
 	public readonly checkedChange = output<boolean>();
+
+	/** Internal writable mirror of the {@link checked} input, updated via {@link toggle} and {@link writeValue}. */
+	protected readonly _checked = linkedSignal(this.checked);
 
 	/**
 	 * Read-only signal of current checkbox state.
 	 * Use this when you only need to read state without changing it.
 	 */
-	public readonly isChecked = this.checked.asReadonly();
+	public readonly isChecked = this._checked.asReadonly();
 
 	/*
 	 * The indeterminate state of the checkbox.
@@ -125,7 +128,7 @@ export class BrnCheckbox implements ControlValueAccessor, AfterContentInit, OnDe
 	 */
 	protected readonly _dataState = computed(() => {
 		if (this.indeterminate()) return 'indeterminate';
-		return this.checked() ? 'checked' : 'unchecked';
+		return this._checked() ? 'checked' : 'unchecked';
 	});
 
 	/**
@@ -134,7 +137,7 @@ export class BrnCheckbox implements ControlValueAccessor, AfterContentInit, OnDe
 	 */
 	protected readonly _ariaChecked = computed(() => {
 		if (this.indeterminate()) return 'mixed';
-		return this.checked() ? 'true' : 'false';
+		return this._checked() ? 'true' : 'false';
 	});
 
 	/**
@@ -269,10 +272,10 @@ export class BrnCheckbox implements ControlValueAccessor, AfterContentInit, OnDe
 		this._onTouched();
 		this.touched.emit();
 
-		const newChecked = this.indeterminate() ? true : !this.checked();
+		const newChecked = this.indeterminate() ? true : !this._checked();
 		this.indeterminate.set(false);
 		this.checkedChange.emit(newChecked);
-		this.checked.set(newChecked);
+		this._checked.set(newChecked);
 		this._onChange(newChecked);
 	}
 
@@ -326,7 +329,7 @@ export class BrnCheckbox implements ControlValueAccessor, AfterContentInit, OnDe
 	 * @param value - New checkbox state (true/false/'indeterminate')
 	 */
 	writeValue(value: boolean): void {
-		this.checked.set(value);
+		this._checked.set(value);
 	}
 
 	/**

--- a/libs/brain/input-otp/src/lib/brn-input-otp.ts
+++ b/libs/brain/input-otp/src/lib/brn-input-otp.ts
@@ -47,7 +47,7 @@ export type InputMode = 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal'
 				[style]="inputStyles()"
 				[disabled]="_disabled()"
 				[inputMode]="inputMode()"
-				[value]="_value() ?? ''"
+				[value]="value() ?? ''"
 				(input)="onInputChange($event)"
 				(paste)="onPaste($event)"
 				(focus)="_focused.set(true)"
@@ -109,16 +109,14 @@ export class BrnInputOtp implements ControlValueAccessor {
 	public readonly transformPaste = input<(pastedText: string, maxLength: number) => string>((text) => text);
 
 	/** The value controlling the input */
-	public readonly value = input<string | null>(null);
+	public readonly valueInput = input<string | null>(null, { alias: 'value' });
+	public readonly value = linkedSignal(this.valueInput);
 
 	/** Emits when the value changes. */
 	public readonly valueChange = output<string>();
 
-	/** Internal writable mirror of the {@link value} input, updated via user interaction and {@link writeValue}. */
-	protected readonly _value = linkedSignal(this.value);
-
 	public readonly context = computed(() => {
-		const value = this._value() ?? '';
+		const value = this.value() ?? '';
 		const focused = this._focused();
 		const maxLength = this.maxLength();
 		const slots = Array.from({ length: this.maxLength() }).map((_, slotIndex) => {
@@ -179,7 +177,7 @@ export class BrnInputOtp implements ControlValueAccessor {
 
 	/** CONTROL VALUE ACCESSOR */
 	writeValue(value: string | null): void {
-		this._value.set(value);
+		this.value.set(value);
 		if (value?.length === this.maxLength()) {
 			this.completed.emit(value ?? '');
 		}
@@ -202,9 +200,9 @@ export class BrnInputOtp implements ControlValueAccessor {
 	}
 
 	private updateValue(newValue: string, maxLength: number) {
-		const previousValue = this._value() ?? '';
+		const previousValue = this.value() ?? '';
 
-		this._value.set(newValue);
+		this.value.set(newValue);
 		this.valueChange.emit(newValue);
 		this._onChange?.(newValue);
 

--- a/libs/brain/input-otp/src/lib/brn-input-otp.ts
+++ b/libs/brain/input-otp/src/lib/brn-input-otp.ts
@@ -9,13 +9,12 @@ import {
 	forwardRef,
 	input,
 	linkedSignal,
-	model,
 	numberAttribute,
 	output,
 	signal,
 	viewChild,
 } from '@angular/core';
-import { type ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import type { ChangeFn, TouchFn } from '@spartan-ng/brain/forms';
 import type { ClassValue } from 'clsx';
 import { provideBrnInputOtp } from './brn-input-otp.token';
@@ -30,7 +29,6 @@ export type InputMode = 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal'
 
 @Component({
 	selector: 'brn-input-otp',
-	imports: [FormsModule],
 	providers: [BRN_INPUT_OTP_VALUE_ACCESSOR, provideBrnInputOtp(BrnInputOtp)],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
@@ -42,14 +40,14 @@ export type InputMode = 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal'
 		<div [style]="containerStyles()">
 			<input
 				#otpInput
+				data-slot="input-otp"
 				[id]="inputId()"
 				[class]="inputClass()"
 				[autocomplete]="inputAutocomplete()"
-				data-slot="input-otp"
 				[style]="inputStyles()"
 				[disabled]="_disabled()"
 				[inputMode]="inputMode()"
-				[ngModel]="value()"
+				[value]="_value() ?? ''"
 				(input)="onInputChange($event)"
 				(paste)="onPaste($event)"
 				(focus)="_focused.set(true)"
@@ -111,13 +109,16 @@ export class BrnInputOtp implements ControlValueAccessor {
 	public readonly transformPaste = input<(pastedText: string, maxLength: number) => string>((text) => text);
 
 	/** The value controlling the input */
-	public readonly value = model<string | null>(null);
+	public readonly value = input<string | null>(null);
 
 	/** Emits when the value changes. */
 	public readonly valueChange = output<string>();
 
+	/** Internal writable mirror of the {@link value} input, updated via user interaction and {@link writeValue}. */
+	protected readonly _value = linkedSignal(this.value);
+
 	public readonly context = computed(() => {
-		const value = this.value() ?? '';
+		const value = this._value() ?? '';
 		const focused = this._focused();
 		const maxLength = this.maxLength();
 		const slots = Array.from({ length: this.maxLength() }).map((_, slotIndex) => {
@@ -178,7 +179,7 @@ export class BrnInputOtp implements ControlValueAccessor {
 
 	/** CONTROL VALUE ACCESSOR */
 	writeValue(value: string | null): void {
-		this.value.set(value);
+		this._value.set(value);
 		if (value?.length === this.maxLength()) {
 			this.completed.emit(value ?? '');
 		}
@@ -201,9 +202,10 @@ export class BrnInputOtp implements ControlValueAccessor {
 	}
 
 	private updateValue(newValue: string, maxLength: number) {
-		const previousValue = this.value() ?? '';
+		const previousValue = this._value() ?? '';
 
-		this.value.set(newValue);
+		this._value.set(newValue);
+		this.valueChange.emit(newValue);
 		this._onChange?.(newValue);
 
 		if (this.isCompleted(newValue, previousValue, maxLength)) {

--- a/libs/brain/radio-group/src/lib/brn-radio-group.ts
+++ b/libs/brain/radio-group/src/lib/brn-radio-group.ts
@@ -10,7 +10,6 @@ import {
 	inject,
 	input,
 	linkedSignal,
-	model,
 	output,
 } from '@angular/core';
 import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -54,10 +53,16 @@ export class BrnRadioGroup<T = unknown> implements ControlValueAccessor {
 	/**
 	 * The value of the selected radio button.
 	 */
-	public readonly value = model<T>();
+	public readonly value = input<T>();
 
 	/** Emits when the value changes. */
 	public readonly valueChange = output<T>();
+
+	/** Internal writable mirror of the {@link value} input, updated via {@link writeValue} and {@link select}. */
+	protected readonly _value = linkedSignal(this.value);
+
+	/** Read-only signal of the currently selected value. */
+	public readonly selectedValue = this._value.asReadonly();
 
 	/**
 	 * Whether the radio group is disabled.
@@ -102,7 +107,7 @@ export class BrnRadioGroup<T = unknown> implements ControlValueAccessor {
 	public readonly radioButtons = contentChildren(BrnRadio, { descendants: true });
 
 	writeValue(value: T): void {
-		this.value.set(value);
+		this._value.set(value);
 	}
 
 	registerOnChange(fn: ChangeFn<T>): void {
@@ -122,11 +127,11 @@ export class BrnRadioGroup<T = unknown> implements ControlValueAccessor {
 	 * @internal
 	 */
 	select(radioButton: BrnRadio<T>, value: T): void {
-		if (this.value() === value) {
+		if (this._value() === value) {
 			return;
 		}
 
-		this.value.set(value);
+		this._value.set(value);
 		this.valueChange.emit(value);
 		this.onChange(value);
 		this.change.emit(new BrnRadioChange<T>(radioButton, value));

--- a/libs/brain/radio-group/src/lib/brn-radio-group.ts
+++ b/libs/brain/radio-group/src/lib/brn-radio-group.ts
@@ -53,16 +53,11 @@ export class BrnRadioGroup<T = unknown> implements ControlValueAccessor {
 	/**
 	 * The value of the selected radio button.
 	 */
-	public readonly value = input<T>();
+	public readonly valueInput = input<T>(undefined, { alias: 'value' });
+	public readonly value = linkedSignal(this.valueInput);
 
 	/** Emits when the value changes. */
 	public readonly valueChange = output<T>();
-
-	/** Internal writable mirror of the {@link value} input, updated via {@link writeValue} and {@link select}. */
-	protected readonly _value = linkedSignal(this.value);
-
-	/** Read-only signal of the currently selected value. */
-	public readonly selectedValue = this._value.asReadonly();
 
 	/**
 	 * Whether the radio group is disabled.
@@ -107,7 +102,7 @@ export class BrnRadioGroup<T = unknown> implements ControlValueAccessor {
 	public readonly radioButtons = contentChildren(BrnRadio, { descendants: true });
 
 	writeValue(value: T): void {
-		this._value.set(value);
+		this.value.set(value);
 	}
 
 	registerOnChange(fn: ChangeFn<T>): void {
@@ -127,11 +122,11 @@ export class BrnRadioGroup<T = unknown> implements ControlValueAccessor {
 	 * @internal
 	 */
 	select(radioButton: BrnRadio<T>, value: T): void {
-		if (this._value() === value) {
+		if (this.value() === value) {
 			return;
 		}
 
-		this._value.set(value);
+		this.value.set(value);
 		this.valueChange.emit(value);
 		this.onChange(value);
 		this.change.emit(new BrnRadioChange<T>(radioButton, value));

--- a/libs/brain/radio-group/src/lib/brn-radio.ts
+++ b/libs/brain/radio-group/src/lib/brn-radio.ts
@@ -92,12 +92,12 @@ export class BrnRadio<T = unknown> implements OnDestroy {
 	/**
 	 * Whether the radio button is checked.
 	 */
-	protected readonly _checked = computed(() => this._radioGroup.selectedValue() === this.value());
+	protected readonly _checked = computed(() => this._radioGroup.value() === this.value());
 
 	protected readonly _tabIndex = computed(() => {
 		const disabled = this._disabledState();
 		const checked = this._checked();
-		const hasSelectedRadio = this._radioGroup.selectedValue() !== undefined;
+		const hasSelectedRadio = this._radioGroup.value() !== undefined;
 		const isFirstRadio = this._radioGroup.radioButtons()[0] === this;
 
 		if (disabled || (!checked && (hasSelectedRadio || !isFirstRadio))) {

--- a/libs/brain/radio-group/src/lib/brn-radio.ts
+++ b/libs/brain/radio-group/src/lib/brn-radio.ts
@@ -92,12 +92,12 @@ export class BrnRadio<T = unknown> implements OnDestroy {
 	/**
 	 * Whether the radio button is checked.
 	 */
-	protected readonly _checked = computed(() => this._radioGroup.value() === this.value());
+	protected readonly _checked = computed(() => this._radioGroup.selectedValue() === this.value());
 
 	protected readonly _tabIndex = computed(() => {
 		const disabled = this._disabledState();
 		const checked = this._checked();
-		const hasSelectedRadio = this._radioGroup.value() !== undefined;
+		const hasSelectedRadio = this._radioGroup.selectedValue() !== undefined;
 		const isFirstRadio = this._radioGroup.radioButtons()[0] === this;
 
 		if (disabled || (!checked && (hasSelectedRadio || !isFirstRadio))) {

--- a/libs/brain/slider/src/lib/brn-slider.ts
+++ b/libs/brain/slider/src/lib/brn-slider.ts
@@ -77,10 +77,8 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 	 * For single-thumb sliders, this contains one value.
 	 * For range sliders, values are kept sorted in ascending order.
 	 */
-	public readonly value = input<number[]>([]);
-
-	/** Internal writable mirror of the {@link value} input, updated via user interaction and {@link writeValue}. */
-	protected readonly _value = linkedSignal(this.value);
+	public readonly valueInput = input<number[]>([], { alias: 'value' });
+	public readonly value = linkedSignal(this.valueInput);
 
 	/** Minimum allowed slider value. */
 	public readonly min = input<number, NumberInput>(0, {
@@ -148,7 +146,7 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 
 	/** @internal Normalized slider values. Values are clamped to `[min, max]` and sorted in ascending order. */
 	public readonly normalizedValue = computed(
-		() => [...this._value()].sort((a, b) => a - b).map((v) => clamp(v, [this.min(), this.max()])),
+		() => [...this.value()].sort((a, b) => a - b).map((v) => clamp(v, [this.min(), this.max()])),
 		{ equal: areArrsEqual },
 	);
 
@@ -237,17 +235,17 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 		// If bound to an Angular form control, writeValue() will run after ngOnInit,
 		// so avoid initializing defaults here to prevent a transient min-value override.
 		if (!this.ngControl) {
-			if (!this._value().length) {
+			if (!this.value().length) {
 				const defaultValue = [this.min()];
-				this._value.set(defaultValue);
+				this.value.set(defaultValue);
 			}
 
-			const normalizedValue = this._value()
+			const normalizedValue = this.value()
 				.map((v) => clamp(v, [this.min(), this.max()]))
 				.sort((a, b) => a - b);
 
-			if (!areArrsEqual(normalizedValue, this._value())) {
-				this._value.set(normalizedValue);
+			if (!areArrsEqual(normalizedValue, this.value())) {
+				this.value.set(normalizedValue);
 			}
 		}
 	}
@@ -274,7 +272,7 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 		}
 
 		const newValue = [...value].sort((a, b) => a - b).map((v) => clamp(v, [this.min(), this.max()]));
-		this._value.set(newValue);
+		this.value.set(newValue);
 	}
 
 	/** Sets a new value for the slider at the given thumb index. */
@@ -296,9 +294,9 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 		const newValIndex = newValue.findIndex((val) => val === value);
 		this.valueIndexToChange.set(newValIndex);
 
-		if (areArrsEqual(newValue, this._value())) return;
+		if (areArrsEqual(newValue, this.value())) return;
 
-		this._value.set(newValue);
+		this.value.set(newValue);
 		this._onChange?.(newValue);
 		this.valueChange.emit(newValue);
 
@@ -335,9 +333,9 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 
 		next = next.map((v) => roundValue(v, decimalCount));
 
-		if (areArrsEqual(next, this._value())) return;
+		if (areArrsEqual(next, this.value())) return;
 
-		this._value.set(next);
+		this.value.set(next);
 		this._onChange?.(next);
 		this.valueChange.emit(next);
 	}

--- a/libs/brain/slider/src/lib/brn-slider.ts
+++ b/libs/brain/slider/src/lib/brn-slider.ts
@@ -9,7 +9,6 @@ import {
 	Injector,
 	input,
 	linkedSignal,
-	model,
 	numberAttribute,
 	type OnInit,
 	output,
@@ -78,7 +77,10 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 	 * For single-thumb sliders, this contains one value.
 	 * For range sliders, values are kept sorted in ascending order.
 	 */
-	public readonly value = model<number[]>([]);
+	public readonly value = input<number[]>([]);
+
+	/** Internal writable mirror of the {@link value} input, updated via user interaction and {@link writeValue}. */
+	protected readonly _value = linkedSignal(this.value);
 
 	/** Minimum allowed slider value. */
 	public readonly min = input<number, NumberInput>(0, {
@@ -146,7 +148,7 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 
 	/** @internal Normalized slider values. Values are clamped to `[min, max]` and sorted in ascending order. */
 	public readonly normalizedValue = computed(
-		() => [...this.value()].sort((a, b) => a - b).map((v) => clamp(v, [this.min(), this.max()])),
+		() => [...this._value()].sort((a, b) => a - b).map((v) => clamp(v, [this.min(), this.max()])),
 		{ equal: areArrsEqual },
 	);
 
@@ -235,17 +237,17 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 		// If bound to an Angular form control, writeValue() will run after ngOnInit,
 		// so avoid initializing defaults here to prevent a transient min-value override.
 		if (!this.ngControl) {
-			if (!this.value().length) {
+			if (!this._value().length) {
 				const defaultValue = [this.min()];
-				this.value.set(defaultValue);
+				this._value.set(defaultValue);
 			}
 
-			const normalizedValue = this.value()
+			const normalizedValue = this._value()
 				.map((v) => clamp(v, [this.min(), this.max()]))
 				.sort((a, b) => a - b);
 
-			if (!areArrsEqual(normalizedValue, this.value())) {
-				this.value.set(normalizedValue);
+			if (!areArrsEqual(normalizedValue, this._value())) {
+				this._value.set(normalizedValue);
 			}
 		}
 	}
@@ -272,7 +274,7 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 		}
 
 		const newValue = [...value].sort((a, b) => a - b).map((v) => clamp(v, [this.min(), this.max()]));
-		this.value.set(newValue);
+		this._value.set(newValue);
 	}
 
 	/** Sets a new value for the slider at the given thumb index. */
@@ -294,9 +296,9 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 		const newValIndex = newValue.findIndex((val) => val === value);
 		this.valueIndexToChange.set(newValIndex);
 
-		if (areArrsEqual(newValue, this.value())) return;
+		if (areArrsEqual(newValue, this._value())) return;
 
-		this.value.set(newValue);
+		this._value.set(newValue);
 		this._onChange?.(newValue);
 		this.valueChange.emit(newValue);
 
@@ -333,9 +335,9 @@ export class BrnSlider implements ControlValueAccessor, OnInit {
 
 		next = next.map((v) => roundValue(v, decimalCount));
 
-		if (areArrsEqual(next, this.value())) return;
+		if (areArrsEqual(next, this._value())) return;
 
-		this.value.set(next);
+		this._value.set(next);
 		this._onChange?.(next);
 		this.valueChange.emit(next);
 	}

--- a/libs/brain/switch/src/lib/brn-switch.ts
+++ b/libs/brain/switch/src/lib/brn-switch.ts
@@ -57,7 +57,7 @@ let uniqueIdCounter = 0;
 		'[attr.data-dirty]': '_dirty?.() ? "true": null',
 		'[attr.data-touched]': '_touched?.() ? "true" : null',
 		'[attr.data-matches-spartan-invalid]': '_spartanInvalid?.() ? "true" : null',
-		'[attr.data-state]': '_checked() ? "checked" : "unchecked"',
+		'[attr.data-state]': 'checked() ? "checked" : "unchecked"',
 		'[attr.data-focus-visible]': '_focusVisible()',
 		'[attr.data-focus]': '_focused()',
 		'[attr.data-disabled]': '_state().disabled()',
@@ -71,8 +71,8 @@ let uniqueIdCounter = 0;
 			[class]="class()"
 			[id]="getSwitchButtonId(_state().id) ?? ''"
 			[name]="getSwitchButtonId(_state().name) ?? ''"
-			[value]="_checked() ? 'on' : 'off'"
-			[attr.aria-checked]="_checked()"
+			[value]="checked() ? 'on' : 'off'"
+			[attr.aria-checked]="checked()"
 			[attr.aria-label]="ariaLabel() || null"
 			[attr.aria-labelledby]="mutableAriaLabelledby() || null"
 			[attr.aria-describedby]="ariaDescribedby() || null"
@@ -80,7 +80,7 @@ let uniqueIdCounter = 0;
 			[attr.data-dirty]="_dirty?.() ? 'true' : null"
 			[attr.data-touched]="_touched?.() ? 'true' : null"
 			[attr.data-matches-spartan-invalid]="_spartanInvalid?.() ? 'true' : null"
-			[attr.data-state]="_checked() ? 'checked' : 'unchecked'"
+			[attr.data-state]="checked() ? 'checked' : 'unchecked'"
 			[attr.data-focus-visible]="_focusVisible()"
 			[attr.data-focus]="_focused()"
 			[attr.data-disabled]="_state().disabled()"
@@ -109,13 +109,11 @@ export class BrnSwitch implements AfterContentInit, OnDestroy, ControlValueAcces
 	 * Whether switch is checked/toggled on.
 	 * Can be bound with [(checked)] for two-way binding.
 	 */
-	public readonly checked = input<boolean>(false);
+	public readonly checkedInput = input<boolean, BooleanInput>(false, { alias: 'checked', transform: booleanAttribute });
+	public readonly checked = linkedSignal(this.checkedInput);
 
 	/** Emits when checked state changes. */
 	public readonly checkedChange = output<boolean>();
-
-	/** Internal writable mirror of the {@link checked} input, updated via {@link toggle} and {@link writeValue}. */
-	protected readonly _checked = linkedSignal(this.checked);
 
 	/**
 	 * Unique identifier for switch component.
@@ -246,9 +244,9 @@ export class BrnSwitch implements AfterContentInit, OnDestroy, ControlValueAcces
 		this._onTouched();
 		this.touched.emit();
 
-		this._checked.update((checked) => !checked);
-		this._onChange(this._checked());
-		this.checkedChange.emit(this._checked());
+		this.checked.update((checked) => !checked);
+		this._onChange(this.checked());
+		this.checkedChange.emit(this.checked());
 	}
 
 	public ngAfterContentInit(): void {
@@ -278,7 +276,7 @@ export class BrnSwitch implements AfterContentInit, OnDestroy, ControlValueAcces
 			});
 
 		if (!this.switch()) return;
-		this.switch().nativeElement.value = this._checked() ? 'on' : 'off';
+		this.switch().nativeElement.value = this.checked() ? 'on' : 'off';
 		this.switch().nativeElement.dispatchEvent(new Event('change'));
 	}
 
@@ -304,7 +302,7 @@ export class BrnSwitch implements AfterContentInit, OnDestroy, ControlValueAcces
 	 * @param value - New checked state
 	 */
 	public writeValue(value: boolean): void {
-		this._checked.set(Boolean(value));
+		this.checked.set(Boolean(value));
 	}
 
 	/**

--- a/libs/brain/switch/src/lib/brn-switch.ts
+++ b/libs/brain/switch/src/lib/brn-switch.ts
@@ -16,7 +16,6 @@ import {
 	inject,
 	input,
 	linkedSignal,
-	model,
 	numberAttribute,
 	type OnDestroy,
 	output,
@@ -58,7 +57,7 @@ let uniqueIdCounter = 0;
 		'[attr.data-dirty]': '_dirty?.() ? "true": null',
 		'[attr.data-touched]': '_touched?.() ? "true" : null',
 		'[attr.data-matches-spartan-invalid]': '_spartanInvalid?.() ? "true" : null',
-		'[attr.data-state]': 'checked() ? "checked" : "unchecked"',
+		'[attr.data-state]': '_checked() ? "checked" : "unchecked"',
 		'[attr.data-focus-visible]': '_focusVisible()',
 		'[attr.data-focus]': '_focused()',
 		'[attr.data-disabled]': '_state().disabled()',
@@ -72,8 +71,8 @@ let uniqueIdCounter = 0;
 			[class]="class()"
 			[id]="getSwitchButtonId(_state().id) ?? ''"
 			[name]="getSwitchButtonId(_state().name) ?? ''"
-			[value]="checked() ? 'on' : 'off'"
-			[attr.aria-checked]="checked()"
+			[value]="_checked() ? 'on' : 'off'"
+			[attr.aria-checked]="_checked()"
 			[attr.aria-label]="ariaLabel() || null"
 			[attr.aria-labelledby]="mutableAriaLabelledby() || null"
 			[attr.aria-describedby]="ariaDescribedby() || null"
@@ -81,7 +80,7 @@ let uniqueIdCounter = 0;
 			[attr.data-dirty]="_dirty?.() ? 'true' : null"
 			[attr.data-touched]="_touched?.() ? 'true' : null"
 			[attr.data-matches-spartan-invalid]="_spartanInvalid?.() ? 'true' : null"
-			[attr.data-state]="checked() ? 'checked' : 'unchecked'"
+			[attr.data-state]="_checked() ? 'checked' : 'unchecked'"
 			[attr.data-focus-visible]="_focusVisible()"
 			[attr.data-focus]="_focused()"
 			[attr.data-disabled]="_state().disabled()"
@@ -110,10 +109,13 @@ export class BrnSwitch implements AfterContentInit, OnDestroy, ControlValueAcces
 	 * Whether switch is checked/toggled on.
 	 * Can be bound with [(checked)] for two-way binding.
 	 */
-	public readonly checked = model<boolean>(false);
+	public readonly checked = input<boolean>(false);
 
 	/** Emits when checked state changes. */
 	public readonly checkedChange = output<boolean>();
+
+	/** Internal writable mirror of the {@link checked} input, updated via {@link toggle} and {@link writeValue}. */
+	protected readonly _checked = linkedSignal(this.checked);
 
 	/**
 	 * Unique identifier for switch component.
@@ -244,9 +246,9 @@ export class BrnSwitch implements AfterContentInit, OnDestroy, ControlValueAcces
 		this._onTouched();
 		this.touched.emit();
 
-		this.checked.update((checked) => !checked);
-		this._onChange(this.checked());
-		this.checkedChange.emit(this.checked());
+		this._checked.update((checked) => !checked);
+		this._onChange(this._checked());
+		this.checkedChange.emit(this._checked());
 	}
 
 	public ngAfterContentInit(): void {
@@ -276,7 +278,7 @@ export class BrnSwitch implements AfterContentInit, OnDestroy, ControlValueAcces
 			});
 
 		if (!this.switch()) return;
-		this.switch().nativeElement.value = this.checked() ? 'on' : 'off';
+		this.switch().nativeElement.value = this._checked() ? 'on' : 'off';
 		this.switch().nativeElement.dispatchEvent(new Event('change'));
 	}
 
@@ -302,7 +304,7 @@ export class BrnSwitch implements AfterContentInit, OnDestroy, ControlValueAcces
 	 * @param value - New checked state
 	 */
 	public writeValue(value: boolean): void {
-		this.checked.set(Boolean(value));
+		this._checked.set(Boolean(value));
 	}
 
 	/**

--- a/libs/brain/toggle-group/src/lib/brn-toggle-group.ts
+++ b/libs/brain/toggle-group/src/lib/brn-toggle-group.ts
@@ -1,5 +1,5 @@
 import type { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, computed, Directive, forwardRef, input, linkedSignal, model, output } from '@angular/core';
+import { booleanAttribute, computed, Directive, forwardRef, input, linkedSignal, output } from '@angular/core';
 import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { provideBrnToggleGroup } from './brn-toggle-group.token';
 import type { BrnToggleGroupItem } from './brn-toggle-item';
@@ -36,10 +36,13 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 	protected readonly _multiple = computed(() => this.type() === 'multiple');
 
 	/** Value of the toggle group. */
-	public readonly value = model<ToggleValue<T>>(undefined);
+	public readonly value = input<ToggleValue<T>>(undefined);
 
 	/** Emits when the value changes. */
 	public readonly valueChange = output<ToggleValue<T>>();
+
+	/** Internal writable mirror of the {@link value} input, updated via {@link writeValue} and selection changes. */
+	protected readonly _value = linkedSignal(this.value);
 
 	/** Whether no button toggles need to be selected. */
 	public readonly nullable = input<boolean, BooleanInput>(true, {
@@ -68,7 +71,7 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 	protected onTouched: () => void = () => {};
 
 	writeValue(value: ToggleValue<T>): void {
-		this.value.set(value);
+		this._value.set(value);
 	}
 
 	registerOnChange(fn: (value: ToggleValue<T>) => void) {
@@ -91,7 +94,7 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 		// if null values are allowed, the group can always be nullable
 		if (this.nullable()) return true;
 
-		const currentValue = this.value();
+		const currentValue = this._value();
 
 		if (this._multiple() && Array.isArray(currentValue)) {
 			return !(currentValue.length === 1 && currentValue[0] === value);
@@ -109,7 +112,7 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 			return;
 		}
 
-		const currentValue = this.value();
+		const currentValue = this._value();
 
 		// emit the valueChange event here as we should only emit based on user interaction
 		if (this._multiple()) {
@@ -118,8 +121,8 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 			this.emitSelectionChange(value, source);
 		}
 
-		this._onChange(this.value());
-		this.change.emit(new BrnButtonToggleChange<T>(source, this.value()));
+		this._onChange(this._value());
+		this.change.emit(new BrnButtonToggleChange<T>(source, this._value()));
 	}
 
 	/**
@@ -131,7 +134,7 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 			return;
 		}
 
-		const currentValue = this.value();
+		const currentValue = this._value();
 
 		if (this._multiple()) {
 			this.emitSelectionChange(
@@ -148,7 +151,7 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 	 * Determines whether a value is selected.
 	 */
 	isSelected(value: T): boolean {
-		const currentValue = this.value();
+		const currentValue = this._value();
 
 		if (
 			currentValue == null ||
@@ -166,10 +169,10 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 
 	/** Update the value of the group */
 	private emitSelectionChange(value: ToggleValue<T>, source: BrnToggleGroupItem<T>): void {
-		this.value.set(value);
+		this._value.set(value);
 		this.valueChange.emit(value);
 		this._onChange(value);
-		this.change.emit(new BrnButtonToggleChange<T>(source, this.value()));
+		this.change.emit(new BrnButtonToggleChange<T>(source, this._value()));
 	}
 }
 

--- a/libs/brain/toggle-group/src/lib/brn-toggle-group.ts
+++ b/libs/brain/toggle-group/src/lib/brn-toggle-group.ts
@@ -120,9 +120,6 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 		} else {
 			this.emitSelectionChange(value, source);
 		}
-
-		this._onChange(this._value());
-		this.change.emit(new BrnButtonToggleChange<T>(source, this._value()));
 	}
 
 	/**

--- a/libs/brain/toggle-group/src/lib/brn-toggle-group.ts
+++ b/libs/brain/toggle-group/src/lib/brn-toggle-group.ts
@@ -36,13 +36,11 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 	protected readonly _multiple = computed(() => this.type() === 'multiple');
 
 	/** Value of the toggle group. */
-	public readonly value = input<ToggleValue<T>>(undefined);
+	public readonly valueInput = input<ToggleValue<T>>(undefined, { alias: 'value' });
+	public readonly value = linkedSignal(this.valueInput);
 
 	/** Emits when the value changes. */
 	public readonly valueChange = output<ToggleValue<T>>();
-
-	/** Internal writable mirror of the {@link value} input, updated via {@link writeValue} and selection changes. */
-	protected readonly _value = linkedSignal(this.value);
 
 	/** Whether no button toggles need to be selected. */
 	public readonly nullable = input<boolean, BooleanInput>(true, {
@@ -71,7 +69,7 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 	protected onTouched: () => void = () => {};
 
 	writeValue(value: ToggleValue<T>): void {
-		this._value.set(value);
+		this.value.set(value);
 	}
 
 	registerOnChange(fn: (value: ToggleValue<T>) => void) {
@@ -94,7 +92,7 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 		// if null values are allowed, the group can always be nullable
 		if (this.nullable()) return true;
 
-		const currentValue = this._value();
+		const currentValue = this.value();
 
 		if (this._multiple() && Array.isArray(currentValue)) {
 			return !(currentValue.length === 1 && currentValue[0] === value);
@@ -112,7 +110,7 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 			return;
 		}
 
-		const currentValue = this._value();
+		const currentValue = this.value();
 
 		// emit the valueChange event here as we should only emit based on user interaction
 		if (this._multiple()) {
@@ -131,7 +129,7 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 			return;
 		}
 
-		const currentValue = this._value();
+		const currentValue = this.value();
 
 		if (this._multiple()) {
 			this.emitSelectionChange(
@@ -148,7 +146,7 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 	 * Determines whether a value is selected.
 	 */
 	isSelected(value: T): boolean {
-		const currentValue = this._value();
+		const currentValue = this.value();
 
 		if (
 			currentValue == null ||
@@ -166,10 +164,10 @@ export class BrnToggleGroup<T = unknown> implements ControlValueAccessor {
 
 	/** Update the value of the group */
 	private emitSelectionChange(value: ToggleValue<T>, source: BrnToggleGroupItem<T>): void {
-		this._value.set(value);
+		this.value.set(value);
 		this.valueChange.emit(value);
 		this._onChange(value);
-		this.change.emit(new BrnButtonToggleChange<T>(source, this._value()));
+		this.change.emit(new BrnButtonToggleChange<T>(source, this.value()));
 	}
 }
 

--- a/libs/helm/checkbox/src/lib/hlm-checkbox.ts
+++ b/libs/helm/checkbox/src/lib/hlm-checkbox.ts
@@ -46,7 +46,7 @@ export const HLM_CHECKBOX_VALUE_ACCESSOR = {
 			[id]="inputId()"
 			[name]="name()"
 			[class]="_computedClass()"
-			[checked]="_checked()"
+			[checked]="checked()"
 			[(indeterminate)]="indeterminate"
 			[disabled]="_disabled()"
 			[required]="required()"
@@ -57,7 +57,7 @@ export const HLM_CHECKBOX_VALUE_ACCESSOR = {
 			(checkedChange)="_handleChange($event)"
 			(touched)="_onTouched?.()"
 		>
-			@if (_checked() || indeterminate()) {
+			@if (checked() || indeterminate()) {
 				<span class="flex items-center justify-center text-current transition-none">
 					<ng-icon hlm size="14px" name="lucideCheck" />
 				</span>
@@ -90,13 +90,11 @@ export class HlmCheckbox implements ControlValueAccessor {
 	public readonly ariaDescribedby = input<string | null>(null, { alias: 'aria-describedby' });
 
 	/** The checked state of the checkbox. */
-	public readonly checked = input<boolean>(false);
+	public readonly checkedInput = input<boolean, BooleanInput>(false, { alias: 'checked', transform: booleanAttribute });
+	public readonly checked = linkedSignal(this.checkedInput);
 
 	/** Emits when checked state changes. */
 	public readonly checkedChange = output<boolean>();
-
-	/** Internal writable mirror of the {@link checked} input, updated via user interaction and {@link writeValue}. */
-	protected readonly _checked = linkedSignal(this.checked);
 
 	/**
 	 * The indeterminate state of the checkbox.
@@ -132,14 +130,14 @@ export class HlmCheckbox implements ControlValueAccessor {
 
 	protected _handleChange(value: boolean): void {
 		if (this._disabled()) return;
-		this._checked.set(value);
+		this.checked.set(value);
 		this.checkedChange.emit(value);
 		this._onChange?.(value);
 	}
 
 	/** CONTROL VALUE ACCESSOR */
 	writeValue(value: boolean): void {
-		this._checked.set(value);
+		this.checked.set(value);
 	}
 
 	registerOnChange(fn: ChangeFn<boolean>): void {

--- a/libs/helm/checkbox/src/lib/hlm-checkbox.ts
+++ b/libs/helm/checkbox/src/lib/hlm-checkbox.ts
@@ -46,7 +46,7 @@ export const HLM_CHECKBOX_VALUE_ACCESSOR = {
 			[id]="inputId()"
 			[name]="name()"
 			[class]="_computedClass()"
-			[checked]="checked()"
+			[checked]="_checked()"
 			[(indeterminate)]="indeterminate"
 			[disabled]="_disabled()"
 			[required]="required()"
@@ -57,7 +57,7 @@ export const HLM_CHECKBOX_VALUE_ACCESSOR = {
 			(checkedChange)="_handleChange($event)"
 			(touched)="_onTouched?.()"
 		>
-			@if (checked() || indeterminate()) {
+			@if (_checked() || indeterminate()) {
 				<span class="flex items-center justify-center text-current transition-none">
 					<ng-icon hlm size="14px" name="lucideCheck" />
 				</span>
@@ -90,10 +90,13 @@ export class HlmCheckbox implements ControlValueAccessor {
 	public readonly ariaDescribedby = input<string | null>(null, { alias: 'aria-describedby' });
 
 	/** The checked state of the checkbox. */
-	public readonly checked = model<boolean>(false);
+	public readonly checked = input<boolean>(false);
 
 	/** Emits when checked state changes. */
 	public readonly checkedChange = output<boolean>();
+
+	/** Internal writable mirror of the {@link checked} input, updated via user interaction and {@link writeValue}. */
+	protected readonly _checked = linkedSignal(this.checked);
 
 	/**
 	 * The indeterminate state of the checkbox.
@@ -129,14 +132,14 @@ export class HlmCheckbox implements ControlValueAccessor {
 
 	protected _handleChange(value: boolean): void {
 		if (this._disabled()) return;
-		this.checked.set(value);
+		this._checked.set(value);
 		this.checkedChange.emit(value);
 		this._onChange?.(value);
 	}
 
 	/** CONTROL VALUE ACCESSOR */
 	writeValue(value: boolean): void {
-		this.checked.set(value);
+		this._checked.set(value);
 	}
 
 	registerOnChange(fn: ChangeFn<boolean>): void {

--- a/libs/helm/native-select/src/lib/hlm-native-select.ts
+++ b/libs/helm/native-select/src/lib/hlm-native-select.ts
@@ -8,7 +8,6 @@ import {
 	inject,
 	input,
 	linkedSignal,
-	model,
 	output,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, type ControlValueAccessor } from '@angular/forms';
@@ -50,7 +49,7 @@ export const HLM_NATIVE_SELECT_VALUE_ACCESSOR = {
 			[attr.data-dirty]="_dirty?.() ? 'true' : null"
 			[attr.data-touched]="_touched?.() ? 'true' : null"
 			[attr.data-matches-spartan-invalid]="_spartanInvalid() ? 'true' : null"
-			[value]="value()"
+			[value]="_value()"
 			[disabled]="_disabled()"
 			(change)="_valueChanged($event)"
 			(blur)="_blur()"
@@ -105,11 +104,13 @@ export class HlmNativeSelect implements ControlValueAccessor {
 
 	protected readonly _ariaInvalid = computed(() => this.ariaInvalidOverride() ?? this._invalid?.());
 
-	public readonly value = model<string | null>('');
+	public readonly value = input<string | undefined | null>('');
 
-	public readonly valueChange = output<string | null>();
+	public readonly valueChange = output<string | undefined | null>();
 
-	protected _onChange?: ChangeFn<string | null>;
+	protected readonly _value = linkedSignal(this.value);
+
+	protected _onChange?: ChangeFn<string | undefined | null>;
 	protected _onTouched?: TouchFn;
 
 	public readonly labelableId = this.selectId;
@@ -125,7 +126,7 @@ export class HlmNativeSelect implements ControlValueAccessor {
 
 	protected _valueChanged(event: Event): void {
 		const value = (event.target as HTMLSelectElement).value;
-		this.value.set(value);
+		this._value.set(value);
 		this.valueChange.emit(value);
 		this._onChange?.(value);
 		this._onTouched?.();
@@ -136,11 +137,11 @@ export class HlmNativeSelect implements ControlValueAccessor {
 	}
 
 	/** CONTROL VALUE ACCESSOR */
-	public writeValue(value: string | null): void {
-		this.value.set(value);
+	public writeValue(value: string | undefined | null): void {
+		this._value.set(value);
 	}
 
-	public registerOnChange(fn: ChangeFn<string | null>): void {
+	public registerOnChange(fn: ChangeFn<string | undefined | null>): void {
 		this._onChange = fn;
 	}
 

--- a/libs/helm/native-select/src/lib/hlm-native-select.ts
+++ b/libs/helm/native-select/src/lib/hlm-native-select.ts
@@ -49,7 +49,7 @@ export const HLM_NATIVE_SELECT_VALUE_ACCESSOR = {
 			[attr.data-dirty]="_dirty?.() ? 'true' : null"
 			[attr.data-touched]="_touched?.() ? 'true' : null"
 			[attr.data-matches-spartan-invalid]="_spartanInvalid() ? 'true' : null"
-			[value]="_value()"
+			[value]="value()"
 			[disabled]="_disabled()"
 			(change)="_valueChanged($event)"
 			(blur)="_blur()"
@@ -104,11 +104,10 @@ export class HlmNativeSelect implements ControlValueAccessor {
 
 	protected readonly _ariaInvalid = computed(() => this.ariaInvalidOverride() ?? this._invalid?.());
 
-	public readonly value = input<string | undefined | null>('');
+	public readonly valueInput = input<string | undefined | null>('', { alias: 'value' });
+	public readonly value = linkedSignal(this.valueInput);
 
 	public readonly valueChange = output<string | undefined | null>();
-
-	protected readonly _value = linkedSignal(this.value);
 
 	protected _onChange?: ChangeFn<string | undefined | null>;
 	protected _onTouched?: TouchFn;
@@ -126,7 +125,7 @@ export class HlmNativeSelect implements ControlValueAccessor {
 
 	protected _valueChanged(event: Event): void {
 		const value = (event.target as HTMLSelectElement).value;
-		this._value.set(value);
+		this.value.set(value);
 		this.valueChange.emit(value);
 		this._onChange?.(value);
 		this._onTouched?.();
@@ -138,7 +137,7 @@ export class HlmNativeSelect implements ControlValueAccessor {
 
 	/** CONTROL VALUE ACCESSOR */
 	public writeValue(value: string | undefined | null): void {
-		this._value.set(value);
+		this.value.set(value);
 	}
 
 	public registerOnChange(fn: ChangeFn<string | undefined | null>): void {

--- a/libs/helm/pagination/src/lib/hlm-numbered-pagination-query-params.ts
+++ b/libs/helm/pagination/src/lib/hlm-numbered-pagination-query-params.ts
@@ -9,7 +9,6 @@ import {
 	numberAttribute,
 	untracked,
 } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 import { HlmSelectImports } from '@spartan-ng/helm/select';
 import { createPageArray, outOfBoundCorrection } from './hlm-numbered-pagination';
 import { HlmPagination } from './hlm-pagination';
@@ -23,7 +22,6 @@ import { HlmPaginationPrevious } from './hlm-pagination-previous';
 @Component({
 	selector: 'hlm-numbered-pagination-query-params',
 	imports: [
-		FormsModule,
 		HlmPagination,
 		HlmPaginationContent,
 		HlmPaginationItem,
@@ -86,7 +84,7 @@ import { HlmPaginationPrevious } from './hlm-pagination-previous';
 			</nav>
 
 			<!-- Show Page Size selector -->
-			<hlm-select [(ngModel)]="itemsPerPage" class="ml-auto">
+			<hlm-select [(value)]="itemsPerPage" class="ml-auto">
 				<hlm-select-trigger class="w-fit">
 					<hlm-select-value />
 				</hlm-select-trigger>

--- a/libs/helm/pagination/src/lib/hlm-numbered-pagination.ts
+++ b/libs/helm/pagination/src/lib/hlm-numbered-pagination.ts
@@ -9,7 +9,6 @@ import {
 	numberAttribute,
 	untracked,
 } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 import { HlmSelectImports } from '@spartan-ng/helm/select';
 import { HlmPagination } from './hlm-pagination';
 import { HlmPaginationContent } from './hlm-pagination-content';
@@ -22,7 +21,6 @@ import { HlmPaginationPrevious } from './hlm-pagination-previous';
 @Component({
 	selector: 'hlm-numbered-pagination',
 	imports: [
-		FormsModule,
 		HlmPagination,
 		HlmPaginationContent,
 		HlmPaginationItem,
@@ -71,7 +69,7 @@ import { HlmPaginationPrevious } from './hlm-pagination-previous';
 			</nav>
 
 			<!-- Show Page Size selector -->
-			<hlm-select [(ngModel)]="itemsPerPage" class="ml-auto">
+			<hlm-select [(value)]="itemsPerPage" class="ml-auto">
 				<hlm-select-trigger class="w-fit">
 					<hlm-select-value />
 				</hlm-select-trigger>

--- a/libs/helm/switch/src/lib/hlm-switch.ts
+++ b/libs/helm/switch/src/lib/hlm-switch.ts
@@ -7,7 +7,6 @@ import {
 	forwardRef,
 	input,
 	linkedSignal,
-	model,
 	output,
 } from '@angular/core';
 import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -38,7 +37,7 @@ export const HLM_SWITCH_VALUE_ACCESSOR = {
 		<brn-switch
 			[class]="_computedClass()"
 			[size]="size()"
-			[checked]="checked()"
+			[checked]="_checked()"
 			(checkedChange)="handleChange($event)"
 			(touched)="_onTouched?.()"
 			[disabled]="_disabled()"
@@ -61,10 +60,13 @@ export class HlmSwitch implements ControlValueAccessor {
 	);
 
 	/** The checked state of the switch. */
-	public readonly checked = model<boolean>(false);
+	public readonly checked = input<boolean>(false);
 
 	/** Emits when the checked state of the switch changes. */
 	public readonly checkedChange = output<boolean>();
+
+	/** Internal writable mirror of the {@link checked} input, updated via user interaction and {@link writeValue}. */
+	protected readonly _checked = linkedSignal(this.checked);
 
 	/** The disabled state of the switch. */
 	public readonly disabled = input<boolean, BooleanInput>(false, {
@@ -92,7 +94,7 @@ export class HlmSwitch implements ControlValueAccessor {
 	protected _onTouched?: TouchFn;
 
 	protected handleChange(value: boolean): void {
-		this.checked.set(value);
+		this._checked.set(value);
 		this._onChange?.(value);
 		this.checkedChange.emit(value);
 	}
@@ -100,7 +102,7 @@ export class HlmSwitch implements ControlValueAccessor {
 	/** CONROL VALUE ACCESSOR */
 
 	writeValue(value: boolean): void {
-		this.checked.set(Boolean(value));
+		this._checked.set(Boolean(value));
 	}
 
 	registerOnChange(fn: ChangeFn<boolean>): void {

--- a/libs/helm/switch/src/lib/hlm-switch.ts
+++ b/libs/helm/switch/src/lib/hlm-switch.ts
@@ -37,7 +37,7 @@ export const HLM_SWITCH_VALUE_ACCESSOR = {
 		<brn-switch
 			[class]="_computedClass()"
 			[size]="size()"
-			[checked]="_checked()"
+			[checked]="checked()"
 			(checkedChange)="handleChange($event)"
 			(touched)="_onTouched?.()"
 			[disabled]="_disabled()"
@@ -60,13 +60,11 @@ export class HlmSwitch implements ControlValueAccessor {
 	);
 
 	/** The checked state of the switch. */
-	public readonly checked = input<boolean>(false);
+	public readonly checkedInput = input<boolean, BooleanInput>(false, { alias: 'checked', transform: booleanAttribute });
+	public readonly checked = linkedSignal(this.checkedInput);
 
 	/** Emits when the checked state of the switch changes. */
 	public readonly checkedChange = output<boolean>();
-
-	/** Internal writable mirror of the {@link checked} input, updated via user interaction and {@link writeValue}. */
-	protected readonly _checked = linkedSignal(this.checked);
 
 	/** The disabled state of the switch. */
 	public readonly disabled = input<boolean, BooleanInput>(false, {
@@ -94,15 +92,14 @@ export class HlmSwitch implements ControlValueAccessor {
 	protected _onTouched?: TouchFn;
 
 	protected handleChange(value: boolean): void {
-		this._checked.set(value);
+		this.checked.set(value);
 		this._onChange?.(value);
 		this.checkedChange.emit(value);
 	}
 
-	/** CONROL VALUE ACCESSOR */
-
+	/** CONTROL VALUE ACCESSOR */
 	writeValue(value: boolean): void {
-		this._checked.set(Boolean(value));
+		this.checked.set(Boolean(value));
 	}
 
 	registerOnChange(fn: ChangeFn<boolean>): void {

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -1345,6 +1345,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
       "BrnCheckbox": {
         "inputs": [
           {
+            "name": "checked",
+            "required": false,
+            "type": "boolean",
+          },
+          {
             "name": "id",
             "required": false,
             "type": "string | null",
@@ -1392,10 +1397,6 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
         ],
         "models": [
           {
-            "name": "checked",
-            "type": "boolean",
-          },
-          {
             "name": "indeterminate",
             "type": "boolean",
           },
@@ -1442,6 +1443,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "string | null",
           },
           {
+            "name": "checked",
+            "required": false,
+            "type": "boolean",
+          },
+          {
             "name": "name",
             "required": false,
             "type": "string | null",
@@ -1463,10 +1469,6 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
           },
         ],
         "models": [
-          {
-            "name": "checked",
-            "type": "boolean",
-          },
           {
             "name": "indeterminate",
             "type": "boolean",
@@ -3369,13 +3371,13 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "required": false,
             "type": "(pastedText: string, maxLength: number) => string",
           },
-        ],
-        "models": [
           {
             "name": "value",
+            "required": false,
             "type": "string | null",
           },
         ],
+        "models": [],
         "outputs": [
           {
             "name": "valueChange",
@@ -3637,17 +3639,17 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "required": false,
             "type": "boolean | undefined",
           },
-        ],
-        "models": [
           {
             "name": "value",
-            "type": "string | null",
+            "required": false,
+            "type": "string | undefined | null",
           },
         ],
+        "models": [],
         "outputs": [
           {
             "name": "valueChange",
-            "type": "string | null",
+            "type": "string | undefined | null",
           },
         ],
         "selector": "hlm-native-select",
@@ -4169,6 +4171,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "string",
           },
           {
+            "name": "value",
+            "required": false,
+            "type": "T",
+          },
+          {
             "name": "disabled",
             "required": false,
             "type": "boolean",
@@ -4179,12 +4186,7 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "boolean",
           },
         ],
-        "models": [
-          {
-            "name": "value",
-            "type": "T",
-          },
-        ],
+        "models": [],
         "outputs": [
           {
             "name": "valueChange",
@@ -5128,6 +5130,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "string | null",
           },
           {
+            "name": "value",
+            "required": false,
+            "type": "number[]",
+          },
+          {
             "name": "min",
             "required": false,
             "type": "number",
@@ -5193,12 +5200,7 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "boolean",
           },
         ],
-        "models": [
-          {
-            "name": "value",
-            "type": "number[]",
-          },
-        ],
+        "models": [],
         "outputs": [
           {
             "name": "valueChange",
@@ -5533,6 +5535,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
       "BrnSwitch": {
         "inputs": [
           {
+            "name": "checked",
+            "required": false,
+            "type": "boolean",
+          },
+          {
             "name": "id",
             "required": false,
             "type": "string | null",
@@ -5583,12 +5590,7 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "number",
           },
         ],
-        "models": [
-          {
-            "name": "checked",
-            "type": "boolean",
-          },
-        ],
+        "models": [],
         "outputs": [
           {
             "name": "checkedChange",
@@ -5615,6 +5617,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "name": "class",
             "required": false,
             "type": "ClassValue",
+          },
+          {
+            "name": "checked",
+            "required": false,
+            "type": "boolean",
           },
           {
             "name": "disabled",
@@ -5647,12 +5654,7 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "string | null",
           },
         ],
-        "models": [
-          {
-            "name": "checked",
-            "type": "boolean",
-          },
-        ],
+        "models": [],
         "outputs": [
           {
             "name": "checkedChange",
@@ -5999,6 +6001,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "ToggleType",
           },
           {
+            "name": "value",
+            "required": false,
+            "type": "ToggleValue<T>",
+          },
+          {
             "name": "nullable",
             "required": false,
             "type": "boolean",
@@ -6009,12 +6016,7 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "boolean",
           },
         ],
-        "models": [
-          {
-            "name": "value",
-            "type": "ToggleValue<T>",
-          },
-        ],
+        "models": [],
         "outputs": [
           {
             "name": "valueChange",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [x] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [x] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [x] native-select
- [ ] navigation-menu
- [x] pagination
- [ ] popover
- [ ] progress
- [x] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [x] slider
- [ ] sonner
- [ ] spinner
- [x] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [x] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Migrate model + output to input + linkedSignal + output to avoid duplicate outputs, reported by Angular v22 migration. Closes #1385

## What is the new behavior?

Use input + linkedSignal + output instead of duplicate outputs with model + output.
Replace `ngModel`

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal state management architecture across checkbox, input-OTP, radio group, slider, switch, and toggle group components for improved efficiency and consistency.

* **Chores**
  * Removed unnecessary form framework dependencies from pagination components to reduce bundle overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->