### PR TITLE
feat(slider): add style support and rtl example

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(slider)/slider--rtl.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(slider)/slider--rtl.example.ts
@@ -1,0 +1,41 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { Component, computed, effect, inject, signal, untracked } from '@angular/core';
+import { TranslateService, Translations } from '@spartan-ng/app/app/shared/translate.service';
+import { HlmLabel } from '@spartan-ng/helm/label';
+import { HlmSliderImports } from '@spartan-ng/helm/slider';
+
+@Component({
+	selector: 'spartan-slider-rtl-preview',
+	imports: [HlmLabel, HlmSliderImports],
+	providers: [Directionality],
+	host: {
+		class: 'grid w-full max-w-sm gap-3',
+		'[dir]': '_dir()',
+	},
+	template: `
+		<label hlmLabel>{{ _t()['volume'] }}</label>
+		<hlm-slider [(value)]="_value" />
+	`,
+})
+export class SliderRtlPreview {
+	private readonly _directionality = inject(Directionality);
+	private readonly _language = inject(TranslateService).language;
+	protected readonly _value = signal([60]);
+
+	private readonly _translations: Translations = {
+		en: { dir: 'ltr', values: { volume: 'Volume' } },
+		ar: { dir: 'rtl', values: { volume: 'مستوى الصوت' } },
+		he: { dir: 'rtl', values: { volume: 'עוצמת קול' } },
+	};
+
+	private readonly _translation = computed(() => this._translations[this._language()]);
+	protected readonly _t = computed(() => this._translation().values);
+	protected readonly _dir = computed(() => this._translation().dir);
+
+	constructor() {
+		effect(() => {
+			const dir = this._dir();
+			untracked(() => this._directionality.valueSignal.set(dir));
+		});
+	}
+}

--- a/apps/app/src/app/pages/(components)/components/(slider)/slider.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(slider)/slider.page.ts
@@ -63,7 +63,11 @@ export const routeMeta: RouteMeta = {
 	],
 	template: `
 		<section spartanMainSection>
-			<spartan-section-intro name="Slider" lead="An input where the user selects a value from within a given range." />
+			<spartan-section-intro
+				name="Slider"
+				lead="An input where the user selects a value from within a given range."
+				showThemeToggle
+			/>
 
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
@@ -72,7 +76,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_defaultCode()" />
 			</spartan-tabs>
 
-			<spartan-install-tabs primitive="slider" />
+			<spartan-install-tabs primitive="slider" [showOnlyVega]="false" />
 
 			<spartan-section-sub-heading id="usage">Usage</spartan-section-sub-heading>
 			<div class="mt-6 space-y-4">

--- a/apps/app/src/app/pages/(components)/components/(slider)/slider.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(slider)/slider.page.ts
@@ -1,6 +1,9 @@
 import type { RouteMeta } from '@analogjs/router';
 import { Component, computed, inject } from '@angular/core';
 import { PrimitiveSnippetsService } from '@spartan-ng/app/app/core/services/primitive-snippets.service';
+import { SliderRtlPreview } from '@spartan-ng/app/app/pages/(components)/components/(slider)/slider--rtl.example';
+import { CodeRtlPreview } from '@spartan-ng/app/app/shared/code/code-rtl-preview';
+import { RtlHeader } from '@spartan-ng/app/app/shared/code/rtl-header';
 import { InstallTabs } from '@spartan-ng/app/app/shared/layout/install-tabs';
 import { UIApiDocs } from '@spartan-ng/app/app/shared/layout/ui-docs-section/ui-docs-section';
 import { Code } from '../../../../shared/code/code';
@@ -60,6 +63,9 @@ export const routeMeta: RouteMeta = {
 		SliderTicks,
 		SliderVertical,
 		UIApiDocs,
+		RtlHeader,
+		CodeRtlPreview,
+		SliderRtlPreview,
 	],
 	template: `
 		<section spartanMainSection>
@@ -195,6 +201,14 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_formCode()" />
 			</spartan-tabs>
 
+			<spartan-header-rtl />
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanRtlCodePreview firstTab>
+					<spartan-slider-rtl-preview />
+				</div>
+				<spartan-code secondTab [code]="_rtlCode()" />
+			</spartan-tabs>
+
 			<spartan-section-sub-heading id="brn-api">Brain API</spartan-section-sub-heading>
 			<spartan-ui-api-docs docType="brain" />
 
@@ -212,6 +226,7 @@ export const routeMeta: RouteMeta = {
 export default class SliderPage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('slider');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
+	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
 
 	protected readonly _rangeCode = computed(() => this._snippets()['range']);
 	protected readonly _multipleThumbsCode = computed(() => this._snippets()['multipleThumbs']);

--- a/libs/cli/src/generators/ui/libs/slider/files/lib/hlm-slider.ts.template
+++ b/libs/cli/src/generators/ui/libs/slider/files/lib/hlm-slider.ts.template
@@ -33,19 +33,16 @@ import { classes } from '<%- importAlias %>/utils';
 	],
 	template: `
 		<div class="relative flex w-full items-center group-data-vertical:w-auto group-data-vertical:flex-col">
-			<div
-				brnSliderTrack
-				class="bg-muted relative grow overflow-hidden rounded-full data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1"
-			>
+			<div brnSliderTrack class="spartan-slider-track relative grow overflow-hidden">
 				<div
-					class="bg-primary absolute select-none data-draggable-range:cursor-move data-horizontal:h-full data-vertical:w-full"
+					class="spartan-slider-range absolute select-none data-draggable-range:cursor-move data-horizontal:h-full data-vertical:w-full"
 					brnSliderRange
 				></div>
 			</div>
 
 			@for (i of _slider.thumbIndexes(); track i) {
 				<span
-					class="border-ring ring-ring/50 absolute block size-3 shrink-0 rounded-full border bg-white transition-[color,box-shadow] select-none after:absolute after:-inset-2 hover:ring-[3px] focus-visible:ring-[3px] focus-visible:outline-hidden active:ring-[3px]"
+					class="spartan-slider-thumb absolute block shrink-0 select-none after:absolute after:-inset-2"
 					brnSliderThumb
 				></span>
 			}

--- a/libs/helm/slider/src/lib/hlm-slider.ts
+++ b/libs/helm/slider/src/lib/hlm-slider.ts
@@ -33,19 +33,16 @@ import { classes } from '@spartan-ng/helm/utils';
 	],
 	template: `
 		<div class="relative flex w-full items-center group-data-vertical:w-auto group-data-vertical:flex-col">
-			<div
-				brnSliderTrack
-				class="bg-muted relative grow overflow-hidden rounded-full data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1"
-			>
+			<div brnSliderTrack class="spartan-slider-track relative grow overflow-hidden">
 				<div
-					class="bg-primary absolute select-none data-draggable-range:cursor-move data-horizontal:h-full data-vertical:w-full"
+					class="spartan-slider-range absolute select-none data-draggable-range:cursor-move data-horizontal:h-full data-vertical:w-full"
 					brnSliderRange
 				></div>
 			</div>
 
 			@for (i of _slider.thumbIndexes(); track i) {
 				<span
-					class="border-ring ring-ring/50 absolute block size-3 shrink-0 rounded-full border bg-white transition-[color,box-shadow] select-none after:absolute after:-inset-2 hover:ring-[3px] focus-visible:ring-[3px] focus-visible:outline-hidden active:ring-[3px]"
+					class="spartan-slider-thumb absolute block shrink-0 select-none after:absolute after:-inset-2"
 					brnSliderThumb
 				></span>
 			}

--- a/libs/registry/src/styles/style-mira.css
+++ b/libs/registry/src/styles/style-mira.css
@@ -1214,7 +1214,7 @@
 	}
 
 	.spartan-slider-track {
-		@apply bg-muted rounded-md data-horizontal:h-3 data-horizontal:w-full data-vertical:h-full data-vertical:w-3;
+		@apply bg-muted rounded-md data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1;
 	}
 
 	.spartan-slider-range {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] slider

### Others

- [x] cli

(Also corrects one mira registry style rule.)

## What is the current behavior?

The Slider does not emit per-style markers, so its track, range and thumb render with hardcoded
sizing/colors and look identical across every registry style. The docs page also lacks a theme
toggle and an RTL example.

Closes #1416

## What is the new behavior?

- **Style support:** emit the `spartan-slider-track`, `spartan-slider-range` and
  `spartan-slider-thumb` markers so the per-style track height, corner radius, thumb size and thumb
  border defined in the registry styles apply at runtime across vega, lyra, maia, mira, nova and
  luma, matching shadcn. Also corrects the mira track height (`h-3` -> `h-1`) to match shadcn. The
  docs theme switcher is enabled (`showThemeToggle`) and all styles are shown
  (`[showOnlyVega]="false"`). The CLI generator template is synced via the `hlm-to-cli-generator`.
- **RTL example:** add a `slider--rtl.example.ts` preview (`[dir]` host binding + `TranslateService`,
  en/ar/he). Because `brn-slider` reads CDK `Directionality` (not just the DOM `dir`), the example
  provides a scoped `Directionality` and pushes the active direction into it, so the fill and thumb
  position render right-to-left. Wired into the page with `spartan-header-rtl` and a
  `spartanRtlCodePreview` tab block.

### Note for reviewers
The per-style `.spartan-slider*` rules already existed in `libs/registry/src/styles/style-*.css`;
this PR adds the marker emission and docs wiring that activate them. Verified locally across all six
styles and in RTL (en/ar/he). `lint`, `test`, `build` and `format:check` pass.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Opened as a draft for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RTL support for sliders with dynamic text-direction switching per active language

* **Documentation**
  * Added an RTL example and interactive preview (preview + code tabs) to the slider docs

* **Style**
  * Updated slider visuals: slimmer track, adjusted axis sizing, and simplified thumb/track styling for cleaner appearance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->