### PR TITLE
feat(progress): add style support and rtl example

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(progress)/progress--rtl.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(progress)/progress--rtl.example.ts
@@ -1,0 +1,42 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { Component, computed, effect, inject, untracked } from '@angular/core';
+import { TranslateService, Translations } from '@spartan-ng/app/app/shared/translate.service';
+import { HlmLabel } from '@spartan-ng/helm/label';
+import { HlmProgressImports } from '@spartan-ng/helm/progress';
+
+@Component({
+	selector: 'spartan-progress-rtl-preview',
+	imports: [HlmLabel, HlmProgressImports],
+	providers: [Directionality],
+	host: {
+		class: 'grid w-full max-w-sm gap-3',
+		'[dir]': '_dir()',
+	},
+	template: `
+		<label hlmLabel>{{ _t()['downloading'] }}</label>
+		<hlm-progress [value]="60">
+			<hlm-progress-indicator />
+		</hlm-progress>
+	`,
+})
+export class ProgressRtlPreview {
+	private readonly _directionality = inject(Directionality);
+	private readonly _language = inject(TranslateService).language;
+
+	private readonly _translations: Translations = {
+		en: { dir: 'ltr', values: { downloading: 'Downloading…' } },
+		ar: { dir: 'rtl', values: { downloading: '…جارٍ التنزيل' } },
+		he: { dir: 'rtl', values: { downloading: '…מוריד' } },
+	};
+
+	private readonly _translation = computed(() => this._translations[this._language()]);
+	protected readonly _t = computed(() => this._translation().values);
+	protected readonly _dir = computed(() => this._translation().dir);
+
+	constructor() {
+		effect(() => {
+			const dir = this._dir();
+			untracked(() => this._directionality.valueSignal.set(dir));
+		});
+	}
+}

--- a/apps/app/src/app/pages/(components)/components/(progress)/progress.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(progress)/progress.page.ts
@@ -1,6 +1,8 @@
 import type { RouteMeta } from '@analogjs/router';
 import { Component, computed, inject } from '@angular/core';
 import { PrimitiveSnippetsService } from '@spartan-ng/app/app/core/services/primitive-snippets.service';
+import { CodeRtlPreview } from '@spartan-ng/app/app/shared/code/code-rtl-preview';
+import { RtlHeader } from '@spartan-ng/app/app/shared/code/rtl-header';
 import { InstallTabs } from '@spartan-ng/app/app/shared/layout/install-tabs';
 import { SectionSubSubHeading } from '@spartan-ng/app/app/shared/layout/section-sub-sub-heading';
 import { hlmCode, hlmP } from '@spartan-ng/helm/typography';
@@ -16,6 +18,7 @@ import { Tabs } from '../../../../shared/layout/tabs';
 import { UIApiDocs } from '../../../../shared/layout/ui-docs-section/ui-docs-section';
 import { metaWith } from '../../../../shared/meta/meta.util';
 import { ProgressIndeterminatePreview } from './progress--indeterminate.preview';
+import { ProgressRtlPreview } from './progress--rtl.example';
 import { ProgressPreview, defaultImports, defaultSkeleton } from './progress.preview';
 
 export const routeMeta: RouteMeta = {
@@ -44,12 +47,16 @@ export const routeMeta: RouteMeta = {
 		ProgressPreview,
 		ProgressIndeterminatePreview,
 		SectionSubSubHeading,
+		RtlHeader,
+		CodeRtlPreview,
+		ProgressRtlPreview,
 	],
 	template: `
 		<section spartanMainSection>
 			<spartan-section-intro
 				name="Progress"
 				lead="Displays an indicator showing the completion progress of a task, typically displayed as a progress bar."
+				showThemeToggle
 			/>
 
 			<spartan-tabs firstTab="Preview" secondTab="Code">
@@ -59,7 +66,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_defaultCode()" />
 			</spartan-tabs>
 
-			<spartan-install-tabs primitive="progress" />
+			<spartan-install-tabs primitive="progress" [showOnlyVega]="false" />
 
 			<spartan-section-sub-heading id="usage">Usage</spartan-section-sub-heading>
 			<div class="mt-6 space-y-4">
@@ -127,6 +134,14 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_indeterminateCode()" />
 			</spartan-tabs>
 
+			<spartan-header-rtl />
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanRtlCodePreview firstTab>
+					<spartan-progress-rtl-preview />
+				</div>
+				<spartan-code secondTab [code]="_rtlCode()" />
+			</spartan-tabs>
+
 			<spartan-section-sub-heading id="brn-api">Brain API</spartan-section-sub-heading>
 			<spartan-ui-api-docs docType="brain" />
 
@@ -141,10 +156,11 @@ export const routeMeta: RouteMeta = {
 		<spartan-page-nav />
 	`,
 })
-export default class LabelPage {
+export default class ProgressPage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('progress');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
 	protected readonly _indeterminateCode = computed(() => this._snippets()['indeterminate']);
+	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 }

--- a/libs/cli/src/generators/ui/libs/progress/files/lib/hlm-progress-indicator.ts.template
+++ b/libs/cli/src/generators/ui/libs/progress/files/lib/hlm-progress-indicator.ts.template
@@ -1,4 +1,5 @@
-import { Directive, computed } from '@angular/core';
+import { Directionality } from '@angular/cdk/bidi';
+import { Directive, computed, inject } from '@angular/core';
 import { BrnProgressIndicator, injectBrnProgress } from '@spartan-ng/brain/progress';
 import { classes } from '<%- importAlias %>/utils';
 
@@ -9,12 +10,18 @@ import { classes } from '<%- importAlias %>/utils';
 })
 export class HlmProgressIndicator {
 	private readonly _progress = injectBrnProgress();
-	protected readonly _transform = computed(() => `translateX(-${100 - (this._progress.value() ?? 100)}%)`);
+	private readonly _dir = inject(Directionality);
+	// Offset the indicator by the unfilled remainder. In RTL the bar fills from the inline-start
+	// (visually the right), so translate the opposite way to keep the fill on the correct side.
+	protected readonly _transform = computed(() => {
+		const offset = 100 - (this._progress.value() ?? 100);
+		return `translateX(${this._dir.valueSignal() === 'rtl' ? '' : '-'}${offset}%)`;
+	});
 	protected readonly _indeterminate = computed(
 		() => this._progress.value() === null || this._progress.value() === undefined,
 	);
 
 	constructor() {
-		classes(() => 'bg-primary h-full w-full flex-1 transition-all');
+		classes(() => 'spartan-progress-indicator h-full w-full flex-1 transition-all');
 	}
 }

--- a/libs/cli/src/generators/ui/libs/progress/files/lib/hlm-progress.ts.template
+++ b/libs/cli/src/generators/ui/libs/progress/files/lib/hlm-progress.ts.template
@@ -8,6 +8,6 @@ import { classes } from '<%- importAlias %>/utils';
 })
 export class HlmProgress {
 	constructor() {
-		classes(() => 'bg-primary/20 relative inline-flex h-2 w-full overflow-hidden rounded-full');
+		classes(() => 'spartan-progress relative inline-flex w-full overflow-hidden');
 	}
 }

--- a/libs/helm/progress/src/lib/hlm-progress-indicator.ts
+++ b/libs/helm/progress/src/lib/hlm-progress-indicator.ts
@@ -1,4 +1,5 @@
-import { Directive, computed } from '@angular/core';
+import { Directionality } from '@angular/cdk/bidi';
+import { Directive, computed, inject } from '@angular/core';
 import { BrnProgressIndicator, injectBrnProgress } from '@spartan-ng/brain/progress';
 import { classes } from '@spartan-ng/helm/utils';
 
@@ -9,12 +10,18 @@ import { classes } from '@spartan-ng/helm/utils';
 })
 export class HlmProgressIndicator {
 	private readonly _progress = injectBrnProgress();
-	protected readonly _transform = computed(() => `translateX(-${100 - (this._progress.value() ?? 100)}%)`);
+	private readonly _dir = inject(Directionality);
+	// Offset the indicator by the unfilled remainder. In RTL the bar fills from the inline-start
+	// (visually the right), so translate the opposite way to keep the fill on the correct side.
+	protected readonly _transform = computed(() => {
+		const offset = 100 - (this._progress.value() ?? 100);
+		return `translateX(${this._dir.valueSignal() === 'rtl' ? '' : '-'}${offset}%)`;
+	});
 	protected readonly _indeterminate = computed(
 		() => this._progress.value() === null || this._progress.value() === undefined,
 	);
 
 	constructor() {
-		classes(() => 'bg-primary h-full w-full flex-1 transition-all');
+		classes(() => 'spartan-progress-indicator h-full w-full flex-1 transition-all');
 	}
 }

--- a/libs/helm/progress/src/lib/hlm-progress.spec.ts
+++ b/libs/helm/progress/src/lib/hlm-progress.spec.ts
@@ -1,0 +1,34 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { TestBed } from '@angular/core/testing';
+import { render } from '@testing-library/angular';
+import { HlmProgress } from './hlm-progress';
+import { HlmProgressIndicator } from './hlm-progress-indicator';
+
+describe('HlmProgressIndicator', () => {
+	const setup = async (value: number) => {
+		const result = await render(`<hlm-progress [value]="${value}"><hlm-progress-indicator /></hlm-progress>`, {
+			imports: [HlmProgress, HlmProgressIndicator],
+		});
+		result.detectChanges();
+		const indicator = result.container.querySelector('hlm-progress-indicator') as HTMLElement;
+		return { ...result, indicator };
+	};
+
+	it('translates the indicator left by the unfilled remainder in LTR', async () => {
+		const { indicator, detectChanges } = await setup(60);
+
+		TestBed.inject(Directionality).valueSignal.set('ltr');
+		detectChanges();
+
+		expect(indicator.style.transform).toBe('translateX(-40%)');
+	});
+
+	it('flips the indicator translation in RTL so the bar fills from the inline-start', async () => {
+		const { indicator, detectChanges } = await setup(60);
+
+		TestBed.inject(Directionality).valueSignal.set('rtl');
+		detectChanges();
+
+		expect(indicator.style.transform).toBe('translateX(40%)');
+	});
+});

--- a/libs/helm/progress/src/lib/hlm-progress.ts
+++ b/libs/helm/progress/src/lib/hlm-progress.ts
@@ -8,6 +8,6 @@ import { classes } from '@spartan-ng/helm/utils';
 })
 export class HlmProgress {
 	constructor() {
-		classes(() => 'bg-primary/20 relative inline-flex h-2 w-full overflow-hidden rounded-full');
+		classes(() => 'spartan-progress relative inline-flex w-full overflow-hidden');
 	}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] progress

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1410

Progress renders the same in every registry style, the docs page has no theme toggle or RTL
example, and the indicator always fills left-to-right.

## What is the new behavior?

- Emit the `spartan-progress` and `spartan-progress-indicator` marker classes from the helm
  components (and CLI templates) so the per-style registry rules apply across all styles.
- Make the indicator RTL-aware: its `translateX` offset flips sign when the ambient direction is
  `rtl`, so the bar fills from the right.
- Enable the theme toggle and `[showOnlyVega]="false"` on the docs page and add a
  `progress--rtl.example.ts` RTL example.
- Add `hlm-progress.spec.ts` asserting the indicator transform direction for LTR and RTL.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Part of the per-component style-support and RTL effort tracked in #1391.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RTL support for progress components, including directional animations.

* **Style**
  * Updated progress component styling and indicator fill behavior for correct RTL/LTR visuals.
  * Adjusted indeterminate animation duration from 4s to 3s.

* **Documentation**
  * Added RTL preview and code examples with a theme toggle on the progress docs.

* **Tests**
  * Added RTL-specific tests to verify directional behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->