### PR TITLE
test: stabilize the docs app vitest suite

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -157,6 +157,19 @@ export default defineConfig(({ command, mode }) => {
 			environment: 'jsdom',
 			setupFiles: ['src/test-setup.ts'],
 			include: ['**/*.spec.ts'],
+			// Run the suite in a single forked process. The AppComponent smoke test boots the full app
+			// shell, and the Analog/vite-plugin-angular transform of that deep import graph is heavy;
+			// spawning a worker per core multiplied that footprint and intermittently OOM-crashed a
+			// vitest worker in CI (exit 1, no output) when several nx projects tested in parallel. One
+			// memory-bounded fork keeps the docs app's footprint predictable. The suite is tiny, so the
+			// loss of intra-suite parallelism is negligible.
+			pool: 'forks',
+			poolOptions: {
+				forks: {
+					minForks: 1,
+					maxForks: 1,
+				},
+			},
 			cache: {
 				dir: '../../node_modules/.vitest',
 			},


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] CI related changes
- [ ] Documentation content changes

## Which package are you modifying?

CI / the docs app's vitest config (`apps/app/vite.config.ts`) only - no published package is affected.

## What is the current behavior?

The `unit` job intermittently fails on `app:test` with `exit 1, no output` before any test runs. The
AppComponent smoke test boots the full app shell, and vitest spawns a worker per core to run the
heavy Analog/vite-plugin-angular transform of that deep import graph. Under `nx affected -t test
--parallel=3` the combined footprint OOM-crashes a worker. It is load-sensitive, so it surfaces on
branches with a larger affected set and is not reproducible locally. (The retry/isolation workaround
for this was previously removed in 24ae1a6d2 on the assumption analog@2.1.3 fixed it.)

## What is the new behavior?

Bound the docs app's vitest forks pool to a single reused process (`pool: 'forks'`,
`minForks/maxForks: 1`) so its memory footprint is predictable regardless of nx parallelism, while
each spec file stays isolated (per-file isolation is preserved, unlike `singleFork: true` which made
the two specs share one Angular platform and threw NG0207/NG0400). No CI workflow change; no retry.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Splits out a pre-existing, repo-wide `unit` flake found while landing the style-support PRs. Worth
landing on `main` so every PR's `app:test` is stable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test suite configuration to optimize CI performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->