### PR TITLE
feat(radio-group): add style support and rtl example

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group--rtl.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group--rtl.example.ts
@@ -1,0 +1,70 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { Component, computed, effect, inject, untracked } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TranslateService, Translations } from '@spartan-ng/app/app/shared/translate.service';
+import { HlmLabelImports } from '@spartan-ng/helm/label';
+import { HlmRadioGroupImports } from '@spartan-ng/helm/radio-group';
+
+@Component({
+	selector: 'spartan-radio-group-rtl-preview',
+	imports: [FormsModule, HlmRadioGroupImports, HlmLabelImports],
+	providers: [Directionality],
+	host: {
+		class: 'grid w-full max-w-sm gap-3',
+		'[dir]': '_dir()',
+	},
+	template: `
+		<label hlmLabel>{{ _t()['label'] }}</label>
+		<hlm-radio-group [(ngModel)]="_value">
+			<div class="flex items-center gap-3">
+				<hlm-radio value="default" inputId="rtl-r1">
+					<hlm-radio-indicator indicator />
+				</hlm-radio>
+				<label hlmLabel for="rtl-r1">{{ _t()['default'] }}</label>
+			</div>
+			<div class="flex items-center gap-3">
+				<hlm-radio value="comfortable" inputId="rtl-r2">
+					<hlm-radio-indicator indicator />
+				</hlm-radio>
+				<label hlmLabel for="rtl-r2">{{ _t()['comfortable'] }}</label>
+			</div>
+			<div class="flex items-center gap-3">
+				<hlm-radio value="compact" inputId="rtl-r3">
+					<hlm-radio-indicator indicator />
+				</hlm-radio>
+				<label hlmLabel for="rtl-r3">{{ _t()['compact'] }}</label>
+			</div>
+		</hlm-radio-group>
+	`,
+})
+export class RadioGroupRtlPreview {
+	private readonly _directionality = inject(Directionality);
+	private readonly _language = inject(TranslateService).language;
+	protected _value = 'comfortable';
+
+	private readonly _translations: Translations = {
+		en: {
+			dir: 'ltr',
+			values: { label: 'Spacing', default: 'Default', comfortable: 'Comfortable', compact: 'Compact' },
+		},
+		ar: {
+			dir: 'rtl',
+			values: { label: 'التباعد', default: 'افتراضي', comfortable: 'مريح', compact: 'مضغوط' },
+		},
+		he: {
+			dir: 'rtl',
+			values: { label: 'מרווח', default: 'ברירת מחדל', comfortable: 'נוח', compact: 'קומפקטי' },
+		},
+	};
+
+	private readonly _translation = computed(() => this._translations[this._language()]);
+	protected readonly _t = computed(() => this._translation().values);
+	protected readonly _dir = computed(() => this._translation().dir);
+
+	constructor() {
+		effect(() => {
+			const dir = this._dir();
+			untracked(() => this._directionality.valueSignal.set(dir));
+		});
+	}
+}

--- a/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(radio-group)/radio-group.page.ts
@@ -1,6 +1,8 @@
 import type { RouteMeta } from '@analogjs/router';
 import { Component, computed, inject } from '@angular/core';
 import { PrimitiveSnippetsService } from '@spartan-ng/app/app/core/services/primitive-snippets.service';
+import { CodeRtlPreview } from '@spartan-ng/app/app/shared/code/code-rtl-preview';
+import { RtlHeader } from '@spartan-ng/app/app/shared/code/rtl-header';
 import { InstallTabs } from '@spartan-ng/app/app/shared/layout/install-tabs';
 import { SectionSubSubHeading } from '@spartan-ng/app/app/shared/layout/section-sub-sub-heading';
 import { Code } from '../../../../shared/code/code';
@@ -16,6 +18,7 @@ import { UIApiDocs } from '../../../../shared/layout/ui-docs-section/ui-docs-sec
 import { metaWith } from '../../../../shared/meta/meta.util';
 import { RadioGroupCard } from './radio-group--card.example';
 import { RadioGroupFormPreview } from './radio-group--form.example';
+import { RadioGroupRtlPreview } from './radio-group--rtl.example';
 import { defaultImports, defaultSkeleton, RadioGroupPreview } from './radio-group.preview';
 
 export const routeMeta: RouteMeta = {
@@ -46,12 +49,16 @@ export const routeMeta: RouteMeta = {
 		RadioGroupCard,
 		RadioGroupFormPreview,
 		SectionSubSubHeading,
+		RtlHeader,
+		CodeRtlPreview,
+		RadioGroupRtlPreview,
 	],
 	template: `
 		<section spartanMainSection>
 			<spartan-section-intro
 				name="Radio Group"
 				lead="A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time."
+				showThemeToggle
 			/>
 
 			<spartan-tabs firstTab="Preview" secondTab="Code">
@@ -61,7 +68,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_defaultCode()" />
 			</spartan-tabs>
 
-			<spartan-install-tabs primitive="radio-group" />
+			<spartan-install-tabs primitive="radio-group" [showOnlyVega]="false" />
 
 			<spartan-section-sub-heading id="usage">Usage</spartan-section-sub-heading>
 			<div class="mt-6 space-y-4">
@@ -86,6 +93,14 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_formCode()" />
 			</spartan-tabs>
 
+			<spartan-header-rtl />
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanRtlCodePreview firstTab>
+					<spartan-radio-group-rtl-preview />
+				</div>
+				<spartan-code secondTab [code]="_rtlCode()" />
+			</spartan-tabs>
+
 			<spartan-section-sub-heading id="brn-api">Brain API</spartan-section-sub-heading>
 			<spartan-ui-api-docs docType="brain" />
 
@@ -100,9 +115,10 @@ export const routeMeta: RouteMeta = {
 		<spartan-page-nav />
 	`,
 })
-export default class LabelPage {
+export default class RadioGroupPage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('radio-group');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
+	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
 	protected readonly _cardCode = computed(() => this._snippets()['card']);
 	protected readonly _formCode = computed(() => this._snippets()['form']);
 	protected readonly _defaultSkeleton = defaultSkeleton;

--- a/libs/cli/src/generators/ui/libs/radio-group/files/lib/hlm-radio-group.ts.template
+++ b/libs/cli/src/generators/ui/libs/radio-group/files/lib/hlm-radio-group.ts.template
@@ -33,6 +33,10 @@ export class HlmRadioGroup {
 	protected readonly _errorState = computed(() => this._brnRadioGroup.controlState?.()?.spartanInvalid);
 
 	constructor() {
-		classes(() => ['grid gap-3', this.userClass(), this._errorState() ? 'data-[invalid=true]:text-destructive' : '']);
+		classes(() => [
+			'spartan-radio-group',
+			this.userClass(),
+			this._errorState() ? 'data-[invalid=true]:text-destructive' : '',
+		]);
 	}
 }

--- a/libs/helm/radio-group/src/lib/hlm-radio-group.ts
+++ b/libs/helm/radio-group/src/lib/hlm-radio-group.ts
@@ -33,6 +33,10 @@ export class HlmRadioGroup {
 	protected readonly _errorState = computed(() => this._brnRadioGroup.controlState?.()?.spartanInvalid);
 
 	constructor() {
-		classes(() => ['grid gap-3', this.userClass(), this._errorState() ? 'data-[invalid=true]:text-destructive' : '']);
+		classes(() => [
+			'spartan-radio-group',
+			this.userClass(),
+			this._errorState() ? 'data-[invalid=true]:text-destructive' : '',
+		]);
 	}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] radio-group

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1411

Radio group renders the same in every registry style and the docs page has no theme toggle or
RTL example.

## What is the new behavior?

- Emit the `spartan-radio-group` marker class from the helm component (and the CLI template) so
  the per-style registry rules apply across all styles.
- Enable the theme toggle and `[showOnlyVega]="false"` on the docs page.
- Add a `radio-group--rtl.example.ts` RTL example that provides `Directionality` and pushes the
  active direction (the brain primitive already consumes `Directionality`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Part of the per-component style-support and RTL effort tracked in #1391.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RTL language support for radio groups with live direction switching and an RTL preview + code example on the radio group docs page.

* **Style**
  * Updated radio group base styling/class structure for consistent visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->