### PR TITLE
feat(tooltip): add style support and rtl example

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip--rtl.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip--rtl.example.ts
@@ -1,0 +1,51 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { Component, computed, effect, inject, untracked } from '@angular/core';
+import { TranslateService, Translations } from '@spartan-ng/app/app/shared/translate.service';
+import { HlmButtonImports } from '@spartan-ng/helm/button';
+import { HlmTooltipImports } from '@spartan-ng/helm/tooltip';
+
+@Component({
+	selector: 'spartan-tooltip-rtl-preview',
+	imports: [HlmButtonImports, HlmTooltipImports],
+	providers: [Directionality],
+	host: {
+		class: 'flex w-full flex-wrap items-center justify-center gap-3',
+		'[dir]': '_dir()',
+	},
+	template: `
+		<button [hlmTooltip]="_t()['save']" position="top" hlmBtn variant="outline">{{ _t()['top'] }}</button>
+		<button [hlmTooltip]="_t()['save']" position="bottom" hlmBtn variant="outline">{{ _t()['bottom'] }}</button>
+		<button [hlmTooltip]="_t()['save']" position="left" hlmBtn variant="outline">{{ _t()['left'] }}</button>
+		<button [hlmTooltip]="_t()['save']" position="right" hlmBtn variant="outline">{{ _t()['right'] }}</button>
+	`,
+})
+export class TooltipRtlPreview {
+	private readonly _directionality = inject(Directionality);
+	private readonly _language = inject(TranslateService).language;
+
+	private readonly _translations: Translations = {
+		en: {
+			dir: 'ltr',
+			values: { save: 'Save your changes', top: 'Top', bottom: 'Bottom', left: 'Left', right: 'Right' },
+		},
+		ar: {
+			dir: 'rtl',
+			values: { save: 'احفظ تغييراتك', top: 'أعلى', bottom: 'أسفل', left: 'يسار', right: 'يمين' },
+		},
+		he: {
+			dir: 'rtl',
+			values: { save: 'שמור את השינויים שלך', top: 'למעלה', bottom: 'למטה', left: 'שמאל', right: 'ימין' },
+		},
+	};
+
+	private readonly _translation = computed(() => this._translations[this._language()]);
+	protected readonly _t = computed(() => this._translation().values);
+	protected readonly _dir = computed(() => this._translation().dir);
+
+	constructor() {
+		effect(() => {
+			const dir = this._dir();
+			untracked(() => this._directionality.valueSignal.set(dir));
+		});
+	}
+}

--- a/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
@@ -4,7 +4,10 @@ import { PrimitiveSnippetsService } from '@spartan-ng/app/app/core/services/prim
 import { TooltipDisabledButtonWithTooltip } from '@spartan-ng/app/app/pages/(components)/components/(tooltip)/tooltip--disabled-button-with-tooltip.example';
 import { TooltipDisabled } from '@spartan-ng/app/app/pages/(components)/components/(tooltip)/tooltip--disabled.example';
 import { TooltipPosition } from '@spartan-ng/app/app/pages/(components)/components/(tooltip)/tooltip--position.example';
+import { TooltipRtlPreview } from '@spartan-ng/app/app/pages/(components)/components/(tooltip)/tooltip--rtl.example';
 import { TooltipTemplate } from '@spartan-ng/app/app/pages/(components)/components/(tooltip)/tooltip--template.example';
+import { CodeRtlPreview } from '@spartan-ng/app/app/shared/code/code-rtl-preview';
+import { RtlHeader } from '@spartan-ng/app/app/shared/code/rtl-header';
 import { InstallTabs } from '@spartan-ng/app/app/shared/layout/install-tabs';
 import { SectionSubSubHeading } from '@spartan-ng/app/app/shared/layout/section-sub-sub-heading';
 import { Code } from '../../../../shared/code/code';
@@ -53,12 +56,16 @@ export const routeMeta: RouteMeta = {
 		TooltipDisabled,
 		TooltipTemplate,
 		TooltipDisabledButtonWithTooltip,
+		RtlHeader,
+		CodeRtlPreview,
+		TooltipRtlPreview,
 	],
 	template: `
 		<section spartanMainSection>
 			<spartan-section-intro
 				name="Tooltip"
 				lead="A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it."
+				showThemeToggle
 			/>
 
 			<spartan-tabs firstTab="Preview" secondTab="Code">
@@ -68,7 +75,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_defaultCode()" />
 			</spartan-tabs>
 
-			<spartan-install-tabs primitive="tooltip" />
+			<spartan-install-tabs primitive="tooltip" [showOnlyVega]="false" />
 
 			<spartan-section-sub-heading id="usage">Usage</spartan-section-sub-heading>
 			<div class="mt-6 space-y-4">
@@ -118,6 +125,14 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_templateCode()" />
 			</spartan-tabs>
 
+			<spartan-header-rtl />
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanRtlCodePreview firstTab>
+					<spartan-tooltip-rtl-preview />
+				</div>
+				<spartan-code secondTab [code]="_rtlCode()" />
+			</spartan-tabs>
+
 			<spartan-section-sub-heading id="brn-api">Brain API</spartan-section-sub-heading>
 			<spartan-ui-api-docs docType="brain" />
 
@@ -140,6 +155,7 @@ export default class TooltipPage {
 	protected readonly _templateCode = computed(() => this._snippets()['template']);
 	protected readonly _disabledCode = computed(() => this._snippets()['disabled']);
 	protected readonly _disabledBtnCode = computed(() => this._snippets()['disabledButtonWithTooltip']);
+	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 }

--- a/libs/cli/src/generators/ui/libs/tooltip/files/lib/hlm-tooltip.ts.template
+++ b/libs/cli/src/generators/ui/libs/tooltip/files/lib/hlm-tooltip.ts.template
@@ -7,7 +7,7 @@ export const DEFAULT_TOOLTIP_SVG_CLASS =
 	'bg-foreground fill-foreground z-50 block size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px]';
 
 export const DEFAULT_TOOLTIP_CONTENT_CLASSES =
-	'bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance';
+	'spartan-tooltip-content bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) text-balance';
 
 export const tooltipPositionVariants = cva('absolute', {
 	variants: {

--- a/libs/helm/tooltip/src/lib/hlm-tooltip.ts
+++ b/libs/helm/tooltip/src/lib/hlm-tooltip.ts
@@ -7,7 +7,7 @@ export const DEFAULT_TOOLTIP_SVG_CLASS =
 	'bg-foreground fill-foreground z-50 block size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px]';
 
 export const DEFAULT_TOOLTIP_CONTENT_CLASSES =
-	'bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance';
+	'spartan-tooltip-content bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) text-balance';
 
 export const tooltipPositionVariants = cva('absolute', {
 	variants: {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] tooltip

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1419

The tooltip content renders the same in every registry style and the docs page has no theme
toggle or RTL example.

## What is the new behavior?

- Emit the `spartan-tooltip-content` marker class from the helm tooltip content config (and the
  CLI template) so the per-style registry rules apply across all styles (e.g. the corner radius
  differs per theme: `vega` 8px, `maia` 18px, `lyra` square, etc.).
- Enable the theme toggle and `[showOnlyVega]="false"` on the docs page and add a
  `tooltip--rtl.example.ts` RTL example (the brain already feeds the ambient `Directionality` to
  the overlay, so the example just provides and pushes the direction).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Part of the per-component style-support and RTL effort tracked in #1391.

The arrow keeps its existing classes from the helm rather than adopting the
`spartan-tooltip-arrow` marker: that registry rule re-applies `rotate-45` at a higher specificity
than the per-position arrow rotations (`rotate-90/180/270`) and would override them. The arrow
renders correctly in every position and in RTL; the only cosmetic difference is the `lyra` arrow
keeps its small rounding instead of becoming sharp. Wiring the arrow marker cleanly needs the
arrow positioning moved onto the `data-[side]` logical rules, which is out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RTL (right-to-left) preview examples for tooltips with support for English, Arabic, and Hebrew languages.
  * Enhanced tooltip content styling with improved animations and state-based transitions for open and close interactions.
  * Updated tooltip documentation to include RTL usage examples and code previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->