### PR TITLE
feat(data-table): add style support and rtl example

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(data-table)/data-table--rtl.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(data-table)/data-table--rtl.preview.ts
@@ -1,0 +1,103 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { TranslateService, Translations } from '@spartan-ng/app/app/shared/translate.service';
+import { HlmTableImports } from '@spartan-ng/helm/table';
+
+type Payment = {
+	email: string;
+	status: 'success' | 'processing' | 'failed';
+	amount: string;
+};
+
+@Component({
+	selector: 'spartan-data-table-rtl',
+	imports: [HlmTableImports],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'w-full',
+	},
+	template: `
+		<div hlmTableContainer>
+			<table hlmTable [dir]="_dir()">
+				<caption hlmTableCaption>{{ _t()['caption'] }}</caption>
+				<thead hlmTableHeader>
+					<tr hlmTableRow>
+						<th hlmTableHead>{{ _t()['customer'] }}</th>
+						<th hlmTableHead>{{ _t()['status'] }}</th>
+						<th hlmTableHead class="text-end">{{ _t()['amount'] }}</th>
+					</tr>
+				</thead>
+				<tbody hlmTableBody>
+					@for (payment of _payments; track payment.email) {
+						<tr hlmTableRow>
+							<td hlmTableCell class="font-medium">{{ payment.email }}</td>
+							<td hlmTableCell>{{ _t()[payment.status] }}</td>
+							<td hlmTableCell class="text-end">{{ payment.amount }}</td>
+						</tr>
+					}
+				</tbody>
+				<tfoot hlmTableFooter>
+					<tr hlmTableRow>
+						<td hlmTableCell [attr.colSpan]="2">{{ _t()['total'] }}</td>
+						<td hlmTableCell class="text-end">$1,250.00</td>
+					</tr>
+				</tfoot>
+			</table>
+		</div>
+	`,
+})
+export class DataTableRtl {
+	protected readonly _payments: Payment[] = [
+		{ email: 'ken99@example.com', status: 'success', amount: '$316.00' },
+		{ email: 'abe45@example.com', status: 'processing', amount: '$242.00' },
+		{ email: 'monserrat44@example.com', status: 'failed', amount: '$837.00' },
+		{ email: 'carmella@example.com', status: 'success', amount: '$721.00' },
+	];
+
+	private readonly _language = inject(TranslateService).language;
+
+	private readonly _translations: Translations = {
+		en: {
+			dir: 'ltr',
+			values: {
+				caption: 'A list of your recent payments.',
+				customer: 'Customer',
+				status: 'Status',
+				amount: 'Amount',
+				success: 'Success',
+				processing: 'Processing',
+				failed: 'Failed',
+				total: 'Total',
+			},
+		},
+		ar: {
+			dir: 'rtl',
+			values: {
+				caption: 'قائمة بمدفوعاتك الأخيرة.',
+				customer: 'العميل',
+				status: 'الحالة',
+				amount: 'المبلغ',
+				success: 'ناجح',
+				processing: 'قيد المعالجة',
+				failed: 'فشل',
+				total: 'المجموع',
+			},
+		},
+		he: {
+			dir: 'rtl',
+			values: {
+				caption: 'רשימת התשלומים האחרונים שלך.',
+				customer: 'לקוח',
+				status: 'סטטוס',
+				amount: 'סכום',
+				success: 'הצליח',
+				processing: 'בעיבוד',
+				failed: 'נכשל',
+				total: 'סה"כ',
+			},
+		},
+	};
+
+	private readonly _translation = computed(() => this._translations[this._language()]);
+	protected readonly _t = computed(() => this._translation().values);
+	protected readonly _dir = computed(() => this._translation().dir);
+}

--- a/apps/app/src/app/pages/(components)/components/(data-table)/data-table.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(data-table)/data-table.page.ts
@@ -2,6 +2,9 @@ import type { RouteMeta } from '@analogjs/router';
 import { Component, computed, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { PrimitiveSnippetsService } from '@spartan-ng/app/app/core/services/primitive-snippets.service';
+import { DataTableRtl } from '@spartan-ng/app/app/pages/(components)/components/(data-table)/data-table--rtl.preview';
+import { CodeRtlPreview } from '@spartan-ng/app/app/shared/code/code-rtl-preview';
+import { RtlHeader } from '@spartan-ng/app/app/shared/code/rtl-header';
 import { InstallTabs } from '@spartan-ng/app/app/shared/layout/install-tabs';
 import { link } from '@spartan-ng/app/app/shared/typography/link';
 import { hlmCode, hlmP, hlmUl } from '@spartan-ng/helm/typography';
@@ -40,10 +43,17 @@ export const routeMeta: RouteMeta = {
 		PageBottomNavLink,
 		DataTablePreview,
 		RouterLink,
+		RtlHeader,
+		CodeRtlPreview,
+		DataTableRtl,
 	],
 	template: `
 		<section spartanMainSection>
-			<spartan-section-intro name="Data Table" lead="Powerful table and datagrids similar powered by TanStack Table" />
+			<spartan-section-intro
+				name="Data Table"
+				lead="Powerful table and datagrids similar powered by TanStack Table"
+				showThemeToggle
+			/>
 
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
@@ -65,7 +75,7 @@ export const routeMeta: RouteMeta = {
 				directives.
 			</p>
 
-			<spartan-install-tabs primitive="table">
+			<spartan-install-tabs primitive="table" [showOnlyVega]="false">
 				<p class="${hlmP}">
 					Add the
 					<a class="${link}" routerLink="/components/table">Table</a>
@@ -128,6 +138,14 @@ export const routeMeta: RouteMeta = {
 				}
 			</ul>
 
+			<spartan-header-rtl />
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanRtlCodePreview firstTab>
+					<spartan-data-table-rtl />
+				</div>
+				<spartan-code secondTab [code]="_rtlCode()" />
+			</spartan-tabs>
+
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="date-picker" label="Date Picker" />
 				<spartan-page-bottom-nav-link direction="previous" href="context-menu" label="Context Menu" />
@@ -139,6 +157,7 @@ export const routeMeta: RouteMeta = {
 export default class DataTablePage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('data-table');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
+	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] data-table

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1401

The data-table docs page has no theme toggle and no RTL example.

## What is the new behavior?

- Enable the theme toggle and `[showOnlyVega]="false"` on the docs page and add a
  `data-table--rtl.preview.ts` RTL example (a payments table with `[dir]` + `en`/`ar`/`he`
  translations and `text-end` numeric alignment, mirroring the Table RTL example). In RTL the
  columns mirror correctly and numeric cells stay end-aligned.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Part of the per-component style-support and RTL effort tracked in #1391.

No helm/registry/CLI changes were needed: data-table is built on the **Table** directives
(`hlmTable`, `hlmTableHead`, `hlmTableCell`, ...), which already emit the `spartan-table*` marker
classes with full per-style support, so the data-table inherits per-style theming automatically.
This PR is the docs wiring + RTL example only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added right-to-left (RTL) language support for data tables, including Arabic and Hebrew translations.
  * Enabled a theme toggle on the data table page.

* **Documentation**
  * Added an RTL data table preview and corresponding code examples to the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->