### PR TITLE
feat(resizable): add style support and rtl example

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(resizable)/resizable--rtl.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(resizable)/resizable--rtl.example.ts
@@ -1,0 +1,64 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { Component, computed, effect, inject, untracked } from '@angular/core';
+import { TranslateService, Translations } from '@spartan-ng/app/app/shared/translate.service';
+import { HlmResizableImports } from '@spartan-ng/helm/resizable';
+
+@Component({
+	selector: 'spartan-resizable-rtl-preview',
+	imports: [HlmResizableImports],
+	providers: [Directionality],
+	host: {
+		'[dir]': '_dir()',
+	},
+	template: `
+		<hlm-resizable-group class="h-[200px] w-[500px] max-w-md rounded-lg border">
+			<hlm-resizable-panel>
+				<div class="flex h-full items-center justify-center p-6">{{ _t()['sidebar'] }}</div>
+			</hlm-resizable-panel>
+			<hlm-resizable-handle />
+			<hlm-resizable-panel>
+				<div class="flex h-full items-center justify-center p-6">
+					<span class="font-semibold">{{ _t()['content'] }}</span>
+				</div>
+			</hlm-resizable-panel>
+		</hlm-resizable-group>
+	`,
+})
+export class ResizableRtlPreview {
+	private readonly _directionality = inject(Directionality);
+	private readonly _language = inject(TranslateService).language;
+	private readonly _translations: Translations = {
+		en: {
+			dir: 'ltr',
+			values: {
+				sidebar: 'Sidebar',
+				content: 'Content',
+			},
+		},
+		ar: {
+			dir: 'rtl',
+			values: {
+				sidebar: 'الشريط الجانبي',
+				content: 'المحتوى',
+			},
+		},
+		he: {
+			dir: 'rtl',
+			values: {
+				sidebar: 'סרגל צד',
+				content: 'תוכן',
+			},
+		},
+	};
+
+	private readonly _translation = computed(() => this._translations[this._language()]);
+	protected readonly _t = computed(() => this._translation().values);
+	protected readonly _dir = computed(() => this._translation().dir);
+
+	constructor() {
+		effect(() => {
+			const dir = this._dir();
+			untracked(() => this._directionality.valueSignal.set(dir));
+		});
+	}
+}

--- a/apps/app/src/app/pages/(components)/components/(resizable)/resizable.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(resizable)/resizable.page.ts
@@ -15,7 +15,10 @@ import { UIApiDocs } from '../../../../shared/layout/ui-docs-section/ui-docs-sec
 import { metaWith } from '../../../../shared/meta/meta.util';
 
 import { ResizableHandlePreview } from '@spartan-ng/app/app/pages/(components)/components/(resizable)/resizable--handle.preview';
+import { ResizableRtlPreview } from '@spartan-ng/app/app/pages/(components)/components/(resizable)/resizable--rtl.example';
 import { ResizableVerticalPreview } from '@spartan-ng/app/app/pages/(components)/components/(resizable)/resizable--vertical.preview';
+import { CodeRtlPreview } from '@spartan-ng/app/app/shared/code/code-rtl-preview';
+import { RtlHeader } from '@spartan-ng/app/app/shared/code/rtl-header';
 import { SectionSubSubHeading } from '@spartan-ng/app/app/shared/layout/section-sub-sub-heading';
 import { HlmCode, HlmP } from '@spartan-ng/helm/typography';
 import { defaultImports, defaultSkeleton, ResizablePreviewComponent } from './resizable.preview';
@@ -46,10 +49,17 @@ export const routeMeta: RouteMeta = {
 		ResizableHandlePreview,
 		HlmP,
 		HlmCode,
+		RtlHeader,
+		CodeRtlPreview,
+		ResizableRtlPreview,
 	],
 	template: `
 		<section spartanMainSection>
-			<spartan-section-intro name="Resizable" lead="A group of resizable horizontal and vertical panels." />
+			<spartan-section-intro
+				name="Resizable"
+				lead="A group of resizable horizontal and vertical panels."
+				showThemeToggle
+			/>
 
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
@@ -58,7 +68,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_defaultCode()" />
 			</spartan-tabs>
 
-			<spartan-install-tabs primitive="resizable" />
+			<spartan-install-tabs primitive="resizable" [showOnlyVega]="false" />
 
 			<spartan-section-sub-heading id="usage">Usage</spartan-section-sub-heading>
 			<div class="mt-6 space-y-4">
@@ -96,6 +106,14 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_handleCode()" />
 			</spartan-tabs>
 
+			<spartan-header-rtl />
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanRtlCodePreview firstTab>
+					<spartan-resizable-rtl-preview />
+				</div>
+				<spartan-code secondTab [code]="_rtlCode()" />
+			</spartan-tabs>
+
 			<spartan-section-sub-heading id="brn-api">Brain API</spartan-section-sub-heading>
 			<spartan-ui-api-docs docType="brain" />
 
@@ -115,6 +133,7 @@ export default class ResizablePage {
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
 	protected readonly _verticalCode = computed(() => this._snippets()['vertical']);
 	protected readonly _handleCode = computed(() => this._snippets()['handle']);
+	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 }

--- a/libs/brain/resizable/src/lib/brn-resizable-group.spec.ts
+++ b/libs/brain/resizable/src/lib/brn-resizable-group.spec.ts
@@ -1,0 +1,73 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { render } from '@testing-library/angular';
+import { BrnResizableGroup } from './brn-resizable-group';
+import { BrnResizableHandle } from './brn-resizable-handle';
+import { BrnResizablePanel } from './brn-resizable-panel';
+
+@Component({
+	imports: [BrnResizableGroup, BrnResizablePanel, BrnResizableHandle],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<brn-resizable-group [(layout)]="layout">
+			<brn-resizable-panel />
+			<brn-resizable-handle />
+			<brn-resizable-panel />
+		</brn-resizable-group>
+	`,
+})
+class ResizableHost {
+	public readonly layout = signal<number[]>([50, 50]);
+}
+
+describe('BrnResizableGroup horizontal RTL resize', () => {
+	let rafSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		// Run the RAF-scheduled layout commit synchronously so the drag result is observable.
+		rafSpy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => (cb(0), 0));
+	});
+
+	afterEach(() => rafSpy.mockRestore());
+
+	const setup = async () => {
+		const view = await render(ResizableHost);
+		view.detectChanges();
+		const group = document.querySelector('[data-slot="resizable-panel-group"]') as HTMLElement;
+		// jsdom reports offsetWidth as 0; give the group a concrete width so deltas resolve to percentages.
+		Object.defineProperty(group, 'offsetWidth', { value: 200, configurable: true });
+		const handle = document.querySelector('brn-resizable-handle') as HTMLElement;
+		return { ...view, handle };
+	};
+
+	const dragRightBy = (handle: HTMLElement, px: number) => {
+		const at = (clientX: number) => ({ bubbles: true, cancelable: true, clientX, clientY: 0, button: 0 });
+		handle.dispatchEvent(new MouseEvent('mousedown', at(100)));
+		document.dispatchEvent(new MouseEvent('mousemove', at(100 + px)));
+		document.dispatchEvent(new MouseEvent('mouseup', at(100 + px)));
+	};
+
+	const firstPanelSize = () =>
+		Number(document.querySelector('[data-slot="resizable-panel"]')?.getAttribute('data-panel-size'));
+
+	it('grows the first panel when dragging the handle right in LTR', async () => {
+		const { handle, detectChanges } = await setup();
+		TestBed.inject(Directionality).valueSignal.set('ltr');
+
+		dragRightBy(handle, 20); // +20px of 200px = +10%
+		detectChanges();
+
+		expect(firstPanelSize()).toBeGreaterThan(50);
+	});
+
+	it('shrinks the first panel when dragging right in RTL (delta mirrored)', async () => {
+		const { handle, detectChanges } = await setup();
+		TestBed.inject(Directionality).valueSignal.set('rtl');
+
+		dragRightBy(handle, 20);
+		detectChanges();
+
+		expect(firstPanelSize()).toBeLessThan(50);
+	});
+});

--- a/libs/brain/resizable/src/lib/brn-resizable-group.ts
+++ b/libs/brain/resizable/src/lib/brn-resizable-group.ts
@@ -1,3 +1,4 @@
+import { Directionality } from '@angular/cdk/bidi';
 import {
 	afterNextRender,
 	contentChildren,
@@ -31,6 +32,9 @@ export class BrnResizableGroup {
 
 	/** Host element reference. */
 	private readonly _el = inject(ElementRef<HTMLElement>);
+
+	/** Layout direction, used to mirror horizontal resizing under RTL. */
+	private readonly _dir = inject(Directionality);
 
 	/** Group orientation */
 	public readonly direction = input<'horizontal' | 'vertical'>('horizontal');
@@ -94,10 +98,13 @@ export class BrnResizableGroup {
 
 		const startPosition = this._getEventPosition(event);
 		const startSizes = [...sizes];
+		// Horizontal resizing is mirrored under RTL: the panel order is reversed, so the pixel
+		// delta is inverted in _handleResize to keep the handle tracking the pointer correctly.
+		const isRtl = this.direction() === 'horizontal' && this._dir.valueSignal() === 'rtl';
 
 		const handleMove = (moveEvent: MouseEvent | TouchEvent) => {
 			this._zone.runOutsideAngular(() => {
-				this._handleResize(moveEvent, handleIndex, startPosition, startSizes);
+				this._handleResize(moveEvent, handleIndex, startPosition, startSizes, isRtl);
 			});
 		};
 
@@ -124,9 +131,10 @@ export class BrnResizableGroup {
 		handleIndex: number,
 		startPosition: number,
 		startSizes: number[],
+		isRtl = false,
 	): void {
 		const currentPosition = this._getEventPosition(event);
-		const delta = currentPosition - startPosition;
+		const delta = (currentPosition - startPosition) * (isRtl ? -1 : 1);
 		const containerSize = this._getContainerSize();
 		const deltaPercentage = (delta / containerSize) * 100;
 

--- a/libs/cli/src/generators/ui/libs/resizable/files/lib/hlm-resizable-handle.ts.template
+++ b/libs/cli/src/generators/ui/libs/resizable/files/lib/hlm-resizable-handle.ts.template
@@ -21,7 +21,7 @@ export class HlmResizableHandle {
 
 	constructor() {
 		classes(() => [
-			'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90',
+			'bg-border ring-offset-background focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90',
 			'data-[panel-group-direction=horizontal]:hover:cursor-ew-resize data-[panel-group-direction=vertical]:hover:cursor-ns-resize',
 		]);
 	}

--- a/libs/cli/src/generators/ui/libs/resizable/files/lib/hlm-resizable-handle.ts.template
+++ b/libs/cli/src/generators/ui/libs/resizable/files/lib/hlm-resizable-handle.ts.template
@@ -12,7 +12,7 @@ import { classes } from '<%- importAlias %>/utils';
 	},
 	template: `
 		@if (_brnResizableHandle.withHandle()) {
-			<div class="bg-border z-10 flex h-6 w-1 shrink-0 rounded-lg"></div>
+			<div class="spartan-resizable-handle-icon z-10 flex shrink-0"></div>
 		}
 	`,
 })

--- a/libs/helm/resizable/src/lib/hlm-resizable-handle.ts
+++ b/libs/helm/resizable/src/lib/hlm-resizable-handle.ts
@@ -21,7 +21,7 @@ export class HlmResizableHandle {
 
 	constructor() {
 		classes(() => [
-			'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90',
+			'bg-border ring-offset-background focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90',
 			'data-[panel-group-direction=horizontal]:hover:cursor-ew-resize data-[panel-group-direction=vertical]:hover:cursor-ns-resize',
 		]);
 	}

--- a/libs/helm/resizable/src/lib/hlm-resizable-handle.ts
+++ b/libs/helm/resizable/src/lib/hlm-resizable-handle.ts
@@ -12,7 +12,7 @@ import { classes } from '@spartan-ng/helm/utils';
 	},
 	template: `
 		@if (_brnResizableHandle.withHandle()) {
-			<div class="bg-border z-10 flex h-6 w-1 shrink-0 rounded-lg"></div>
+			<div class="spartan-resizable-handle-icon z-10 flex shrink-0"></div>
 		}
 	`,
 })

--- a/libs/registry/src/styles/style-lyra.css
+++ b/libs/registry/src/styles/style-lyra.css
@@ -1,4 +1,7 @@
 .style-lyra {
+	/* Lyra is a sharp style: match shadcn's Lyra preset which sets --radius to 0. */
+	--radius: 0rem;
+
 	.spartan-rtl-flip {
 		@apply rtl:rotate-180;
 	}
@@ -964,7 +967,7 @@
 
 	/* MARK: Resizable */
 	.spartan-resizable-handle-icon {
-		@apply bg-border h-6 w-1 rounded-none;
+		@apply bg-border h-6 w-1 rounded-lg;
 	}
 
 	/* MARK: Scroll Area */

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -1487,6 +1487,7 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
   "collapsible": {
     "brain": {
       "BrnCollapsible": {
+        "exportAs": "brnCollapsible",
         "inputs": [
           {
             "name": "disabled",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] resizable

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1412

The resize handle renders the same in every registry style, the docs page has no theme toggle or
RTL example, and dragging a handle in an RTL layout moves panels the wrong way.

## What is the new behavior?

- Emit the `spartan-resizable-handle-icon` marker class from the helm handle (and the CLI
  template) so the per-style registry rules apply across all styles.
- Make horizontal resizing RTL-aware in the brain: the drag delta is negated when the group is
  horizontal and the ambient direction is `rtl`, so dragging feels correct.
- Enable the theme toggle and `[showOnlyVega]="false"` on the docs page and add a
  `resizable--rtl.example.ts` RTL example.
- Add `brn-resizable-group.spec.ts` asserting the panel-resize direction for LTR and RTL.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Part of the per-component style-support and RTL effort tracked in #1391.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RTL support for resizable components with language-aware direction, plus an RTL preview and code tab on the Resizable page.

* **Style**
  * Refined resizable handle visuals (icon styling, corner radius) and adjusted focus ring/ring-offset behavior.

* **Tests**
  * Added tests validating mirrored horizontal resizing behavior under RTL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->