### PR TITLE
feat(switch): add style support and rtl example

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(switch)/switch--rtl.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(switch)/switch--rtl.example.ts
@@ -1,0 +1,30 @@
+import { Component, computed, inject } from '@angular/core';
+import { TranslateService, Translations } from '@spartan-ng/app/app/shared/translate.service';
+import { HlmLabel } from '@spartan-ng/helm/label';
+import { HlmSwitch } from '@spartan-ng/helm/switch';
+
+@Component({
+	selector: 'spartan-switch-rtl-preview',
+	imports: [HlmLabel, HlmSwitch],
+	host: {
+		'[dir]': '_dir()',
+	},
+	template: `
+		<label class="flex items-center" hlmLabel>
+			<hlm-switch class="me-2" [checked]="true" />
+			{{ _t()['airplaneMode'] }}
+		</label>
+	`,
+})
+export class SwitchRtlPreview {
+	private readonly _language = inject(TranslateService).language;
+	private readonly _translations: Translations = {
+		en: { dir: 'ltr', values: { airplaneMode: 'Airplane mode' } },
+		ar: { dir: 'rtl', values: { airplaneMode: 'وضع الطيران' } },
+		he: { dir: 'rtl', values: { airplaneMode: 'מצב טיסה' } },
+	};
+
+	private readonly _translation = computed(() => this._translations[this._language()]);
+	protected readonly _t = computed(() => this._translation().values);
+	protected readonly _dir = computed(() => this._translation().dir);
+}

--- a/apps/app/src/app/pages/(components)/components/(switch)/switch--sizes.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(switch)/switch--sizes.example.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { HlmLabel } from '@spartan-ng/helm/label';
+import { HlmSwitch } from '@spartan-ng/helm/switch';
+
+@Component({
+	selector: 'spartan-switch-sizes',
+	imports: [HlmLabel, HlmSwitch],
+	host: {
+		class: 'flex items-center gap-6',
+	},
+	template: `
+		<label class="flex items-center" hlmLabel>
+			<hlm-switch class="me-2" size="sm" />
+			Small
+		</label>
+		<label class="flex items-center" hlmLabel>
+			<hlm-switch class="me-2" size="default" />
+			Default
+		</label>
+	`,
+})
+export class SwitchSizes {}

--- a/apps/app/src/app/pages/(components)/components/(switch)/switch.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(switch)/switch.page.ts
@@ -13,9 +13,11 @@ import { PageBottomNavLink } from '../../../../shared/layout/page-bottom-nav/pag
 import { PageNav } from '../../../../shared/layout/page-nav/page-nav';
 import { SectionIntro } from '../../../../shared/layout/section-intro';
 import { SectionSubHeading } from '../../../../shared/layout/section-sub-heading';
+import { SectionSubSubHeading } from '../../../../shared/layout/section-sub-sub-heading';
 import { Tabs } from '../../../../shared/layout/tabs';
 import { UIApiDocs } from '../../../../shared/layout/ui-docs-section/ui-docs-section';
 import { metaWith } from '../../../../shared/meta/meta.util';
+import { SwitchSizes } from './switch--sizes.example';
 import { SwitchPreview, defaultImports, defaultSkeleton } from './switch.preview';
 
 export const routeMeta: RouteMeta = {
@@ -39,6 +41,8 @@ export const routeMeta: RouteMeta = {
 		PageBottomNav,
 		PageBottomNavLink,
 		SwitchPreview,
+		SectionSubSubHeading,
+		SwitchSizes,
 		RtlHeader,
 		CodeRtlPreview,
 		SwitchRtlPreview,
@@ -66,6 +70,15 @@ export const routeMeta: RouteMeta = {
 				<spartan-code [code]="_defaultSkeleton" />
 			</div>
 
+			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
+			<h3 id="examples__sizes" spartanH4>Sizes</h3>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-switch-sizes />
+				</div>
+				<spartan-code secondTab [code]="_sizesCode()" />
+			</spartan-tabs>
+
 			<spartan-header-rtl />
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanRtlCodePreview firstTab>
@@ -92,6 +105,7 @@ export default class SkeletonPage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('switch');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
 	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
+	protected readonly _sizesCode = computed(() => this._snippets()['sizes']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 }

--- a/apps/app/src/app/pages/(components)/components/(switch)/switch.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(switch)/switch.page.ts
@@ -42,6 +42,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-section-intro
 				name="Switch"
 				lead="A control that allows the user to toggle between checked and not checked."
+				showThemeToggle
 			/>
 
 			<spartan-tabs firstTab="Preview" secondTab="Code">
@@ -51,7 +52,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_defaultCode()" />
 			</spartan-tabs>
 
-			<spartan-install-tabs primitive="switch" />
+			<spartan-install-tabs primitive="switch" [showOnlyVega]="false" />
 
 			<spartan-section-sub-heading id="usage">Usage</spartan-section-sub-heading>
 			<div class="mt-6 space-y-4">

--- a/apps/app/src/app/pages/(components)/components/(switch)/switch.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(switch)/switch.page.ts
@@ -1,6 +1,9 @@
 import type { RouteMeta } from '@analogjs/router';
 import { Component, computed, inject } from '@angular/core';
 import { PrimitiveSnippetsService } from '@spartan-ng/app/app/core/services/primitive-snippets.service';
+import { SwitchRtlPreview } from '@spartan-ng/app/app/pages/(components)/components/(switch)/switch--rtl.example';
+import { CodeRtlPreview } from '@spartan-ng/app/app/shared/code/code-rtl-preview';
+import { RtlHeader } from '@spartan-ng/app/app/shared/code/rtl-header';
 import { InstallTabs } from '@spartan-ng/app/app/shared/layout/install-tabs';
 import { Code } from '../../../../shared/code/code';
 import { CodePreview } from '../../../../shared/code/code-preview';
@@ -36,6 +39,9 @@ export const routeMeta: RouteMeta = {
 		PageBottomNav,
 		PageBottomNavLink,
 		SwitchPreview,
+		RtlHeader,
+		CodeRtlPreview,
+		SwitchRtlPreview,
 	],
 	template: `
 		<section spartanMainSection>
@@ -60,6 +66,14 @@ export const routeMeta: RouteMeta = {
 				<spartan-code [code]="_defaultSkeleton" />
 			</div>
 
+			<spartan-header-rtl />
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanRtlCodePreview firstTab>
+					<spartan-switch-rtl-preview />
+				</div>
+				<spartan-code secondTab [code]="_rtlCode()" />
+			</spartan-tabs>
+
 			<spartan-section-sub-heading id="brn-api">Brain API</spartan-section-sub-heading>
 			<spartan-ui-api-docs docType="brain" />
 
@@ -77,6 +91,7 @@ export const routeMeta: RouteMeta = {
 export default class SkeletonPage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('switch');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
+	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 }

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -157,6 +157,19 @@ export default defineConfig(({ command, mode }) => {
 			environment: 'jsdom',
 			setupFiles: ['src/test-setup.ts'],
 			include: ['**/*.spec.ts'],
+			// Run the suite in a single forked process. The AppComponent smoke test boots the full app
+			// shell, and the Analog/vite-plugin-angular transform of that deep import graph is heavy;
+			// spawning a worker per core multiplied that footprint and intermittently OOM-crashed a
+			// vitest worker in CI (exit 1, no output) when several nx projects tested in parallel. One
+			// memory-bounded fork keeps the docs app's footprint predictable. The suite is tiny, so the
+			// loss of intra-suite parallelism is negligible.
+			pool: 'forks',
+			poolOptions: {
+				forks: {
+					minForks: 1,
+					maxForks: 1,
+				},
+			},
 			cache: {
 				dir: '../../node_modules/.vitest',
 			},

--- a/libs/brain/switch/src/lib/brn-switch-thumb.ts
+++ b/libs/brain/switch/src/lib/brn-switch-thumb.ts
@@ -1,12 +1,16 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { BrnSwitch } from './brn-switch';
 
 @Component({
 	selector: 'brn-switch-thumb',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
 		role: 'presentation',
+		'[attr.data-state]': "_switch.checked() ? 'checked' : 'unchecked'",
 		'(click)': '$event.preventDefault()',
 	},
 	template: '',
 })
-export class BrnSwitchThumb {}
+export class BrnSwitchThumb {
+	protected readonly _switch = inject(BrnSwitch);
+}

--- a/libs/brain/switch/src/lib/brn-switch.spec.ts
+++ b/libs/brain/switch/src/lib/brn-switch.spec.ts
@@ -280,4 +280,46 @@ describe('BrnSwitchComponent', () => {
 			await validateSwitchOn(options);
 		});
 	});
+
+	describe('size', () => {
+		const renderWithSize = async (size?: string) => {
+			const view = await render(
+				`<brn-switch ${size ? `size='${size}'` : ''} aria-label='switch'><brn-switch-thumb /></brn-switch>`,
+				{ imports: [BrnSwitch, BrnSwitchThumb] },
+			);
+			view.detectChanges();
+			return view;
+		};
+
+		it('defaults data-size to "default" on the button', async () => {
+			await renderWithSize();
+			expect(screen.getByRole('switch')).toHaveAttribute('data-size', 'default');
+		});
+
+		it('reflects the size input on the button', async () => {
+			await renderWithSize('sm');
+			expect(screen.getByRole('switch')).toHaveAttribute('data-size', 'sm');
+		});
+	});
+
+	describe('thumb data-state', () => {
+		const renderThumb = async (checked: boolean) => {
+			const view = await render(
+				`<brn-switch [checked]='${checked}' aria-label='switch'><brn-switch-thumb data-testid='thumb' /></brn-switch>`,
+				{ imports: [BrnSwitch, BrnSwitchThumb] },
+			);
+			view.detectChanges();
+			return view;
+		};
+
+		it('is unchecked by default', async () => {
+			await renderThumb(false);
+			expect(screen.getByTestId('thumb')).toHaveAttribute('data-state', 'unchecked');
+		});
+
+		it('reflects the checked state', async () => {
+			await renderThumb(true);
+			expect(screen.getByTestId('thumb')).toHaveAttribute('data-state', 'checked');
+		});
+	});
 });

--- a/libs/brain/switch/src/lib/brn-switch.ts
+++ b/libs/brain/switch/src/lib/brn-switch.ts
@@ -36,6 +36,8 @@ export const BRN_SWITCH_VALUE_ACCESSOR = {
 	multi: true,
 };
 
+export type BrnSwitchSize = 'default' | 'sm';
+
 const CONTAINER_POST_FIX = '-switch';
 
 let uniqueIdCounter = 0;
@@ -66,7 +68,7 @@ let uniqueIdCounter = 0;
 			#switch
 			role="switch"
 			type="button"
-			data-size="default"
+			[attr.data-size]="size()"
 			[class]="class()"
 			[id]="getSwitchButtonId(_state().id) ?? ''"
 			[name]="getSwitchButtonId(_state().name) ?? ''"
@@ -130,6 +132,13 @@ export class BrnSwitch implements AfterContentInit, OnDestroy, ControlValueAcces
 	 * CSS classes applied to inner button element.
 	 */
 	public readonly class = input<string | null>(null);
+
+	/**
+	 * Size of the switch.
+	 * Drives the size-keyed registry style rules via the `data-size` attribute.
+	 * @default 'default'
+	 */
+	public readonly size = input<BrnSwitchSize>('default');
 
 	/**
 	 * Accessibility label for screen readers.

--- a/libs/brain/switch/src/lib/brn-switch.ts
+++ b/libs/brain/switch/src/lib/brn-switch.ts
@@ -66,6 +66,7 @@ let uniqueIdCounter = 0;
 			#switch
 			role="switch"
 			type="button"
+			data-size="default"
 			[class]="class()"
 			[id]="getSwitchButtonId(_state().id) ?? ''"
 			[name]="getSwitchButtonId(_state().name) ?? ''"

--- a/libs/cli/src/generators/ui/libs/switch/files/lib/hlm-switch-thumb.ts.template
+++ b/libs/cli/src/generators/ui/libs/switch/files/lib/hlm-switch-thumb.ts.template
@@ -6,9 +6,6 @@ import { classes } from '<%- importAlias %>/utils';
 })
 export class HlmSwitchThumb {
 	constructor() {
-		classes(
-			() =>
-				'bg-background dark:group-data-[state=unchecked]:bg-foreground dark:group-data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform group-data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
-		);
+		classes(() => 'spartan-switch-thumb pointer-events-none block ring-0 transition-transform');
 	}
 }

--- a/libs/cli/src/generators/ui/libs/switch/files/lib/hlm-switch.ts.template
+++ b/libs/cli/src/generators/ui/libs/switch/files/lib/hlm-switch.ts.template
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import type { ChangeFn, TouchFn } from '@spartan-ng/brain/forms';
-import { BrnSwitch, BrnSwitchThumb } from '@spartan-ng/brain/switch';
+import { BrnSwitch, type BrnSwitchSize, BrnSwitchThumb } from '@spartan-ng/brain/switch';
 import { hlm } from '<%- importAlias %>/utils';
 import type { ClassValue } from 'clsx';
 import { HlmSwitchThumb } from './hlm-switch-thumb';
@@ -37,6 +37,7 @@ export const HLM_SWITCH_VALUE_ACCESSOR = {
 	template: `
 		<brn-switch
 			[class]="_computedClass()"
+			[size]="size()"
 			[checked]="checked()"
 			(checkedChange)="handleChange($event)"
 			(touched)="_onTouched?.()"
@@ -69,6 +70,9 @@ export class HlmSwitch implements ControlValueAccessor {
 	public readonly disabled = input<boolean, BooleanInput>(false, {
 		transform: booleanAttribute,
 	});
+
+	/** The size of the switch. */
+	public readonly size = input<BrnSwitchSize>('default');
 
 	/** Used to set the id on the underlying brn element. */
 	public readonly inputId = input<string | null>(null);

--- a/libs/cli/src/generators/ui/libs/switch/files/lib/hlm-switch.ts.template
+++ b/libs/cli/src/generators/ui/libs/switch/files/lib/hlm-switch.ts.template
@@ -54,7 +54,7 @@ export class HlmSwitch implements ControlValueAccessor {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-50',
+			'spartan-switch group/switch inline-flex shrink-0 items-center transition-all outline-none data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-50',
 			this.userClass(),
 		),
 	);

--- a/libs/helm/switch/src/lib/hlm-switch-thumb.ts
+++ b/libs/helm/switch/src/lib/hlm-switch-thumb.ts
@@ -6,9 +6,6 @@ import { classes } from '@spartan-ng/helm/utils';
 })
 export class HlmSwitchThumb {
 	constructor() {
-		classes(
-			() =>
-				'bg-background dark:group-data-[state=unchecked]:bg-foreground dark:group-data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform group-data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
-		);
+		classes(() => 'spartan-switch-thumb pointer-events-none block ring-0 transition-transform');
 	}
 }

--- a/libs/helm/switch/src/lib/hlm-switch.ts
+++ b/libs/helm/switch/src/lib/hlm-switch.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import type { ChangeFn, TouchFn } from '@spartan-ng/brain/forms';
-import { BrnSwitch, BrnSwitchThumb } from '@spartan-ng/brain/switch';
+import { BrnSwitch, type BrnSwitchSize, BrnSwitchThumb } from '@spartan-ng/brain/switch';
 import { hlm } from '@spartan-ng/helm/utils';
 import type { ClassValue } from 'clsx';
 import { HlmSwitchThumb } from './hlm-switch-thumb';
@@ -37,6 +37,7 @@ export const HLM_SWITCH_VALUE_ACCESSOR = {
 	template: `
 		<brn-switch
 			[class]="_computedClass()"
+			[size]="size()"
 			[checked]="checked()"
 			(checkedChange)="handleChange($event)"
 			(touched)="_onTouched?.()"
@@ -69,6 +70,9 @@ export class HlmSwitch implements ControlValueAccessor {
 	public readonly disabled = input<boolean, BooleanInput>(false, {
 		transform: booleanAttribute,
 	});
+
+	/** The size of the switch. */
+	public readonly size = input<BrnSwitchSize>('default');
 
 	/** Used to set the id on the underlying brn element. */
 	public readonly inputId = input<string | null>(null);

--- a/libs/helm/switch/src/lib/hlm-switch.ts
+++ b/libs/helm/switch/src/lib/hlm-switch.ts
@@ -54,7 +54,7 @@ export class HlmSwitch implements ControlValueAccessor {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-50',
+			'spartan-switch group/switch inline-flex shrink-0 items-center transition-all outline-none data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-50',
 			this.userClass(),
 		),
 	);

--- a/libs/registry/src/styles/style-luma.css
+++ b/libs/registry/src/styles/style-luma.css
@@ -47,7 +47,7 @@
 	}
 
 	.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full shadow-sm not-dark:bg-clip-padding group-data-[size=default]/switch:h-4 group-data-[size=default]/switch:w-6 group-data-[size=sm]/switch:h-3 group-data-[size=sm]/switch:w-4 data-checked:translate-x-[calc(100%-8px)] data-unchecked:translate-x-0;
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full shadow-sm not-dark:bg-clip-padding group-data-[size=default]/switch:h-4 group-data-[size=default]/switch:w-6 group-data-[size=sm]/switch:h-3 group-data-[size=sm]/switch:w-4 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-8px)] data-checked:rtl:-translate-x-[calc(100%-8px)];
 	}
 
 	/* MARK: Radio */

--- a/libs/registry/src/styles/style-lyra.css
+++ b/libs/registry/src/styles/style-lyra.css
@@ -1209,7 +1209,7 @@
 	}
 
 	.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0;
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
 	}
 
 	/* MARK: Table */

--- a/libs/registry/src/styles/style-maia.css
+++ b/libs/registry/src/styles/style-maia.css
@@ -1234,7 +1234,7 @@
 	}
 
 	.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0;
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
 	}
 
 	/* MARK: Table */

--- a/libs/registry/src/styles/style-mira.css
+++ b/libs/registry/src/styles/style-mira.css
@@ -1236,7 +1236,7 @@
 	}
 
 	.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-3.5 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0;
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-3.5 group-data-[size=sm]/switch:size-3 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
 	}
 
 	/* MARK: Table */

--- a/libs/registry/src/styles/style-nova.css
+++ b/libs/registry/src/styles/style-nova.css
@@ -1234,7 +1234,7 @@
 	}
 
 	.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0;
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
 	}
 
 	/* MARK: Table */

--- a/libs/registry/src/styles/style-vega.css
+++ b/libs/registry/src/styles/style-vega.css
@@ -1230,7 +1230,7 @@
 	}
 
 	&.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0;
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
 	}
 
 	/* MARK: Table */

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -5548,6 +5548,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "type": "string | null",
           },
           {
+            "name": "size",
+            "required": false,
+            "type": "BrnSwitchSize",
+          },
+          {
             "name": "aria-label",
             "required": false,
             "type": "string | null",
@@ -5615,6 +5620,11 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
             "name": "disabled",
             "required": false,
             "type": "boolean",
+          },
+          {
+            "name": "size",
+            "required": false,
+            "type": "BrnSwitchSize",
           },
           {
             "name": "inputId",


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] switch

### Others

- [x] cli

(Also touches `libs/brain/switch` and the registry style sheets.)

## What is the current behavior?

The Switch component does not emit per-style markers, so its track and thumb render with
hardcoded sizing/colors and look identical across every registry style. The docs page also lacks
a theme toggle and an RTL example.

Closes #1417

## What is the new behavior?

- **Style support:** emit the `spartan-switch` and `spartan-switch-thumb` markers so the per-style
  track size, border, radius and thumb size/offset defined in the registry styles apply at runtime
  across vega, lyra, maia, mira, nova and luma, matching shadcn. A `data-size` attribute is added to
  the brain switch button and a `data-state` to the brain thumb so the size- and state-keyed
  registry rules resolve. The docs theme switcher is enabled (`showThemeToggle`) and all styles are
  shown (`[showOnlyVega]="false"`). The CLI generator templates are synced via the
  `hlm-to-cli-generator`.
- **RTL example:** add a `switch--rtl.example.ts` preview (`[dir]` host binding + `TranslateService`,
  en/ar/he), wired into the page with `spartan-header-rtl` and a `spartanRtlCodePreview` tab block.

### Note for reviewers
The per-style `.spartan-switch*` rules already existed in `libs/registry/src/styles/style-*.css`;
this PR adds the marker emission, the `data-size`/`data-state` attributes, and the docs wiring that
activate them. **Beyond the original scope:** I also made the checked thumb translate
direction-aware (`ltr:`/`rtl:`) across the 6 style sheets so the thumb animates to the correct side
under RTL - without it the thumb overflowed the track in RTL. Verified locally across all six styles
and in RTL (en/ar/he). `lint`, `test`, `build` and `format:check` pass.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Opened as a draft for review of the approach (particularly the RTL thumb-flip extension).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switch supports configurable sizes (small, default)
  * Added RTL (right-to-left) support and directional examples
  * New example pages showcasing size and RTL previews

* **Tests**
  * Added tests for switch size defaults/reflection
  * Added tests for switch thumb state transitions

* **Refactor**
  * Simplified switch thumb styling and class usage
  * Updated directional styling to explicitly handle LTR/RTL
<!-- end of auto-generated comment: release notes by coderabbit.ai -->