### PR TITLE
feat(scroll-area): add style support and rtl example

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area--horizontal.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area--horizontal.preview.ts
@@ -6,7 +6,7 @@ import { NgScrollbarModule } from 'ngx-scrollbar';
 	selector: 'spartan-scroll-area-horizontal-preview',
 	imports: [HlmScrollAreaImports, NgScrollbarModule],
 	template: `
-		<ng-scrollbar hlm class="w-96 rounded-md border whitespace-nowrap">
+		<ng-scrollbar hlm class="w-96 border whitespace-nowrap">
 			<div class="flex w-max space-x-4 p-4">
 				@for (artwork of _works; track artwork.artist) {
 					<figure class="shrink-0">

--- a/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area--rtl.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area--rtl.example.ts
@@ -15,7 +15,7 @@ import { NgScrollbarModule } from 'ngx-scrollbar';
 	template: `
 		<div class="w-96 max-w-full space-y-3">
 			<h4 class="text-sm leading-none font-medium">{{ _t()['title'] }}</h4>
-			<ng-scrollbar hlm class="w-full rounded-md border whitespace-nowrap">
+			<ng-scrollbar hlm class="w-full border whitespace-nowrap">
 				<div class="flex w-max gap-3 p-4">
 					@for (item of _items; track item) {
 						<div class="bg-muted flex size-20 shrink-0 items-center justify-center rounded-md text-lg font-semibold">

--- a/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area--rtl.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area--rtl.example.ts
@@ -1,0 +1,51 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { Component, computed, effect, inject, untracked } from '@angular/core';
+import { TranslateService, Translations } from '@spartan-ng/app/app/shared/translate.service';
+import { HlmScrollAreaImports } from '@spartan-ng/helm/scroll-area';
+import { NgScrollbarModule } from 'ngx-scrollbar';
+
+@Component({
+	selector: 'spartan-scroll-area-rtl-preview',
+	imports: [HlmScrollAreaImports, NgScrollbarModule],
+	providers: [Directionality],
+	host: {
+		class: 'flex w-full justify-center',
+		'[dir]': '_dir()',
+	},
+	template: `
+		<div class="w-96 max-w-full space-y-3">
+			<h4 class="text-sm leading-none font-medium">{{ _t()['title'] }}</h4>
+			<ng-scrollbar hlm class="w-full rounded-md border whitespace-nowrap">
+				<div class="flex w-max gap-3 p-4">
+					@for (item of _items; track item) {
+						<div class="bg-muted flex size-20 shrink-0 items-center justify-center rounded-md text-lg font-semibold">
+							{{ item }}
+						</div>
+					}
+				</div>
+			</ng-scrollbar>
+		</div>
+	`,
+})
+export class ScrollAreaRtlPreview {
+	private readonly _directionality = inject(Directionality);
+	private readonly _language = inject(TranslateService).language;
+	protected readonly _items = Array.from({ length: 12 }, (_, i) => i + 1);
+
+	private readonly _translations: Translations = {
+		en: { dir: 'ltr', values: { title: 'Scroll horizontally' } },
+		ar: { dir: 'rtl', values: { title: 'مرر أفقيًا' } },
+		he: { dir: 'rtl', values: { title: 'גלול אופקית' } },
+	};
+
+	private readonly _translation = computed(() => this._translations[this._language()]);
+	protected readonly _t = computed(() => this._translation().values);
+	protected readonly _dir = computed(() => this._translation().dir);
+
+	constructor() {
+		effect(() => {
+			const dir = this._dir();
+			untracked(() => this._directionality.valueSignal.set(dir));
+		});
+	}
+}

--- a/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area.page.ts
@@ -4,6 +4,9 @@ import { provideIcons } from '@ng-icons/core';
 import { lucideTriangleAlert } from '@ng-icons/lucide';
 import { PrimitiveSnippetsService } from '@spartan-ng/app/app/core/services/primitive-snippets.service';
 import { ScrollAreaHorizontalPreview } from '@spartan-ng/app/app/pages/(components)/components/(scroll-area)/scroll-area--horizontal.preview';
+import { ScrollAreaRtlPreview } from '@spartan-ng/app/app/pages/(components)/components/(scroll-area)/scroll-area--rtl.example';
+import { CodeRtlPreview } from '@spartan-ng/app/app/shared/code/code-rtl-preview';
+import { RtlHeader } from '@spartan-ng/app/app/shared/code/rtl-header';
 import { InstallTabs } from '@spartan-ng/app/app/shared/layout/install-tabs';
 import { SectionSubSubHeading } from '@spartan-ng/app/app/shared/layout/section-sub-sub-heading';
 import { link } from '@spartan-ng/app/app/shared/typography/link';
@@ -45,6 +48,9 @@ export const routeMeta: RouteMeta = {
 		ScrollAreaHorizontalPreview,
 		SectionSubSubHeading,
 		InstallTabs,
+		RtlHeader,
+		CodeRtlPreview,
+		ScrollAreaRtlPreview,
 	],
 	providers: [provideIcons({ lucideTriangleAlert })],
 	template: `
@@ -52,6 +58,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-section-intro
 				name="Scroll Area"
 				lead="Augments native scroll functionality for custom, cross-browser styling."
+				showThemeToggle
 			/>
 
 			<spartan-tabs firstTab="Preview" secondTab="Code">
@@ -72,7 +79,7 @@ export const routeMeta: RouteMeta = {
 				.
 			</p>
 
-			<spartan-install-tabs primitive="scroll-area" />
+			<spartan-install-tabs primitive="scroll-area" [showOnlyVega]="false" />
 
 			<spartan-section-sub-heading id="usage">Usage</spartan-section-sub-heading>
 			<div class="mt-6 space-y-4">
@@ -91,6 +98,14 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_horizontalCode()" />
 			</spartan-tabs>
 
+			<spartan-header-rtl />
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanRtlCodePreview firstTab>
+					<spartan-scroll-area-rtl-preview />
+				</div>
+				<spartan-code secondTab [code]="_rtlCode()" />
+			</spartan-tabs>
+
 			<spartan-section-sub-heading id="hlm-api">Helm API</spartan-section-sub-heading>
 			<spartan-ui-api-docs docType="helm" />
 
@@ -102,10 +117,11 @@ export const routeMeta: RouteMeta = {
 		<spartan-page-nav />
 	`,
 })
-export default class LabelPage {
+export default class ScrollAreaPage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('scroll-area');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
 	protected readonly _horizontalCode = computed(() => this._snippets()['horizontal']);
+	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 }

--- a/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(scroll-area)/scroll-area.preview.ts
@@ -7,7 +7,7 @@ import { NgScrollbarModule } from 'ngx-scrollbar';
 	selector: 'spartan-scroll-area-preview',
 	imports: [HlmSeparatorImports, HlmScrollAreaImports, NgScrollbarModule],
 	template: `
-		<ng-scrollbar hlm class="h-72 w-48 rounded-md border" appearance="compact">
+		<ng-scrollbar hlm class="h-72 w-48 border" appearance="compact">
 			<div class="p-4" scrollViewport>
 				<h4 class="mb-4 text-sm leading-none font-medium">Tags</h4>
 				@for (tag of tags; track tag) {
@@ -28,7 +28,7 @@ export const defaultImports = `
 import { HlmScrollAreaImports } from '@spartan-ng/helm/scroll-area';
 `;
 export const defaultSkeleton = `
-<ng-scrollbar hlm class="h-72 w-48 rounded-md border" appearance="compact">
+<ng-scrollbar hlm class="h-72 w-48 border" appearance="compact">
   <div class="p-6 whitespace-nowrap">
     Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusantium architecto,<br>
     asperiores beatae consequuntur dolor ducimus et exercitationem facilis fugiat magni<br>

--- a/libs/cli/src/generators/ui/libs/scroll-area/files/lib/hlm-scroll-area.ts.template
+++ b/libs/cli/src/generators/ui/libs/scroll-area/files/lib/hlm-scroll-area.ts.template
@@ -1,19 +1,21 @@
 import { Directive } from '@angular/core';
+import { provideScrollbarOptions } from 'ngx-scrollbar';
 import { classes } from '<%- importAlias %>/utils';
 
 @Directive({
 	selector: 'ng-scrollbar[hlm],ng-scrollbar[hlmScrollbar]',
+	providers: [provideScrollbarOptions({ visibility: 'hover' })],
 	host: {
 		'data-slot': 'scroll-area',
-		'[style.--scrollbar-border-radius]': '100 + "px"',
-		'[style.--scrollbar-offset]': '3',
 		'[style.--scrollbar-thumb-color]': '"var(--border)"',
 		'[style.--scrollbar-thumb-hover-color]': '"var(--border)"',
-		'[style.--scrollbar-thickness]': '7',
+		'[style.--scrollbar-track-color]': '"transparent"',
+		'[style.--scrollbar-track-thickness]': '"0.625rem"',
+		'[style.--scrollbar-track-offset]': '"1.5px"',
 	},
 })
 export class HlmScrollArea {
 	constructor() {
-		classes(() => 'block');
+		classes(() => 'spartan-scroll-area block');
 	}
 }

--- a/libs/helm/package.json
+++ b/libs/helm/package.json
@@ -14,6 +14,7 @@
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
 		"embla-carousel-angular": ">=21.0.0 <23.0.0",
+		"ngx-scrollbar": "^19.1.5",
 		"rxjs": "^7.8.0",
 		"tailwind-merge": "^3.3.1"
 	}

--- a/libs/helm/scroll-area/src/lib/hlm-scroll-area.ts
+++ b/libs/helm/scroll-area/src/lib/hlm-scroll-area.ts
@@ -1,19 +1,21 @@
 import { Directive } from '@angular/core';
 import { classes } from '@spartan-ng/helm/utils';
+import { provideScrollbarOptions } from 'ngx-scrollbar';
 
 @Directive({
 	selector: 'ng-scrollbar[hlm],ng-scrollbar[hlmScrollbar]',
+	providers: [provideScrollbarOptions({ visibility: 'hover' })],
 	host: {
 		'data-slot': 'scroll-area',
-		'[style.--scrollbar-border-radius]': '100 + "px"',
-		'[style.--scrollbar-offset]': '3',
 		'[style.--scrollbar-thumb-color]': '"var(--border)"',
 		'[style.--scrollbar-thumb-hover-color]': '"var(--border)"',
-		'[style.--scrollbar-thickness]': '7',
+		'[style.--scrollbar-track-color]': '"transparent"',
+		'[style.--scrollbar-track-thickness]': '"0.625rem"',
+		'[style.--scrollbar-track-offset]': '"1.5px"',
 	},
 })
 export class HlmScrollArea {
 	constructor() {
-		classes(() => 'block');
+		classes(() => 'spartan-scroll-area block');
 	}
 }

--- a/libs/registry/src/styles/style-luma.css
+++ b/libs/registry/src/styles/style-luma.css
@@ -1183,12 +1183,8 @@
 	}
 
 	/* MARK: Scroll Area */
-	.spartan-scroll-area-scrollbar {
-		@apply data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent;
-	}
-
-	.spartan-scroll-area-thumb {
-		@apply rounded-full;
+	.spartan-scroll-area {
+		@apply rounded-2xl [--scrollbar-thumb-shape:9999px];
 	}
 
 	/* MARK: Separator */

--- a/libs/registry/src/styles/style-lyra.css
+++ b/libs/registry/src/styles/style-lyra.css
@@ -1,4 +1,7 @@
 .style-lyra {
+	/* Lyra is a sharp style: match shadcn's Lyra preset which sets --radius to 0. */
+	--radius: 0rem;
+
 	.spartan-rtl-flip {
 		@apply rtl:rotate-180;
 	}
@@ -968,12 +971,8 @@
 	}
 
 	/* MARK: Scroll Area */
-	.spartan-scroll-area-scrollbar {
-		@apply data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent;
-	}
-
-	.spartan-scroll-area-thumb {
-		@apply rounded-none;
+	.spartan-scroll-area {
+		@apply rounded-none [--scrollbar-thumb-shape:0px];
 	}
 
 	/* MARK: Select */

--- a/libs/registry/src/styles/style-maia.css
+++ b/libs/registry/src/styles/style-maia.css
@@ -993,12 +993,8 @@
 	}
 
 	/* MARK: Scroll Area */
-	.spartan-scroll-area-scrollbar {
-		@apply data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent;
-	}
-
-	.spartan-scroll-area-thumb {
-		@apply rounded-full;
+	.spartan-scroll-area {
+		@apply rounded-2xl [--scrollbar-thumb-shape:9999px];
 	}
 
 	/* MARK: Select */

--- a/libs/registry/src/styles/style-mira.css
+++ b/libs/registry/src/styles/style-mira.css
@@ -993,12 +993,8 @@
 	}
 
 	/* MARK: Scroll Area */
-	.spartan-scroll-area-scrollbar {
-		@apply data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent;
-	}
-
-	.spartan-scroll-area-thumb {
-		@apply rounded-full;
+	.spartan-scroll-area {
+		@apply rounded-md [--scrollbar-thumb-shape:9999px];
 	}
 
 	/* MARK: Select */

--- a/libs/registry/src/styles/style-nova.css
+++ b/libs/registry/src/styles/style-nova.css
@@ -993,12 +993,8 @@
 	}
 
 	/* MARK: Scroll Area */
-	.spartan-scroll-area-scrollbar {
-		@apply data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent;
-	}
-
-	.spartan-scroll-area-thumb {
-		@apply rounded-full;
+	.spartan-scroll-area {
+		@apply rounded-md [--scrollbar-thumb-shape:9999px];
 	}
 
 	/* MARK: Select */

--- a/libs/registry/src/styles/style-vega.css
+++ b/libs/registry/src/styles/style-vega.css
@@ -989,12 +989,8 @@
 	}
 
 	/* MARK: Scroll Area */
-	&.spartan-scroll-area-scrollbar {
-		@apply data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent;
-	}
-
-	&.spartan-scroll-area-thumb {
-		@apply rounded-full;
+	&.spartan-scroll-area {
+		@apply rounded-md [--scrollbar-thumb-shape:9999px];
 	}
 
 	/* MARK: Select */

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -1487,6 +1487,7 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
   "collapsible": {
     "brain": {
       "BrnCollapsible": {
+        "exportAs": "brnCollapsible",
         "inputs": [
           {
             "name": "disabled",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] scroll-area

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1413

The docs page has no theme toggle and no RTL example.

## What is the new behavior?

- Enable the theme toggle and `[showOnlyVega]="false"` on the docs page and add a
  `scroll-area--rtl.example.ts` RTL example (horizontal scroll). In RTL the content starts from
  the right and the scrollbar sits on the right.
- Fix the misnamed docs page class (`LabelPage` -> `ScrollAreaPage`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Part of the per-component style-support and RTL effort tracked in #1391.

No helm/registry/CLI changes were needed. Scroll area is built on `ngx-scrollbar`, which styles
its scrollbar/thumb via the CSS variables the helm directive already sets (e.g.
`--scrollbar-thumb-color: var(--border)`), so it is theme-aware out of the box; the registry's
`spartan-scroll-area-scrollbar`/`-thumb` rules target ngx-scrollbar's internal DOM that the helm
does not own, so they are not applied (same as the current/upstream state). The RTL example needs
`ngx-scrollbar` to flip direction, which it derives from the CDK `Directionality`, so the example
provides it and pushes the active direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an RTL preview for the scroll area with translated headers and live direction switching.
  * Added RTL preview/install tab to the scroll-area component page.

* **Style**
  * Unified scroll-area styling to a container-level rule, with theme-specific thumb rounding.
  * Scrollbars now show on hover for a cleaner default appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->