### PR TITLE
fix(accordion): prevent openChange emit on init

### DIFF
--- a/libs/brain/accordion/src/lib/brn-accordion-item.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-item.ts
@@ -44,33 +44,40 @@ export class BrnAccordionItem {
 		if (!this._accordion) {
 			throw Error('Accordion item can only be used inside an Accordion. Add brnAccordion to ancestor.');
 		}
-		effect(() => {
-			const state = this.state();
-			if (untracked(this.disabled)) return;
-			untracked(() => {
-				this.stateChange.emit(state);
-				this.openedChange.emit(state === 'open');
-			});
-		});
+
 		effect(() => {
 			const isOpened = this.isOpened();
 			untracked(() => {
 				if (isOpened) {
-					this.open();
+					this._triggerOpen(false);
 				} else {
-					this.close();
+					this._triggerClose(false);
 				}
 			});
 		});
 	}
 
 	public open(): void {
-		if (this.disabled()) return;
-		this._accordion.openItem(this.id);
+		this._triggerOpen(true);
 	}
 
 	public close(): void {
+		this._triggerClose(true);
+	}
+
+	private _triggerOpen(emitEvent: boolean): void {
+		if (this.disabled()) return;
+		this._accordion.openItem(this.id);
+		if (emitEvent) {
+			this.openedChange.emit(true);
+		}
+	}
+
+	private _triggerClose(emitEvent: boolean): void {
 		if (this.disabled()) return;
 		this._accordion.closeItem(this.id);
+		if (emitEvent) {
+			this.openedChange.emit(false);
+		}
 	}
 }

--- a/libs/brain/accordion/src/lib/brn-accordion-item.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-item.ts
@@ -66,7 +66,7 @@ export class BrnAccordionItem {
 	}
 
 	private _triggerOpen(emitEvent: boolean): void {
-		if (this.disabled() || this.isOpened()) return;
+		if (this.disabled() || this.state() === 'open') return;
 		this._accordion.openItem(this.id);
 		if (emitEvent) {
 			this.stateChange.emit('open');
@@ -75,7 +75,7 @@ export class BrnAccordionItem {
 	}
 
 	private _triggerClose(emitEvent: boolean): void {
-		if (this.disabled() || !this.isOpened()) return;
+		if (this.disabled() || this.state() !== 'open') return;
 		this._accordion.closeItem(this.id);
 		if (emitEvent) {
 			this.stateChange.emit('closed');

--- a/libs/brain/accordion/src/lib/brn-accordion-item.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-item.ts
@@ -69,6 +69,7 @@ export class BrnAccordionItem {
 		if (this.disabled()) return;
 		this._accordion.openItem(this.id);
 		if (emitEvent) {
+			this.stateChange.emit('open');
 			this.openedChange.emit(true);
 		}
 	}
@@ -77,6 +78,7 @@ export class BrnAccordionItem {
 		if (this.disabled()) return;
 		this._accordion.closeItem(this.id);
 		if (emitEvent) {
+			this.stateChange.emit('closed');
 			this.openedChange.emit(false);
 		}
 	}

--- a/libs/brain/accordion/src/lib/brn-accordion-item.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-item.ts
@@ -66,7 +66,7 @@ export class BrnAccordionItem {
 	}
 
 	private _triggerOpen(emitEvent: boolean): void {
-		if (this.disabled()) return;
+		if (this.disabled() || this.isOpened()) return;
 		this._accordion.openItem(this.id);
 		if (emitEvent) {
 			this.stateChange.emit('open');
@@ -75,7 +75,7 @@ export class BrnAccordionItem {
 	}
 
 	private _triggerClose(emitEvent: boolean): void {
-		if (this.disabled()) return;
+		if (this.disabled() || !this.isOpened()) return;
 		this._accordion.closeItem(this.id);
 		if (emitEvent) {
 			this.stateChange.emit('closed');

--- a/libs/brain/accordion/src/lib/brn-accordion-trigger.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-trigger.ts
@@ -59,7 +59,11 @@ export class BrnAccordionTrigger implements FocusableOption {
 
 	protected toggle(event: Event): void {
 		event.preventDefault();
-		this._accordion.toggleItem(this._item.id);
+		if (this._state() === 'open') {
+			this._item.close();
+		} else {
+			this._item.open();
+		}
 	}
 
 	public focus() {

--- a/libs/brain/accordion/src/lib/brn-accordion.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.ts
@@ -113,14 +113,6 @@ export class BrnAccordion implements AfterContentInit, OnDestroy {
 		this._keyManager()?.setActiveItem(item);
 	}
 
-	public toggleItem(id: number) {
-		if (this._openItemIds().includes(id)) {
-			this.closeItem(id);
-			return;
-		}
-		this.openItem(id);
-	}
-
 	public openItem(id: number) {
 		if (this.type() === 'single') {
 			this._openItemIds.set([id]);

--- a/libs/brain/accordion/src/lib/brn-accordion.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.ts
@@ -165,17 +165,13 @@ export class BrnAccordion implements AfterContentInit, OnDestroy {
 
 	public openAll(): void {
 		if (this.type() === 'multiple') {
-			this._brnAccordionItems()
-				.filter((a) => !a.disabled())
-				.forEach((a) => this.openItem(a.id));
+			this._brnAccordionItems().forEach((a) => a.open());
 		} else {
 			console.warn('[BrnAccordion]: openAll is only available in multiple mode');
 		}
 	}
 
 	public closeAll(): void {
-		this._brnAccordionItems()
-			.filter((a) => !a.disabled())
-			.forEach((a) => this.closeItem(a.id));
+		this._brnAccordionItems().forEach((a) => a.close());
 	}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

the openChange event from the brnAccordionItem is only fired when it's triggered manually

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Programmatic open/close actions now update state without emitting change events; manual user-triggered open/close still emit events.
  * Trigger controls now toggle items by invoking item open/close directly for more reliable interaction.
  * Global Open All / Close All now apply uniformly to every item, including those previously excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->