### PR TITLE
feat(carousel): add style support and rtl example

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(carousel)/carousel--rtl.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(carousel)/carousel--rtl.example.ts
@@ -1,0 +1,57 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { Component, computed, effect, inject, untracked } from '@angular/core';
+import { TranslateService, Translations } from '@spartan-ng/app/app/shared/translate.service';
+import { HlmCardImports } from '@spartan-ng/helm/card';
+import { HlmCarouselImports } from '@spartan-ng/helm/carousel';
+
+@Component({
+	selector: 'spartan-carousel-rtl-preview',
+	imports: [HlmCarouselImports, HlmCardImports],
+	providers: [Directionality],
+	host: {
+		'[dir]': '_dir()',
+	},
+	template: `
+		<div class="flex w-full items-center justify-center p-4">
+			<hlm-carousel class="w-full max-w-xs">
+				<hlm-carousel-content>
+					@for (item of items; track item) {
+						<hlm-carousel-item>
+							<div class="p-1">
+								<section hlmCard>
+									<p hlmCardContent class="flex aspect-square items-center justify-center p-6">
+										<span class="text-4xl font-semibold">{{ _t()['slide'] }} {{ item }}</span>
+									</p>
+								</section>
+							</div>
+						</hlm-carousel-item>
+					}
+				</hlm-carousel-content>
+				<button hlm-carousel-previous></button>
+				<button hlm-carousel-next></button>
+			</hlm-carousel>
+		</div>
+	`,
+})
+export class CarouselRtlPreview {
+	private readonly _directionality = inject(Directionality);
+	private readonly _language = inject(TranslateService).language;
+	public items = Array.from({ length: 5 }, (_, i) => i + 1);
+
+	private readonly _translations: Translations = {
+		en: { dir: 'ltr', values: { slide: 'Slide' } },
+		ar: { dir: 'rtl', values: { slide: 'شريحة' } },
+		he: { dir: 'rtl', values: { slide: 'שקופית' } },
+	};
+
+	private readonly _translation = computed(() => this._translations[this._language()]);
+	protected readonly _t = computed(() => this._translation().values);
+	protected readonly _dir = computed(() => this._translation().dir);
+
+	constructor() {
+		effect(() => {
+			const dir = this._dir();
+			untracked(() => this._directionality.valueSignal.set(dir));
+		});
+	}
+}

--- a/apps/app/src/app/pages/(components)/components/(carousel)/carousel.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(carousel)/carousel.page.ts
@@ -1,6 +1,8 @@
 import type { RouteMeta } from '@analogjs/router';
 import { Component, computed, inject } from '@angular/core';
 import { PrimitiveSnippetsService } from '@spartan-ng/app/app/core/services/primitive-snippets.service';
+import { CodeRtlPreview } from '@spartan-ng/app/app/shared/code/code-rtl-preview';
+import { RtlHeader } from '@spartan-ng/app/app/shared/code/rtl-header';
 import { InstallTabs } from '@spartan-ng/app/app/shared/layout/install-tabs';
 import { SectionSubSubHeading } from '@spartan-ng/app/app/shared/layout/section-sub-sub-heading';
 import { link } from '@spartan-ng/app/app/shared/typography/link';
@@ -18,6 +20,7 @@ import { UIApiDocs } from '../../../../shared/layout/ui-docs-section/ui-docs-sec
 import { metaWith } from '../../../../shared/meta/meta.util';
 import { CarouselOrientation } from './carousel--orientation.example';
 import { CarouselPlugins } from './carousel--plugins.example';
+import { CarouselRtlPreview } from './carousel--rtl.example';
 import { CarouselSizes } from './carousel--sizes.example';
 import { CarouselSlideCount } from './carousel--slide-count.example';
 import { CarouselSpacing } from './carousel--spacing.example';
@@ -51,10 +54,17 @@ export const routeMeta: RouteMeta = {
 		CarouselOrientation,
 		CarouselSlideCount,
 		SectionSubSubHeading,
+		RtlHeader,
+		CodeRtlPreview,
+		CarouselRtlPreview,
 	],
 	template: `
 		<section spartanMainSection>
-			<spartan-section-intro name="Carousel" lead="A carousel with motion and swipe built using Embla." />
+			<spartan-section-intro
+				name="Carousel"
+				lead="A carousel with motion and swipe built using Embla."
+				showThemeToggle
+			/>
 
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
@@ -79,7 +89,7 @@ export const routeMeta: RouteMeta = {
 				wrapper.
 			</p>
 
-			<spartan-install-tabs primitive="carousel" />
+			<spartan-install-tabs primitive="carousel" [showOnlyVega]="false" />
 
 			<spartan-section-sub-heading id="usage">Usage</spartan-section-sub-heading>
 			<div class="mt-6 space-y-4">
@@ -168,6 +178,14 @@ export const routeMeta: RouteMeta = {
 				for more information on using plugins.
 			</p>
 
+			<spartan-header-rtl />
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanRtlCodePreview firstTab>
+					<spartan-carousel-rtl-preview />
+				</div>
+				<spartan-code secondTab [code]="_rtlCode()" />
+			</spartan-tabs>
+
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
 			<spartan-ui-api-docs docType="helm" />
 
@@ -187,6 +205,7 @@ export default class CarouselPage {
 	protected readonly _slideCountCode = computed(() => this._snippets()['slideCount']);
 	protected readonly _pluginsCode = computed(() => this._snippets()['plugins']);
 	protected readonly _orientationCode = computed(() => this._snippets()['orientation']);
+	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 }

--- a/libs/cli/src/generators/ui/libs/carousel/files/lib/hlm-carousel-next.ts.template
+++ b/libs/cli/src/generators/ui/libs/carousel/files/lib/hlm-carousel-next.ts.template
@@ -18,7 +18,7 @@ import { HlmCarousel } from './hlm-carousel';
 		'(click)': '_carousel.scrollNext()',
 	},
 	template: `
-		<ng-icon hlm size="sm" name="lucideArrowRight" />
+		<ng-icon hlm size="sm" name="lucideArrowRight" class="rtl:rotate-180" />
 		<span class="sr-only">Next slide</span>
 	`,
 })
@@ -27,9 +27,9 @@ export class HlmCarouselNext {
 	protected readonly _carousel = inject(HlmCarousel);
 	private readonly _computedClass = computed(() =>
 		hlm(
-			'absolute h-8 w-8 rounded-full',
+			'spartan-carousel-next absolute h-8 w-8',
 			this._carousel.orientation() === 'horizontal'
-				? 'top-1/2 -right-12 -translate-y-1/2'
+				? '-end-12 top-1/2 -translate-y-1/2'
 				: '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
 		),
 	);

--- a/libs/cli/src/generators/ui/libs/carousel/files/lib/hlm-carousel-previous.ts.template
+++ b/libs/cli/src/generators/ui/libs/carousel/files/lib/hlm-carousel-previous.ts.template
@@ -18,7 +18,7 @@ import { HlmCarousel } from './hlm-carousel';
 		'(click)': '_carousel.scrollPrev()',
 	},
 	template: `
-		<ng-icon hlm size="sm" name="lucideArrowLeft" />
+		<ng-icon hlm size="sm" name="lucideArrowLeft" class="rtl:rotate-180" />
 		<span class="sr-only">Previous slide</span>
 	`,
 })
@@ -29,9 +29,9 @@ export class HlmCarouselPrevious {
 
 	private readonly _computedClass = computed(() =>
 		hlm(
-			'absolute h-8 w-8 rounded-full',
+			'spartan-carousel-previous absolute h-8 w-8',
 			this._carousel.orientation() === 'horizontal'
-				? 'top-1/2 -left-12 -translate-y-1/2'
+				? '-start-12 top-1/2 -translate-y-1/2'
 				: '-top-12 left-1/2 -translate-x-1/2 rotate-90',
 		),
 	);

--- a/libs/helm/carousel/src/lib/hlm-carousel-next.ts
+++ b/libs/helm/carousel/src/lib/hlm-carousel-next.ts
@@ -18,7 +18,7 @@ import { HlmCarousel } from './hlm-carousel';
 		'(click)': '_carousel.scrollNext()',
 	},
 	template: `
-		<ng-icon hlm size="sm" name="lucideArrowRight" />
+		<ng-icon hlm size="sm" name="lucideArrowRight" class="rtl:rotate-180" />
 		<span class="sr-only">Next slide</span>
 	`,
 })
@@ -27,9 +27,9 @@ export class HlmCarouselNext {
 	protected readonly _carousel = inject(HlmCarousel);
 	private readonly _computedClass = computed(() =>
 		hlm(
-			'absolute h-8 w-8 rounded-full',
+			'spartan-carousel-next absolute h-8 w-8',
 			this._carousel.orientation() === 'horizontal'
-				? 'top-1/2 -right-12 -translate-y-1/2'
+				? '-end-12 top-1/2 -translate-y-1/2'
 				: '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
 		),
 	);

--- a/libs/helm/carousel/src/lib/hlm-carousel-previous.ts
+++ b/libs/helm/carousel/src/lib/hlm-carousel-previous.ts
@@ -18,7 +18,7 @@ import { HlmCarousel } from './hlm-carousel';
 		'(click)': '_carousel.scrollPrev()',
 	},
 	template: `
-		<ng-icon hlm size="sm" name="lucideArrowLeft" />
+		<ng-icon hlm size="sm" name="lucideArrowLeft" class="rtl:rotate-180" />
 		<span class="sr-only">Previous slide</span>
 	`,
 })
@@ -29,9 +29,9 @@ export class HlmCarouselPrevious {
 
 	private readonly _computedClass = computed(() =>
 		hlm(
-			'absolute h-8 w-8 rounded-full',
+			'spartan-carousel-previous absolute h-8 w-8',
 			this._carousel.orientation() === 'horizontal'
-				? 'top-1/2 -left-12 -translate-y-1/2'
+				? '-start-12 top-1/2 -translate-y-1/2'
 				: '-top-12 left-1/2 -translate-x-1/2 rotate-90',
 		),
 	);

--- a/libs/helm/carousel/src/lib/hlm-carousel.spec.ts
+++ b/libs/helm/carousel/src/lib/hlm-carousel.spec.ts
@@ -1,0 +1,32 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { render } from '@testing-library/angular';
+import { HlmCarousel } from './hlm-carousel';
+import { HlmCarouselContent } from './hlm-carousel-content';
+
+describe('HlmCarousel RTL direction', () => {
+	const setup = async () => {
+		const view = await render(`<hlm-carousel><hlm-carousel-content /></hlm-carousel>`, {
+			imports: [HlmCarousel, HlmCarouselContent],
+		});
+		view.detectChanges();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const carousel = view.fixture.debugElement.query(By.directive(HlmCarousel)).componentInstance as any;
+		return { ...view, carousel };
+	};
+
+	it('defaults embla direction to ltr', async () => {
+		const { carousel } = await setup();
+		expect(carousel._emblaOptions().direction).toBe('ltr');
+	});
+
+	it('follows the ambient layout direction (rtl) so the carousel scrolls right-to-left', async () => {
+		const { carousel, detectChanges } = await setup();
+
+		TestBed.inject(Directionality).valueSignal.set('rtl');
+		detectChanges();
+
+		expect(carousel._emblaOptions().direction).toBe('rtl');
+	});
+});

--- a/libs/helm/carousel/src/lib/hlm-carousel.ts
+++ b/libs/helm/carousel/src/lib/hlm-carousel.ts
@@ -1,9 +1,11 @@
+import { Directionality } from '@angular/cdk/bidi';
 import {
 	ChangeDetectionStrategy,
 	Component,
 	type InputSignal,
 	type Signal,
 	computed,
+	inject,
 	input,
 	signal,
 	viewChild,
@@ -42,6 +44,7 @@ import {
 })
 export class HlmCarousel {
 	protected readonly _emblaCarousel = viewChild.required(EmblaCarouselDirective);
+	private readonly _dir = inject(Directionality);
 
 	public readonly orientation = input<'horizontal' | 'vertical'>('horizontal');
 	public readonly options: InputSignal<Omit<EmblaOptionsType, 'axis'> | undefined> =
@@ -49,6 +52,9 @@ export class HlmCarousel {
 	public readonly plugins: InputSignal<EmblaPluginType[]> = input<EmblaPluginType[]>([]);
 
 	protected readonly _emblaOptions: Signal<EmblaOptionsType> = computed(() => ({
+		// Default embla's direction to the ambient layout direction so the carousel scrolls RTL
+		// automatically; an explicit `direction` in `options` still wins.
+		direction: this._dir.valueSignal(),
 		...this.options(),
 		axis: this.orientation() === 'horizontal' ? 'x' : 'y',
 	}));


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] carousel

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1396

The carousel renders the same in every registry style, the docs page has no theme toggle or RTL
example, and the carousel does not adapt to RTL.

## What is the new behavior?

- Emit the `spartan-carousel-next` / `spartan-carousel-previous` marker classes from the helm
  navigation buttons (and CLI templates) so the per-style registry rules apply across all styles.
- Make the carousel RTL-aware: `hlm-carousel` feeds the ambient direction into embla, the nav
  buttons use logical `-start`/`-end` positioning, and the arrow icons flip with `rtl:rotate-180`.
- Enable the theme toggle and `[showOnlyVega]="false"` on the docs page and add a
  `carousel--rtl.example.ts` RTL example.
- Add `hlm-carousel.spec.ts` asserting embla's direction follows the ambient layout direction.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Part of the per-component style-support and RTL effort tracked in #1391.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Carousel component now supports Right-to-Left (RTL) layouts with automatic direction detection based on document orientation.
  * Previous and next navigation buttons automatically adapt their arrow orientation in RTL mode.
  * New RTL preview examples demonstrate carousel behavior across multiple language directions.
  * Carousel automatically detects and applies appropriate scrolling direction.

* **Tests**
  * Added RTL behavior and direction detection tests for the carousel component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->