### PR TITLE
ci: stabilize the storybook e2e suite with test retries

### DIFF
--- a/apps/ui-storybook-e2e/cypress.config.cjs
+++ b/apps/ui-storybook-e2e/cypress.config.cjs
@@ -7,6 +7,15 @@ const presetSetupNodeEvents = preset.setupNodeEvents;
 module.exports = defineConfig({
 	e2e: {
 		...preset,
+		// Retry a failed test in CI before failing the run. The storybook suite runs every spec in one
+		// long Chromium process; under CI load individual assertions (notably the cypress-axe a11y
+		// checks and rapid keyboard-nav specs) intermittently exceed the command timeout on a random
+		// story. A per-test retry absorbs that without re-running the whole job, and is a no-op when the
+		// test is genuinely green. openMode is left at 0 so local runs surface flakes immediately.
+		retries: { runMode: 2, openMode: 0 },
+		// Give commands more headroom than the 4s default; the a11y audits and afterNextRender focus
+		// work legitimately take longer than 4s deep into the single-process run under CI load.
+		defaultCommandTimeout: 10000,
 		// Please ensure you use `cy.origin()` when navigating between domains and remove this option.
 		// See https://docs.cypress.io/app/references/migration-guide#Changes-to-cyorigin
 		injectDocumentDomain: true,


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes

## Which package are you modifying?

CI / the `ui-storybook-e2e` cypress config only - no published package is affected.

## What is the current behavior?

The storybook e2e job is intermittently flaky. The whole suite runs in one long Chromium process,
and under CI load individual assertions exceed Cypress's default 4s command timeout on a *random*
story each run - observed across the `with-form-inputs`, `button-state-sync`, `default` and
`separator` accessibility (cypress-axe) audits and the `menubar` keyboard-nav spec, all failing with
`cy.then() timed out after 4000ms` / `Timed out retrying after 4000ms`. A single slow audit fails the
entire job, so unrelated PRs go red and get re-run by hand.

## What is the new behavior?

- Add `retries: { runMode: 2, openMode: 0 }` so a transient failure is retried in CI (only the failed
  test re-runs, not the whole job) while local runs still surface flakes immediately.
- Raise `defaultCommandTimeout` to `10s`, since the a11y audits and `afterNextRender` focus work
  legitimately take longer than 4s deep into the single-process run under load.

This is purely an e2e-stability change; it does not touch any component or alter test assertions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Splits out a pre-existing, repo-wide e2e flake found while landing the style-support PRs (the failing
stories are unrelated to those changes). Worth landing on `main` so every PR benefits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced E2E test reliability through automatic retry mechanisms and increased timeout thresholds to reduce intermittent test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->