### PR TITLE
fix: vertically center the navbar separators

### DIFF
--- a/apps/app/src/app/shared/header/header.ts
+++ b/apps/app/src/app/shared/header/header.ts
@@ -55,17 +55,17 @@ import { HeaderMobileNav } from './header-mobile-nav';
 
 				<div class="ml-auto flex items-center gap-2 md:flex-1 md:justify-end">
 					<spartan-docs-dialog class="hidden w-full flex-1 md:flex md:w-auto md:flex-none" />
-					<hlm-separator orientation="vertical" class="!h-4" />
+					<hlm-separator orientation="vertical" class="!h-4 !self-center" />
 					<a href="https://twitter.com/goetzrobin" target="_blank" size="sm" variant="ghost" hlmBtn>
 						<span class="sr-only">Twitter</span>
 						<ng-icon hlm name="lucideTwitter" size="sm" />
 					</a>
-					<hlm-separator orientation="vertical" class="!h-4" />
+					<hlm-separator orientation="vertical" class="!h-4 !self-center" />
 					<a href="https://github.com/spartan-ng/spartan" target="_blank" size="sm" variant="ghost" hlmBtn>
 						<ng-icon hlm name="lucideGithub" size="sm" />
 						<span class="text-muted-foreground text-xs">{{ _stars() }}</span>
 					</a>
-					<hlm-separator orientation="vertical" class="!h-4" />
+					<hlm-separator orientation="vertical" class="!h-4 !self-center" />
 					<spartan-layout-mode class="3xl:flex hidden" />
 					<spartan-dark-mode />
 				</div>


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

Docs app only (the `spartan-header` navbar) - no published package is affected.

## What is the current behavior?

The vertical separators in the docs navbar (between the Twitter, GitHub and theme-toggle
controls) render top-aligned rather than vertically centered. It is most noticeable on mobile.

The separators set a fixed `!h-4`, but the helm separator base class applies
`data-vertical:self-stretch`. Per the flexbox spec, `align-self: stretch` is ignored when the item
has an explicit cross-size and falls back to `flex-start`, so the fixed-height separators sit at the
top of the bar. The container's `items-center` cannot help because the item's own `self-stretch`
takes precedence, and a plain `self-center` loses to the variant's higher specificity.

## What is the new behavior?

Add `!self-center` to the three navbar separators so they override the `data-vertical:self-stretch`
variant and center against the adjacent icons. Verified in the browser at a mobile viewport: all
three separators now compute `align-self: center` and their mid-point matches the icon buttons'.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined separators in the header’s social links for improved vertical alignment and centering; separators are now standalone between the links.
  * Visual adjustment preserves existing link behavior and star count display; no functional or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->