### PR TITLE
fix(cli): emit CommonJS so generators load in compat mode

### DIFF
--- a/libs/cli/tsconfig.json
+++ b/libs/cli/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"module": "preserve",
-		"moduleResolution": "bundler"
+		"module": "commonjs",
+		"moduleResolution": "node"
 	},
 	"files": [],
 	"include": [],

--- a/libs/tools/tsconfig.json
+++ b/libs/tools/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"module": "preserve",
+		"module": "commonjs",
 		"resolveJsonModule": true,
 		"esModuleInterop": true,
-		"moduleResolution": "bundler"
+		"moduleResolution": "node"
 	},
 	"files": [],
 	"include": [],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Others

- [x] cli

## What is the current behavior?

Closes #1451

Since `@spartan-ng/cli@0.0.1-alpha.708`, every `ng g @spartan-ng/cli:*` command fails in
compat mode (Angular CLI / Nx) with:

```
Warning: Failed to load the ES module: .../generators/.../compat.js. Make sure to set
"type": "module" in the nearest package.json file or use the .mjs extension.
An unhandled exception occurred: Cannot use import statement outside a module
```

The nx 22 / angular 21 upgrade (#1430) changed `libs/cli/tsconfig.json` from
`module: commonjs` to `module: preserve` with `moduleResolution: bundler`. With `preserve`,
TypeScript keeps the ESM `import`/`export` syntax in the emitted `.js` files, but the
published package still declares `"type": "commonjs"`. Node therefore loads the generator
files (such as `compat.js`) as CommonJS and chokes on the `import` statement. `alpha.707`
was the last build before #1430 and is unaffected.

## What is the new behavior?

`libs/cli/tsconfig.json` is restored to `module: commonjs` (with `moduleResolution: node`)
so the build output matches the package's `"type": "commonjs"` again, and the emitted files
use `require`/`exports`. All `ng g @spartan-ng/cli:*` commands load and run as before.

`libs/tools/tsconfig.json` carries the same `preserve` mismatch and is corrected for
consistency. `tools` is `private` and is loaded from TypeScript source (never published or
`require`d from its build output), so it was not affected at runtime; this is hygiene only.

Verified end to end by reproducing the failure with the published `alpha.708` in a fresh
Angular CLI workspace, then confirming a compat-mode generator loads and completes with the
fixed build. Workspace `lint`, `format:check`, `test`, and `build` all pass.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compiler configuration to use CommonJS module system and Node module resolution strategy across libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->