### PR TITLE
feat(popover): add style support and rtl example

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(popover)/popover--rtl.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(popover)/popover--rtl.example.ts
@@ -1,0 +1,86 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { Component, computed, effect, inject, untracked } from '@angular/core';
+import { TranslateService, Translations } from '@spartan-ng/app/app/shared/translate.service';
+import { HlmButtonImports } from '@spartan-ng/helm/button';
+import { HlmInputImports } from '@spartan-ng/helm/input';
+import { HlmLabelImports } from '@spartan-ng/helm/label';
+import { HlmPopoverImports } from '@spartan-ng/helm/popover';
+
+@Component({
+	selector: 'spartan-popover-rtl-preview',
+	imports: [HlmPopoverImports, HlmButtonImports, HlmLabelImports, HlmInputImports],
+	providers: [Directionality],
+	host: {
+		class: 'flex w-full justify-center',
+		'[dir]': '_dir()',
+	},
+	template: `
+		<hlm-popover sideOffset="5">
+			<button hlmPopoverTrigger hlmBtn variant="outline">{{ _t()['open'] }}</button>
+			<hlm-popover-content class="grid w-80 gap-4" *hlmPopoverPortal="let ctx">
+				<div class="space-y-2">
+					<h4 class="leading-none font-medium">{{ _t()['title'] }}</h4>
+					<p class="text-muted-foreground text-sm">{{ _t()['description'] }}</p>
+				</div>
+				<div class="grid gap-2">
+					<div class="grid grid-cols-3 items-center gap-4">
+						<label hlmLabel for="width">{{ _t()['width'] }}</label>
+						<input hlmInput id="width" [defaultValue]="'100%'" class="col-span-2 h-8" />
+					</div>
+					<div class="grid grid-cols-3 items-center gap-4">
+						<label hlmLabel for="height">{{ _t()['height'] }}</label>
+						<input hlmInput id="height" [defaultValue]="'25px'" class="col-span-2 h-8" />
+					</div>
+				</div>
+			</hlm-popover-content>
+		</hlm-popover>
+	`,
+})
+export class PopoverRtlPreview {
+	private readonly _directionality = inject(Directionality);
+	private readonly _language = inject(TranslateService).language;
+
+	private readonly _translations: Translations = {
+		en: {
+			dir: 'ltr',
+			values: {
+				open: 'Open popover',
+				title: 'Dimensions',
+				description: 'Set the dimensions for the layer.',
+				width: 'Width',
+				height: 'Height',
+			},
+		},
+		ar: {
+			dir: 'rtl',
+			values: {
+				open: 'افتح النافذة',
+				title: 'الأبعاد',
+				description: 'اضبط أبعاد الطبقة.',
+				width: 'العرض',
+				height: 'الارتفاع',
+			},
+		},
+		he: {
+			dir: 'rtl',
+			values: {
+				open: 'פתח חלון',
+				title: 'מידות',
+				description: 'הגדר את המידות עבור השכבה.',
+				width: 'רוחב',
+				height: 'גובה',
+			},
+		},
+	};
+
+	private readonly _translation = computed(() => this._translations[this._language()]);
+	protected readonly _t = computed(() => this._translation().values);
+	protected readonly _dir = computed(() => this._translation().dir);
+
+	constructor() {
+		effect(() => {
+			const dir = this._dir();
+			untracked(() => this._directionality.valueSignal.set(dir));
+		});
+	}
+}

--- a/apps/app/src/app/pages/(components)/components/(popover)/popover.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(popover)/popover.page.ts
@@ -1,6 +1,9 @@
 import type { RouteMeta } from '@analogjs/router';
 import { Component, computed, inject } from '@angular/core';
 import { PrimitiveSnippetsService } from '@spartan-ng/app/app/core/services/primitive-snippets.service';
+import { PopoverRtlPreview } from '@spartan-ng/app/app/pages/(components)/components/(popover)/popover--rtl.example';
+import { CodeRtlPreview } from '@spartan-ng/app/app/shared/code/code-rtl-preview';
+import { RtlHeader } from '@spartan-ng/app/app/shared/code/rtl-header';
 import { InstallTabs } from '@spartan-ng/app/app/shared/layout/install-tabs';
 import { Code } from '../../../../shared/code/code';
 import { CodePreview } from '../../../../shared/code/code-preview';
@@ -36,10 +39,17 @@ export const routeMeta: RouteMeta = {
 		PageBottomNav,
 		PageBottomNavLink,
 		PopoverPreview,
+		RtlHeader,
+		CodeRtlPreview,
+		PopoverRtlPreview,
 	],
 	template: `
 		<section spartanMainSection>
-			<spartan-section-intro name="Popover" lead="Displays rich content in a portal, triggered by a button." />
+			<spartan-section-intro
+				name="Popover"
+				lead="Displays rich content in a portal, triggered by a button."
+				showThemeToggle
+			/>
 
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
@@ -48,13 +58,21 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_defaultCode()" />
 			</spartan-tabs>
 
-			<spartan-install-tabs primitive="popover" />
+			<spartan-install-tabs primitive="popover" [showOnlyVega]="false" />
 
 			<spartan-section-sub-heading id="usage">Usage</spartan-section-sub-heading>
 			<div class="mt-6 space-y-4">
 				<spartan-code [code]="_defaultImports" />
 				<spartan-code [code]="_defaultSkeleton" />
 			</div>
+
+			<spartan-header-rtl />
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanRtlCodePreview firstTab>
+					<spartan-popover-rtl-preview />
+				</div>
+				<spartan-code secondTab [code]="_rtlCode()" />
+			</spartan-tabs>
 
 			<spartan-section-sub-heading id="brn-api">Brain API</spartan-section-sub-heading>
 			<spartan-ui-api-docs docType="brain" />
@@ -70,9 +88,10 @@ export const routeMeta: RouteMeta = {
 		<spartan-page-nav />
 	`,
 })
-export default class LabelPage {
+export default class PopoverPage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('popover');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
+	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 }

--- a/libs/brain/dialog/src/lib/brn-dialog-options.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog-options.ts
@@ -1,3 +1,4 @@
+import type { Direction } from '@angular/cdk/bidi';
 import type { AutoFocusTarget } from '@angular/cdk/dialog';
 import type {
 	ConnectedPosition,
@@ -17,6 +18,7 @@ export type BrnDialogOptions = {
 	autoFocus: AutoFocusTarget | (Record<never, never> & string);
 	backdropClass: string | string[];
 	closeDelay: number;
+	direction?: Direction;
 	closeOnBackdropClick: boolean;
 	closeOnOutsidePointerEvents: boolean;
 	disableClose: boolean;

--- a/libs/brain/dialog/src/lib/brn-dialog.service.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog.service.ts
@@ -103,6 +103,7 @@ export class BrnDialogService {
 				$implicit: contextOrData,
 			}),
 			data: contextOrData,
+			direction: options?.direction,
 			hasBackdrop: options?.hasBackdrop ?? this._defaultOptions.hasBackdrop,
 			panelClass: options?.panelClass,
 			backdropClass: options?.backdropClass,

--- a/libs/brain/dialog/src/lib/brn-dialog.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog.ts
@@ -1,3 +1,4 @@
+import { Directionality } from '@angular/cdk/bidi';
 import { type BooleanInput, type NumberInput } from '@angular/cdk/coercion';
 import { OverlayPositionBuilder, type ScrollStrategy, ScrollStrategyOptions } from '@angular/cdk/overlay';
 import {
@@ -40,6 +41,7 @@ export class BrnDialog<TResult = unknown, TContext extends Record<string, unknow
 	public readonly positionBuilder = inject(OverlayPositionBuilder);
 	public readonly ssos = inject(ScrollStrategyOptions);
 	private readonly _injector = inject(Injector);
+	private readonly _directionality = inject(Directionality);
 
 	protected readonly _defaultOptions = injectBrnDialogDefaultOptions();
 
@@ -85,6 +87,7 @@ export class BrnDialog<TResult = unknown, TContext extends Record<string, unknow
 
 		return {
 			role: this.role(),
+			direction: this._directionality.valueSignal(),
 			hasBackdrop: this.hasBackdrop(),
 			positionStrategy: this.mutablePositionStrategy(),
 			scrollStrategy,

--- a/libs/cli/src/generators/ui/libs/popover/files/lib/hlm-popover-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/popover/files/lib/hlm-popover-content.ts.template
@@ -18,7 +18,7 @@ export class HlmPopoverContent {
 
 		classes(
 			() =>
-				'border-border bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative flex w-72 flex-col rounded-md border p-4 shadow-md outline-none',
+				'spartan-popover-content data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative flex w-72 flex-col outline-none',
 		);
 	}
 }

--- a/libs/helm/popover/src/lib/hlm-popover-content.ts
+++ b/libs/helm/popover/src/lib/hlm-popover-content.ts
@@ -18,7 +18,7 @@ export class HlmPopoverContent {
 
 		classes(
 			() =>
-				'border-border bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative flex w-72 flex-col rounded-md border p-4 shadow-md outline-none',
+				'spartan-popover-content data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative flex w-72 flex-col outline-none',
 		);
 	}
 }

--- a/libs/helm/popover/src/lib/hlm-popover.spec.ts
+++ b/libs/helm/popover/src/lib/hlm-popover.spec.ts
@@ -1,0 +1,64 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { BrnDialogService } from '@spartan-ng/brain/dialog';
+import { BrnPopover } from '@spartan-ng/brain/popover';
+import { render } from '@testing-library/angular';
+import { HlmPopover } from './hlm-popover';
+import { HlmPopoverContent } from './hlm-popover-content';
+import { HlmPopoverPortal } from './hlm-popover-portal';
+import { HlmPopoverTrigger } from './hlm-popover-trigger';
+
+@Component({
+	selector: 'hlm-popover-direction-host',
+	imports: [HlmPopover, HlmPopoverContent, HlmPopoverPortal, HlmPopoverTrigger],
+	providers: [Directionality],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<hlm-popover>
+			<button hlmPopoverTrigger>open</button>
+			<hlm-popover-content *hlmPopoverPortal="let ctx">
+				<span>content</span>
+			</hlm-popover-content>
+		</hlm-popover>
+	`,
+})
+class PopoverDirectionHost {
+	public readonly directionality = inject(Directionality);
+}
+
+describe('HlmPopover direction', () => {
+	const setup = async (dir: 'ltr' | 'rtl' | null) => {
+		const view = await render(PopoverDirectionHost);
+		const host = view.fixture.componentInstance;
+		const service = TestBed.inject(BrnDialogService);
+		const openSpy = jest.spyOn(service, 'open');
+
+		if (dir) {
+			host.directionality.valueSignal.set(dir);
+		}
+		view.detectChanges();
+
+		const popover = view.fixture.debugElement.query(By.directive(HlmPopover)).injector.get(BrnPopover);
+		popover.open();
+
+		return openSpy;
+	};
+
+	afterEach(() => {
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	it('passes the ambient rtl direction to the opened overlay', async () => {
+		const openSpy = await setup('rtl');
+		expect(openSpy).toHaveBeenCalled();
+		expect(openSpy.mock.calls.at(-1)?.[3]?.direction).toBe('rtl');
+	});
+
+	it('passes ltr to the overlay by default', async () => {
+		const openSpy = await setup(null);
+		expect(openSpy).toHaveBeenCalled();
+		expect(openSpy.mock.calls.at(-1)?.[3]?.direction).toBe('ltr');
+	});
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] popover
- [x] dialog

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1409

The popover content renders the same in every registry style, the docs page has no theme toggle
or RTL example, and the overlay always renders left-to-right because the CDK dialog does not
inherit the trigger's layout direction.

## What is the new behavior?

- Emit the `spartan-popover-content` marker class from the helm content (and the CLI template) so
  the per-style registry rules apply across all styles.
- Make overlays direction-aware in the brain: `BrnDialog` reads the trigger's ambient
  `Directionality` and passes it to the CDK dialog, so popover (and every dialog-based overlay)
  inherits RTL automatically. It defaults to `ltr`, so existing LTR usage is unchanged.
- Enable the theme toggle and `[showOnlyVega]="false"` on the docs page and add a
  `popover--rtl.example.ts` RTL example.
- Add `hlm-popover.spec.ts` asserting the opened overlay receives the ambient direction.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Part of the per-component style-support and RTL effort tracked in #1391. The `BrnDialog` change
is additive (direction defaults to the existing ambient value) and lays the groundwork for RTL on
the other dialog-based overlays (dialog, sheet, menus, tooltip).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added right-to-left (RTL) language support for popover and dialog components
  * Includes multi-language examples with English, Arabic, and Hebrew translations

* **Documentation**
  * Enhanced popover documentation with RTL preview and code examples

* **Tests**
  * Added tests verifying RTL direction handling in popovers

* **Style**
  * Refined popover content styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->