### PR TITLE
test(cli): add cli-smoke setup-matrix harness (+ carousel, scroll-area & nx-standalone fixes)

### DIFF
--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -1,0 +1,123 @@
+name: cli-smoke
+
+# Verifies the spartan CLI against the full matrix of supported workspace setups (nx/angular-cli x
+# library/entrypoint x buildable). Each cell scaffolds a real workspace, runs the generators, consumes a
+# generated component, and builds it - so the cells are slow individually. We fan each one out to its own
+# runner via the job matrix so they run in parallel from the start of the workflow; wall-clock is roughly
+# the slowest single cell rather than the sum.
+#
+# This runs unconditionally (no path filter) so the `cli-smoke result` job can be a required check that
+# never sits pending. Cheapness on unrelated PRs comes in two layers:
+#   1. A `git diff` gate before `pnpm install` - if nothing CLI-relevant changed, the job goes green in
+#      seconds without installing anything (the common case for unrelated PRs).
+#   2. When it does install, the in-runner isSmokeAffected() check (global-setup + the spec) makes the
+#      precise nx-affected call and still short-circuits to a pass if cli-smoke is not actually affected
+#      (e.g. a global dependency changed but not in a way nx attributes to the CLI). See
+#      apps/cli-smoke/src/support/affected.ts.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+concurrency:
+  group: cli-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      # Don't cancel the other cells when one fails - we want the full picture of which setups broke.
+      fail-fast: false
+      matrix:
+        # Keep in sync with apps/cli-smoke/src/matrix.ts. The drift-guard job below fails CI if a cell
+        # in matrix.ts is missing here.
+        cell:
+          - nx-lib-buildable
+          - nx-lib-nonbuildable
+          - nx-entry-buildable
+          - nx-entry-nonbuildable
+          - nx-standalone
+          - acli
+          - all-components
+    name: ${{ matrix.cell }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      # Sets NX_BASE/NX_HEAD from git history (no install needed - it's a standalone action).
+      - uses: nrwl/nx-set-shas@v5
+      # Cheap gate BEFORE the expensive `pnpm install`: if this push/PR changed nothing that could
+      # affect the CLI, skip the rest of the job (it goes green in seconds). The path list is
+      # deliberately broad - CLI sources plus global dependency/config files - and errs towards running:
+      # when relevant, the in-runner isSmokeAffected() check still makes the precise nx-affected call.
+      - name: Detect CLI-relevant changes
+        id: changes
+        run: |
+          if git diff --name-only "$NX_BASE" "$NX_HEAD" \
+            | grep -qE '^(libs/cli/|libs/brain/|libs/helm/|apps/cli-smoke/|package\.json$|pnpm-lock\.yaml$|nx\.json$|tsconfig\.base\.json$|\.verdaccio/)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No CLI-relevant changes; skipping the smoke run for ${{ matrix.cell }}."
+          fi
+      - uses: ./.github/actions/setup
+        if: steps.changes.outputs.relevant == 'true'
+      # Each cell builds + publishes the packages to its own local verdaccio registry (in globalSetup),
+      # so this is self-contained and not gated on any build job. jest matches the whole test name, so
+      # the trailing space anchors the pattern to this exact cell.
+      - name: smoke (${{ matrix.cell }})
+        if: steps.changes.outputs.relevant == 'true'
+        run: pnpm nx run cli-smoke:smoke --testNamePattern="${{ matrix.cell }} "
+
+  drift-guard:
+    # Runs in parallel with the cells (does not delay them). Fails if matrix.ts declares a cell that the
+    # static matrix above does not cover, so the hardcoded list cannot silently go stale. Only the matrix
+    # source or this workflow can introduce drift, so it installs only when one of those changed.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: nrwl/nx-set-shas@v5
+      - name: Detect matrix changes
+        id: changes
+        run: |
+          if git diff --name-only "$NX_BASE" "$NX_HEAD" \
+            | grep -qE '^(apps/cli-smoke/src/matrix\.ts$|\.github/workflows/cli-smoke\.yml$)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: ./.github/actions/setup
+        if: steps.changes.outputs.relevant == 'true'
+      - name: Ensure the workflow matrix covers every cell in matrix.ts
+        if: steps.changes.outputs.relevant == 'true'
+        run: |
+          CELLS=$(node -e "require('jiti')(process.cwd())('./apps/cli-smoke/src/list-cells')")
+          echo "matrix.ts cells: $CELLS"
+          MISSING=0
+          for cell in $(echo "$CELLS" | jq -r '.[]'); do
+            if ! grep -q "          - ${cell}\$" .github/workflows/cli-smoke.yml; then
+              echo "::error::Cell '${cell}' from apps/cli-smoke/src/matrix.ts is missing from the cli-smoke.yml matrix"
+              MISSING=1
+            fi
+          done
+          exit $MISSING
+
+  result:
+    # Single aggregating check to mark as required in branch protection. Because the workflow always
+    # runs, this always reports a status (it never sits pending), and it is green quickly on PRs that
+    # don't affect the CLI (every cell short-circuits to a pass).
+    name: cli-smoke result
+    needs: [setup-matrix, drift-guard]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all cells and the drift guard passed
+        run: |
+          echo "setup-matrix: ${{ needs.setup-matrix.result }}"
+          echo "drift-guard:  ${{ needs.drift-guard.result }}"
+          [ "${{ needs.setup-matrix.result }}" = "success" ] && [ "${{ needs.drift-guard.result }}" = "success" ]

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -111,6 +111,28 @@ jobs:
       - name: Build
         run: pnpm run build
 
+  cli-smoke:
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: 'pnpm'
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+      # Run the full CLI smoke matrix unconditionally (not just affected) every night.
+      - name: CLI smoke matrix (full)
+        run: pnpm nx run-many -t smoke --parallel=1 --outputStyle=stream
+
   release:
     needs:
       - check_date

--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -1,0 +1,35 @@
+# Verdaccio config used only by the cli-smoke harness' local registry.
+# Locally-built @spartan-ng/* packages are published here; everything else proxies to npmjs.
+# Based on the config the @nx/js:setup-verdaccio generator produces.
+
+# path to a directory with all packages
+storage: ../tmp/local-registry/storage
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    maxage: 60m
+
+packages:
+  '@spartan-ng/*':
+    # Serve only locally-published versions so the e2e workspaces resolve the
+    # freshly built CLI/brain instead of whatever is on npm.
+    access: $all
+    publish: $all
+    unpublish: $all
+
+  '@*/*':
+    access: $all
+    publish: $all
+    unpublish: $all
+    proxy: npmjs
+
+  '**':
+    access: $all
+    publish: $all
+    unpublish: $all
+    proxy: npmjs
+
+# log only warnings/errors to keep CI output readable
+log: { type: stdout, format: pretty, level: warn }

--- a/apps/cli-smoke/README.md
+++ b/apps/cli-smoke/README.md
@@ -1,0 +1,68 @@
+# cli-smoke
+
+Smoke tests that verify the spartan CLI against every supported workspace **setup**, by scaffolding
+real workspaces, running the generators, consuming a generated component, and building the result.
+This catches the class of bug that the in-memory generator unit tests cannot: broken tsconfig path
+mapping, missing dependencies, generated code that does not compile or is not consumable through its
+public alias, secondary-entrypoint wiring, and theme styles that never reach the build output.
+
+They are smoke tests, not full end-to-end tests: they assert the output **compiles, is consumable,
+and builds with themed styles**, but they do not run the app or assert runtime behaviour.
+
+## What it does
+
+1. **global-setup** starts a local [verdaccio](https://verdaccio.org/) registry (the `local-registry`
+   target on the root `spartan` project), then builds and publishes `@spartan-ng/cli` and
+   `@spartan-ng/brain` to it under a forced version (`9999.0.0-smoke.<timestamp>` - unique per run so
+   pnpm's cache can't serve a stale build). They share a version because the CLI writes the
+   `@spartan-ng/brain` dependency at the installed CLI version.
+2. For each cell in [`src/matrix.ts`](./src/matrix.ts) it scaffolds a fresh workspace (in the OS temp
+   dir, not the repo), pins Tailwind v4 via the documented `.postcssrc.json` setup, installs the
+   locally published CLI, writes `components.json`, runs `init` + `ui <component>`, asserts the CLI's
+   own `healthcheck` reports no issues on the generated output, drops in a probe component that
+   **uses** the generated code through the `@spartan-ng/helm/*` alias, then builds and asserts the theme
+   CSS variables reached the output. A generator error, a healthcheck failure, a non-zero build, or
+   missing themed CSS fails the cell.
+3. **global-teardown** stops the registry.
+
+## The matrix
+
+- `nx` monorepo x {`library`, `entrypoint`} x {`buildable`, `non-buildable`}
+- `nx-standalone` - single-app nx workspace with no `tsconfig.base.json`
+- `acli` - Angular CLI, no Nx
+- `all-components` - generates **every** supported primitive into an Angular CLI app and builds them all
+  in one `ng build`; the slowest cell, but fans out to its own runner. Set `nightlyOnly: true` in
+  `src/matrix.ts` to drop it from per-PR CI if it proves too slow.
+
+Tailwind is fixed at v4. Add or remove combinations in `src/matrix.ts`.
+
+## Running
+
+```bash
+# full matrix (also: `pnpm smoke`)
+pnpm nx run cli-smoke:smoke
+
+# a single cell (jest matches the whole test name, so use a substring, not an anchored id)
+pnpm nx run cli-smoke:smoke --testNamePattern="nx-lib-buildable scaffolds"
+```
+
+Each cell installs dependencies and runs a real Angular build, so it is slow; locally the cells run
+single-threaded (one shared local registry). On failure the scaffolded workspace is left under
+`<os-tmp>/spartan-cli-smoke-workspaces/<cell-id>` for inspection; on success it is removed.
+
+## CI
+
+- **`.github/workflows/cli-smoke.yml`** runs the matrix, fanning **each cell out to its own runner** so
+  they run in parallel from the start - wall-clock is roughly the slowest single cell, not the sum.
+  - It runs on **every** push/PR (no path filter) so the `cli-smoke result` job can be a **required
+    check** that never sits pending. Cheapness on unrelated PRs comes in two layers: (1) a `git diff`
+    gate before `pnpm install` skips the job in seconds when nothing CLI-relevant changed; (2) when it
+    does install, the in-runner `isSmokeAffected()` check (`src/support/affected.ts`) makes the precise
+    nx-affected call and still short-circuits to a pass if cli-smoke isn't actually affected.
+    `nrwl/nx-set-shas` provides the base/head both layers use.
+  - A fast `drift-guard` job fails CI if `matrix.ts` grows a cell the workflow's static matrix doesn't
+    list (keep the two in sync).
+  - `cli-smoke result` aggregates the matrix + drift-guard into one status to require in branch
+    protection.
+- **nightly-release.yml** runs the full matrix unconditionally every night (single job; no base/head,
+  so the affected check always runs it).

--- a/apps/cli-smoke/eslint.config.cjs
+++ b/apps/cli-smoke/eslint.config.cjs
@@ -1,0 +1,9 @@
+const baseConfig = require('../../eslint.config.cjs');
+
+module.exports = [
+	...baseConfig,
+	{
+		files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+		rules: {},
+	},
+];

--- a/apps/cli-smoke/jest.config.ts
+++ b/apps/cli-smoke/jest.config.ts
@@ -1,0 +1,16 @@
+export default {
+	displayName: 'cli-smoke',
+	preset: '../../jest.preset.cjs',
+	testEnvironment: 'node',
+	transform: {
+		'^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+	},
+	moduleFileExtensions: ['ts', 'js', 'html'],
+	// Each matrix cell scaffolds a workspace, installs dependencies and runs a real build, so the
+	// suite is slow and must not run in parallel (a single local registry is shared).
+	maxWorkers: 1,
+	testTimeout: 900_000,
+	globalSetup: '<rootDir>/src/support/global-setup.ts',
+	globalTeardown: '<rootDir>/src/support/global-teardown.ts',
+	coverageDirectory: '../../coverage/apps/cli-smoke',
+};

--- a/apps/cli-smoke/project.json
+++ b/apps/cli-smoke/project.json
@@ -1,0 +1,22 @@
+{
+	"name": "cli-smoke",
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/cli-smoke/src",
+	"tags": ["scope:cli-smoke"],
+	"implicitDependencies": ["cli", "brain", "helm"],
+	"targets": {
+		"smoke": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "apps/cli-smoke/jest.config.ts",
+				"runInBand": true
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"]
+		}
+	}
+}

--- a/apps/cli-smoke/src/list-cells.ts
+++ b/apps/cli-smoke/src/list-cells.ts
@@ -1,0 +1,7 @@
+import { setupMatrix } from './matrix';
+
+// Prints the per-PR matrix cell ids as a JSON array, so CI can fan each cell out to its own parallel job
+// without hardcoding the list. Nightly-only cells are excluded - they are not in the PR matrix and the
+// drift-guard checks against this list. Run with:
+//   node -e "require('jiti')(process.cwd())('./apps/cli-smoke/src/list-cells')"
+process.stdout.write(JSON.stringify(setupMatrix.filter((cell) => !cell.nightlyOnly).map((cell) => cell.id)));

--- a/apps/cli-smoke/src/matrix.ts
+++ b/apps/cli-smoke/src/matrix.ts
@@ -1,0 +1,67 @@
+/**
+ * The set of supported workspace setups the CLI must keep working. Each cell drives one real
+ * scaffold -> generate -> build run in the smoke suite. Adding/removing a combination is a one-line
+ * change here.
+ *
+ * Tailwind is fixed at v4 (the supported/documented setup). The v3 axis was intentionally dropped:
+ * v3 is "best effort" in the CLI (it warns about it) and exercising it would make the matrix red by
+ * design rather than catching regressions. Re-add a `tailwind` field here if v3 becomes supported.
+ */
+export type WorkspaceType = 'nx' | 'angular-cli';
+export type GenerateAs = 'library' | 'entrypoint';
+/** nx workspace shape: a classic monorepo (apps/ + libs/, has tsconfig.base.json) or a single-app
+ * standalone workspace (app at root, no tsconfig.base.json until the first lib is created). */
+export type NxLayout = 'monorepo' | 'standalone';
+
+export interface SetupCell {
+	/** Stable id, also used as the temp workspace folder name. */
+	id: string;
+	workspace: WorkspaceType;
+	/** Only meaningful for nx. Defaults to 'monorepo'. */
+	nxLayout?: NxLayout;
+	/** Only meaningful for nx: the angular-cli branch ignores it. */
+	generateAs?: GenerateAs;
+	/** Only meaningful for nx: the angular-cli branch ignores it. */
+	buildable?: boolean;
+	/** Generate every supported primitive instead of the small default set. */
+	allComponents?: boolean;
+	/** Excluded from the per-PR CI matrix (too slow); runs only in the nightly full run. */
+	nightlyOnly?: boolean;
+}
+
+const nxCells: SetupCell[] = (['library', 'entrypoint'] as GenerateAs[]).flatMap((generateAs) =>
+	[true, false].map((buildable) => ({
+		id: `nx-${generateAs === 'library' ? 'lib' : 'entry'}-${buildable ? 'buildable' : 'nonbuildable'}`,
+		workspace: 'nx' as const,
+		generateAs,
+		buildable,
+	})),
+);
+
+// A single-app nx workspace (no tsconfig.base.json initially). Guards that the nx generators resolve the
+// root tsconfig rather than assuming tsconfig.base.json - see libs/cli initialize-angular-library.ts.
+const nxStandaloneCells: SetupCell[] = [
+	{ id: 'nx-standalone', workspace: 'nx', nxLayout: 'standalone', generateAs: 'library', buildable: true },
+];
+
+// For angular-cli the generateAs/buildable axes are dead code (setupAngularCliProject ignores both),
+// so a single cell covers it. Re-add the other axes here if that ever changes.
+const angularCliCells: SetupCell[] = [{ id: 'acli', workspace: 'angular-cli' }];
+
+// Generate every supported primitive and build them all - broad per-component coverage the small default
+// set can't give, so a broken template in any single primitive surfaces here. Uses the angular-cli setup
+// on purpose: the components all land in src/ and `ng build` compiles the lot in one pass, with no nx
+// project graph to serialize (nx hits V8's max-string-length / OOM well before 57 generators). It is the
+// slowest cell; it fans out to its own runner so it does not hold up the others. Set `nightlyOnly: true`
+// to drop it from per-PR CI if it proves too slow.
+const allComponentsCells: SetupCell[] = [{ id: 'all-components', workspace: 'angular-cli', allComponents: true }];
+
+export const setupMatrix: SetupCell[] = [...nxCells, ...nxStandaloneCells, ...angularCliCells, ...allComponentsCells];
+
+/**
+ * Default components generated in every cell. `button` is a standalone primitive; `card` exercises a
+ * multi-part primitive; `calendar` pulls in dependent primitives (button/icon/select) so the
+ * dependent-primitive resolution path is covered too. The all-components cell overrides this with the
+ * full supported set (see workspace.ts).
+ */
+export const componentsUnderTest = ['button', 'card', 'calendar'] as const;

--- a/apps/cli-smoke/src/matrix.ts
+++ b/apps/cli-smoke/src/matrix.ts
@@ -3,9 +3,7 @@
  * scaffold -> generate -> build run in the smoke suite. Adding/removing a combination is a one-line
  * change here.
  *
- * Tailwind is fixed at v4 (the supported/documented setup). The v3 axis was intentionally dropped:
- * v3 is "best effort" in the CLI (it warns about it) and exercising it would make the matrix red by
- * design rather than catching regressions. Re-add a `tailwind` field here if v3 becomes supported.
+ * Tailwind is fixed at v4 (the supported/documented setup).
  */
 export type WorkspaceType = 'nx' | 'angular-cli';
 export type GenerateAs = 'library' | 'entrypoint';

--- a/apps/cli-smoke/src/setup-matrix.spec.ts
+++ b/apps/cli-smoke/src/setup-matrix.spec.ts
@@ -1,0 +1,41 @@
+import { setupMatrix } from './matrix';
+import { isSmokeAffected } from './support/affected';
+import {
+	assertHealthcheckClean,
+	buildWorkspace,
+	cleanupWorkspace,
+	prepareWorkspace,
+	runGenerators,
+	useGeneratedComponents,
+} from './utils/workspace';
+
+// Computed once. When nothing affecting the CLI changed, every cell returns a pass without doing work -
+// global-setup likewise skipped standing up the registry. This lets the workflow be a required check
+// that stays cheap on unrelated PRs. Same git state as global-setup, so the decision matches.
+const affected = isSmokeAffected();
+
+/**
+ * For every supported workspace setup: scaffold a real workspace from the locally published CLI, run
+ * the init + ui generators, consume a generated component in the app, and build it. A generator error,
+ * a generated component that does not compile/consume through its alias, a build failure, or missing
+ * themed CSS in the output all fail the cell.
+ *
+ * On success the temp workspace is removed; on failure it is left on disk under
+ * <os-tmp>/spartan-cli-smoke-workspaces/<cell-id> for inspection.
+ */
+describe('CLI setup matrix', () => {
+	describe.each(setupMatrix)('$id', (cell) => {
+		it('scaffolds, generates, passes healthcheck, consumes components, and builds with themed styles', () => {
+			if (!affected) {
+				console.log(`[cli-smoke] ${cell.id}: skipped (nothing affecting the CLI changed).`);
+				return;
+			}
+			const ws = prepareWorkspace(cell);
+			runGenerators(ws);
+			assertHealthcheckClean(ws);
+			useGeneratedComponents(ws);
+			buildWorkspace(ws);
+			cleanupWorkspace(ws);
+		});
+	});
+});

--- a/apps/cli-smoke/src/support/affected.ts
+++ b/apps/cli-smoke/src/support/affected.ts
@@ -1,0 +1,49 @@
+import { workspaceRoot } from '@nx/devkit';
+import { execSync } from 'node:child_process';
+
+/**
+ * Whether anything affecting the CLI smoke scope changed in this CI run. The `cli-smoke` project
+ * implicitly depends on cli/brain/helm, so nx marks it affected when any of those - or its own files,
+ * or global inputs like the lockfile - change.
+ *
+ * This is what lets the workflow run unconditionally (so it can be a required check) while still being
+ * cheap on unrelated PRs: when nothing relevant changed the runner short-circuits to a pass instead of
+ * scaffolding and building real workspaces.
+ *
+ * Without base/head refs (local runs, or a push where nx-set-shas didn't provide them) we always run -
+ * the conservative default is to verify, never to silently skip.
+ */
+const PROJECT = 'cli-smoke';
+
+export function isSmokeAffected(): boolean {
+	const base = process.env.NX_BASE;
+	const head = process.env.NX_HEAD;
+	if (!base || !head) {
+		return true;
+	}
+
+	try {
+		const affected = showProjects(`--affected --base=${base} --head=${head}`);
+		if (affected.includes(PROJECT)) {
+			return true;
+		}
+
+		// Not in the affected set. Before skipping, make sure that is because nothing relevant changed -
+		// not because the project no longer exists under this name. Otherwise a rename/typo would silently
+		// disable the smoke suite on every PR (only nightly would still run it).
+		if (!showProjects('').includes(PROJECT)) {
+			console.warn(`[cli-smoke] Project "${PROJECT}" not found in the workspace; running rather than skipping.`);
+			return true;
+		}
+
+		return false;
+	} catch (error) {
+		console.warn('[cli-smoke] Could not determine affected projects; running the smoke test anyway.', error);
+		return true;
+	}
+}
+
+function showProjects(flags: string): string[] {
+	const out = execSync(`npx nx show projects ${flags} --json`, { cwd: workspaceRoot, encoding: 'utf-8' });
+	return JSON.parse(out) as string[];
+}

--- a/apps/cli-smoke/src/support/affected.ts
+++ b/apps/cli-smoke/src/support/affected.ts
@@ -1,5 +1,5 @@
 import { workspaceRoot } from '@nx/devkit';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 /**
  * Whether anything affecting the CLI smoke scope changed in this CI run. The `cli-smoke` project
@@ -23,7 +23,7 @@ export function isSmokeAffected(): boolean {
 	}
 
 	try {
-		const affected = showProjects(`--affected --base=${base} --head=${head}`);
+		const affected = showProjects(['--affected', `--base=${base}`, `--head=${head}`]);
 		if (affected.includes(PROJECT)) {
 			return true;
 		}
@@ -31,7 +31,7 @@ export function isSmokeAffected(): boolean {
 		// Not in the affected set. Before skipping, make sure that is because nothing relevant changed -
 		// not because the project no longer exists under this name. Otherwise a rename/typo would silently
 		// disable the smoke suite on every PR (only nightly would still run it).
-		if (!showProjects('').includes(PROJECT)) {
+		if (!showProjects([]).includes(PROJECT)) {
 			console.warn(`[cli-smoke] Project "${PROJECT}" not found in the workspace; running rather than skipping.`);
 			return true;
 		}
@@ -43,7 +43,11 @@ export function isSmokeAffected(): boolean {
 	}
 }
 
-function showProjects(flags: string): string[] {
-	const out = execSync(`npx nx show projects ${flags} --json`, { cwd: workspaceRoot, encoding: 'utf-8' });
+// Pass args as an array (execFileSync, no shell) so NX_BASE/NX_HEAD are never interpreted by a shell.
+function showProjects(args: string[]): string[] {
+	const out = execFileSync('npx', ['nx', 'show', 'projects', ...args, '--json'], {
+		cwd: workspaceRoot,
+		encoding: 'utf-8',
+	});
 	return JSON.parse(out) as string[];
 }

--- a/apps/cli-smoke/src/support/global-setup.ts
+++ b/apps/cli-smoke/src/support/global-setup.ts
@@ -32,7 +32,7 @@ export default async function () {
 	try {
 		buildAndPublishPackages(registry);
 	} catch (error) {
-		stopLocalRegistry();
+		await stopLocalRegistry();
 		throw error;
 	}
 

--- a/apps/cli-smoke/src/support/global-setup.ts
+++ b/apps/cli-smoke/src/support/global-setup.ts
@@ -1,0 +1,40 @@
+import { startLocalRegistry } from '@nx/js/plugins/jest/local-registry';
+import { isSmokeAffected } from './affected';
+import { buildAndPublishPackages, DEFAULT_REGISTRY } from './registry';
+
+/**
+ * Jest globalSetup: stand up a local npm registry, then build and publish the spartan packages to it
+ * so every matrix cell installs the freshly built CLI/brain exactly as a real consumer would.
+ *
+ * First, though, short-circuit when nothing affecting the CLI changed: skip all the heavy work (no
+ * registry, no build/publish) and let the spec pass trivially. This keeps the workflow cheap on
+ * unrelated PRs even though it runs unconditionally (so it can be a required check).
+ */
+export default async function () {
+	if (!isSmokeAffected()) {
+		console.log('[cli-smoke] No changes affect the CLI (cli/brain/helm/cli-smoke); skipping - cells will pass.');
+		return;
+	}
+
+	const stopLocalRegistry = await startLocalRegistry({
+		localRegistryTarget: 'spartan:local-registry',
+		storage: './tmp/local-registry/storage',
+		verbose: false,
+	});
+
+	// Stash the teardown handle for global-teardown (separate module invocation, same process).
+	(globalThis as Record<string, unknown>).__STOP_LOCAL_REGISTRY__ = stopLocalRegistry;
+
+	// startLocalRegistry sets npm_config_registry to the URL verdaccio actually bound to (the requested
+	// port may have been busy), so use that rather than assuming the default.
+	const registry = process.env.npm_config_registry || DEFAULT_REGISTRY;
+
+	try {
+		buildAndPublishPackages(registry);
+	} catch (error) {
+		stopLocalRegistry();
+		throw error;
+	}
+
+	console.log(`[cli-smoke] Local registry ready on ${registry}`);
+}

--- a/apps/cli-smoke/src/support/global-teardown.ts
+++ b/apps/cli-smoke/src/support/global-teardown.ts
@@ -2,6 +2,8 @@
  * Jest globalTeardown: stop the local registry started in global-setup.
  */
 export default async function () {
-	const stop = (globalThis as Record<string, unknown>).__STOP_LOCAL_REGISTRY__ as (() => void) | undefined;
-	stop?.();
+	const stop = (globalThis as Record<string, unknown>).__STOP_LOCAL_REGISTRY__ as
+		| (() => void | Promise<void>)
+		| undefined;
+	await stop?.();
 }

--- a/apps/cli-smoke/src/support/global-teardown.ts
+++ b/apps/cli-smoke/src/support/global-teardown.ts
@@ -1,0 +1,7 @@
+/**
+ * Jest globalTeardown: stop the local registry started in global-setup.
+ */
+export default async function () {
+	const stop = (globalThis as Record<string, unknown>).__STOP_LOCAL_REGISTRY__ as (() => void) | undefined;
+	stop?.();
+}

--- a/apps/cli-smoke/src/support/registry.ts
+++ b/apps/cli-smoke/src/support/registry.ts
@@ -60,15 +60,21 @@ export function buildAndPublishPackages(registry: string): RegistryInfo {
 
 	for (const { dist } of PACKAGES) {
 		const pkgPath = join(workspaceRoot, dist, 'package.json');
-		const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-		pkg.version = version;
-		writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
-
-		console.log(`[cli-smoke] Publishing ${pkg.name}@${version} to ${registry}...`);
-		execSync(`npm publish --registry ${registry} --userconfig ${publishNpmrc} --tag smoke`, {
-			cwd: join(workspaceRoot, dist),
-			stdio: 'inherit',
-		});
+		// Bump the version only for the publish, then restore the original file byte-for-byte so a local
+		// `pnpm smoke` leaves the build artifacts untouched (CI uses a fresh checkout, so it only matters
+		// locally - a dev inspecting dist afterwards would otherwise see the smoke version).
+		const original = readFileSync(pkgPath, 'utf-8');
+		const pkg = JSON.parse(original);
+		writeFileSync(pkgPath, JSON.stringify({ ...pkg, version }, null, 2));
+		try {
+			console.log(`[cli-smoke] Publishing ${pkg.name}@${version} to ${registry}...`);
+			execSync(`npm publish --registry ${registry} --userconfig ${publishNpmrc} --tag smoke`, {
+				cwd: join(workspaceRoot, dist),
+				stdio: 'inherit',
+			});
+		} finally {
+			writeFileSync(pkgPath, original);
+		}
 	}
 
 	const info: RegistryInfo = { registry, version };

--- a/apps/cli-smoke/src/support/registry.ts
+++ b/apps/cli-smoke/src/support/registry.ts
@@ -1,0 +1,82 @@
+import { workspaceRoot } from '@nx/devkit';
+import { execSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+/**
+ * A version that does not exist on the public npm registry, so the smoke workspaces unambiguously
+ * resolve the freshly built packages from the local registry. The CLI writes the `@spartan-ng/brain`
+ * dependency at the *installed CLI version* (see build-dependency-array.ts), so cli and brain MUST be
+ * published under the same version.
+ *
+ * It is unique PER RUN (timestamp suffix): a constant version is fatal here, because pnpm's
+ * content-addressed store + metadata cache key on name@version and would serve a previously published
+ * build of the same version, so changes to cli/brain would silently not be picked up across runs.
+ */
+function newSmokeVersion(): string {
+	return `9999.0.0-smoke.${Date.now()}`;
+}
+
+/** The port the local-registry target requests. Verdaccio may pick another if it is busy, which is why
+ * global-setup reads the actual URL from the registry rather than assuming this one. */
+export const REGISTRY_PORT = 4873;
+export const DEFAULT_REGISTRY = `http://localhost:${REGISTRY_PORT}`;
+
+/** Packages the smoke workspaces consume. `helm` is generated as source by the CLI, not installed. */
+const PACKAGES = [
+	{ project: 'cli', dist: 'dist/libs/cli' },
+	{ project: 'brain', dist: 'dist/libs/brain' },
+] as const;
+
+/** Written by global-setup, read by the spec (globalSetup and workers are separate processes). */
+export const REGISTRY_INFO_FILE = join(workspaceRoot, 'tmp', 'cli-smoke', 'registry.json');
+
+export interface RegistryInfo {
+	registry: string;
+	version: string;
+}
+
+/**
+ * Build and publish the spartan packages to the (already running) local registry.
+ * @param registry the registry URL verdaccio actually bound to - NOT assumed, since it may differ from
+ *   the requested port if that port was busy.
+ */
+export function buildAndPublishPackages(registry: string): RegistryInfo {
+	const version = newSmokeVersion();
+	const projects = PACKAGES.map((p) => p.project).join(',');
+	console.log(`[cli-smoke] Building ${projects}...`);
+	execSync(`pnpm nx run-many -t build -p ${projects} --parallel=1`, {
+		cwd: workspaceRoot,
+		stdio: 'inherit',
+	});
+
+	// Publish with an explicit userconfig npmrc carrying the auth token. We do NOT rely on the global
+	// `npm config set` that startLocalRegistry runs - it can be a no-op in some environments (e.g. a
+	// volta shim), which surfaces as ENEEDAUTH. Verdaccio allows anonymous publish, so any token works.
+	const publishNpmrc = join(dirname(REGISTRY_INFO_FILE), '.npmrc-publish');
+	mkdirSync(dirname(publishNpmrc), { recursive: true });
+	const host = new URL(registry).host;
+	writeFileSync(publishNpmrc, `//${host}/:_authToken=secretVerdaccioToken\nregistry=${registry}\n`);
+
+	for (const { dist } of PACKAGES) {
+		const pkgPath = join(workspaceRoot, dist, 'package.json');
+		const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+		pkg.version = version;
+		writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+
+		console.log(`[cli-smoke] Publishing ${pkg.name}@${version} to ${registry}...`);
+		execSync(`npm publish --registry ${registry} --userconfig ${publishNpmrc} --tag smoke`, {
+			cwd: join(workspaceRoot, dist),
+			stdio: 'inherit',
+		});
+	}
+
+	const info: RegistryInfo = { registry, version };
+	mkdirSync(dirname(REGISTRY_INFO_FILE), { recursive: true });
+	writeFileSync(REGISTRY_INFO_FILE, JSON.stringify(info, null, 2));
+	return info;
+}
+
+export function readRegistryInfo(): RegistryInfo {
+	return JSON.parse(readFileSync(REGISTRY_INFO_FILE, 'utf-8'));
+}

--- a/apps/cli-smoke/src/support/registry.ts
+++ b/apps/cli-smoke/src/support/registry.ts
@@ -1,5 +1,5 @@
 import { workspaceRoot } from '@nx/devkit';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
@@ -68,7 +68,9 @@ export function buildAndPublishPackages(registry: string): RegistryInfo {
 		writeFileSync(pkgPath, JSON.stringify({ ...pkg, version }, null, 2));
 		try {
 			console.log(`[cli-smoke] Publishing ${pkg.name}@${version} to ${registry}...`);
-			execSync(`npm publish --registry ${registry} --userconfig ${publishNpmrc} --tag smoke`, {
+			// Pass args as an array (execFileSync, no shell) so the registry/npmrc values are never
+			// interpreted by a shell.
+			execFileSync('npm', ['publish', '--registry', registry, '--userconfig', publishNpmrc, '--tag', 'smoke'], {
 				cwd: join(workspaceRoot, dist),
 				stdio: 'inherit',
 			});

--- a/apps/cli-smoke/src/utils/workspace.ts
+++ b/apps/cli-smoke/src/utils/workspace.ts
@@ -1,0 +1,316 @@
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { componentsUnderTest, type SetupCell } from '../matrix';
+import { readRegistryInfo, type RegistryInfo } from '../support/registry';
+
+// Read lazily (not at import time): when a cell is skipped because nothing affecting the CLI changed,
+// global-setup never writes registry.json, and this module is still imported by the spec.
+let cachedRegistry: RegistryInfo | undefined;
+function registryInfo(): RegistryInfo {
+	return (cachedRegistry ??= readRegistryInfo());
+}
+
+// Match the workspace's own Angular/Nx versions so scaffolded projects mirror real consumers.
+const rootPkg = require(join(workspaceRootDir(), 'package.json'));
+const NX_VERSION: string = rootPkg.devDependencies?.nx ?? rootPkg.dependencies?.nx ?? 'latest';
+const NG_CLI_VERSION: string = (
+	rootPkg.devDependencies?.['@angular/cli'] ??
+	rootPkg.dependencies?.['@angular/cli'] ??
+	'latest'
+).replace(/^[\^~]/, '');
+
+// Scaffold OUTSIDE the repo: create-nx-workspace/ng new run `git add`, which fails for paths the
+// repo's .gitignore covers, and 700MB+ per workspace should not touch the working tree anyway.
+const TMP_ROOT = join(tmpdir(), 'spartan-cli-smoke-workspaces');
+
+export interface CellWorkspace {
+	cell: SetupCell;
+	dir: string;
+	/** The Angular application project name inside the scaffolded workspace. */
+	app: string;
+	/** Workspace-relative directory the spartan components are generated into. */
+	componentsPath: string;
+	/** nx only: project names present before the spartan generators ran (to identify what they add). */
+	baselineProjects?: string[];
+}
+
+function workspaceRootDir(): string {
+	// apps/cli-smoke/src/utils -> repo root
+	return join(__dirname, '..', '..', '..', '..');
+}
+
+/** Registry + auth env shared by every child process so installs hit the local registry. */
+function execEnv(): NodeJS.ProcessEnv {
+	return {
+		...process.env,
+		npm_config_registry: registryInfo().registry,
+		NPM_CONFIG_REGISTRY: registryInfo().registry,
+		// Make create-nx-workspace/ng fully non-interactive (suppresses the git-provider prompt etc.).
+		CI: 'true',
+		// The all-components cell generates 57 primitives and compiles them in one `ng build`, which
+		// exceeds the 4GB default heap. Raise it for all cells (harmless for the small ones).
+		NODE_OPTIONS: '--max-old-space-size=8192',
+	};
+}
+
+function run(command: string, cwd: string): void {
+	console.log(`[cli-smoke] $ (${cwd}) ${command}`);
+	execSync(command, { cwd, env: execEnv(), stdio: 'inherit' });
+}
+
+function capture(command: string, cwd: string): string {
+	return execSync(command, { cwd, env: execEnv(), encoding: 'utf-8' }).trim();
+}
+
+/** Tag applied to the spartan-generated nx libraries so the build step can target just them. */
+const SPARTAN_TAG = 'scope:spartan-smoke';
+
+/** Scaffold the workspace, pin Tailwind v4, install the CLI, and write components.json. */
+export function prepareWorkspace(cell: SetupCell): CellWorkspace {
+	mkdirSync(TMP_ROOT, { recursive: true });
+	const dir = join(TMP_ROOT, cell.id);
+	rmSync(dir, { recursive: true, force: true });
+
+	const isStandalone = cell.workspace === 'nx' && cell.nxLayout === 'standalone';
+	let app: string;
+	let componentsPath: string;
+
+	if (isStandalone) {
+		// Minimal single-app nx workspace: one app at the workspace root, no tsconfig.base.json (it only
+		// appears once the first lib is generated). This guards that the nx generators resolve the root
+		// tsconfig instead of assuming tsconfig.base.json. `--skipGit` is what makes angular-standalone
+		// non-interactive (otherwise it prompts "Will you be using GitHub as your git hosting provider?").
+		app = cell.id;
+		componentsPath = 'libs/ui';
+		run(
+			`npx --yes create-nx-workspace@${NX_VERSION} ${cell.id} --preset=angular-standalone ` +
+				`--style=css --bundler=esbuild --ssr=false --e2eTestRunner=none --unitTestRunner=none ` +
+				`--nxCloud=skip --skipGit --interactive=false --packageManager=pnpm`,
+			TMP_ROOT,
+		);
+	} else if (cell.workspace === 'nx') {
+		app = 'demo';
+		componentsPath = 'libs/ui';
+		// Classic monorepo. The `angular-monorepo` template is the only preset that gives a classic layout
+		// (with tsconfig.base.json) AND a composite-free TS setup the Angular build accepts - the empty
+		// `apps` preset uses composite project references that fail the Angular build (NG4006). It ships a
+		// sample app we ignore: we generate our own `demo` below and build only that + the spartan libs, so
+		// the sample only costs install time, not build time.
+		run(
+			`npx --yes create-nx-workspace@${NX_VERSION} ${cell.id} --preset=angular-monorepo --appName=sample ` +
+				`--style=css --bundler=esbuild --ssr=false --e2eTestRunner=none --unitTestRunner=none ` +
+				`--nxCloud=skip --no-interactive --packageManager=pnpm`,
+			TMP_ROOT,
+		);
+	} else {
+		app = cell.id;
+		componentsPath = 'src/app/spartan';
+		run(
+			`npx --yes @angular/cli@${NG_CLI_VERSION} new ${cell.id} --style=css --routing=false --ssr=false ` +
+				`--skip-git --skip-tests --package-manager=pnpm --defaults`,
+			TMP_ROOT,
+		);
+	}
+
+	if (!existsSync(dir)) {
+		throw new Error(`Scaffolding ${cell.id} did not produce a workspace at ${dir}`);
+	}
+
+	writeNpmrc(dir);
+
+	if (cell.workspace === 'nx' && !isStandalone) {
+		// @nx/angular ships with the template; generate our own clean app in the classic layout. The
+		// standalone preset already is the app, so this only applies to the monorepo scaffold.
+		run(
+			`npx nx g @nx/angular:application --name=${app} --directory=apps/${app} --style=css --bundler=esbuild ` +
+				`--ssr=false --routing=false --e2eTestRunner=none --unitTestRunner=none --no-interactive`,
+			dir,
+		);
+	}
+
+	writeTailwindConfig(dir);
+	writeComponentsJson(dir, cell, componentsPath);
+
+	// Install the locally published CLI (as a real consumer would) together with Tailwind v4 in a
+	// single pass - separate `pnpm add` calls would each re-resolve the lockfile.
+	run(`pnpm add -D @spartan-ng/cli@${registryInfo().version} tailwindcss@4 @tailwindcss/postcss postcss`, dir);
+
+	// Record the project set before the spartan generators run so the build step can identify and build
+	// exactly the libraries they add, ignoring the template's sample projects.
+	const baselineProjects =
+		cell.workspace === 'nx' ? (JSON.parse(capture(`npx nx show projects --json`, dir)) as string[]) : undefined;
+
+	return { cell, dir, app, componentsPath, baselineProjects };
+}
+
+function writeNpmrc(dir: string): void {
+	const { registry } = registryInfo();
+	writeFileSync(
+		join(dir, '.npmrc'),
+		[
+			`registry=${registry}`,
+			`@spartan-ng:registry=${registry}`,
+			`//${new URL(registry).host}/:_authToken=secretVerdaccioToken`,
+			// npm's strict peer resolution trips over the Angular/brain peer ranges; match the workspace.
+			`legacy-peer-deps=true`,
+			'',
+		].join('\n'),
+	);
+}
+
+/** Tailwind v4 via the Angular CLI PostCSS pipeline - the documented spartan setup. The packages are
+ * installed alongside the CLI (see prepareWorkspace); this only writes the PostCSS config. */
+function writeTailwindConfig(dir: string): void {
+	writeFileSync(
+		join(dir, '.postcssrc.json'),
+		`${JSON.stringify({ plugins: { '@tailwindcss/postcss': {} } }, null, 2)}\n`,
+	);
+}
+
+function writeComponentsJson(dir: string, cell: SetupCell, componentsPath: string): void {
+	const config =
+		cell.workspace === 'nx'
+			? {
+					componentsPath,
+					buildable: cell.buildable,
+					generateAs: cell.generateAs,
+					importAlias: '@spartan-ng/helm',
+				}
+			: { componentsPath, importAlias: '@spartan-ng/helm' };
+	writeFileSync(join(dir, 'components.json'), `${JSON.stringify(config, null, 2)}\n`);
+}
+
+/** Run `init` then `ui` for each component under test, non-interactively. */
+export function runGenerators(ws: CellWorkspace): void {
+	const gen = ws.cell.workspace === 'nx' ? 'npx nx g' : 'npx ng generate';
+	// Tag spartan libs (nx only) so buildWorkspace can build just them, ignoring the template's sample.
+	const tags = ws.cell.workspace === 'nx' ? ` --tags=${SPARTAN_TAG}` : '';
+
+	run(`${gen} @spartan-ng/cli:init --project=${ws.app} --theme=zinc`, ws.dir);
+
+	const components = ws.cell.allComponents ? readAllPrimitives() : [...componentsUnderTest];
+	for (const component of components) {
+		run(`${gen} @spartan-ng/cli:ui ${component} --directory=${ws.componentsPath}${tags}`, ws.dir);
+	}
+}
+
+/** Every supported primitive name, read from the CLI source so the list stays current as primitives are
+ * added (the harness lives in the same repo as the CLI). */
+function readAllPrimitives(): string[] {
+	const file = join(workspaceRootDir(), 'libs', 'cli', 'src', 'generators', 'ui', 'supported-ui-libraries.json');
+	return Object.keys(JSON.parse(readFileSync(file, 'utf-8')));
+}
+
+/**
+ * Run the CLI's own healthcheck against the freshly generated output and fail the cell if it reports any
+ * issue - this catches drift between what the generators emit and what the healthchecks expect. The
+ * auto-fix flag avoids the interactive fix prompt (healthcheck never exits non-zero); the report is
+ * printed before any fix runs, so failures are still visible in the output.
+ *
+ * Flag casing differs by CLI: Angular wants kebab-case (--auto-fix), nx accepts camelCase (--autoFix).
+ */
+export function assertHealthcheckClean(ws: CellWorkspace): void {
+	const isNx = ws.cell.workspace === 'nx';
+	const gen = isNx ? 'npx nx g' : 'npx ng generate';
+	const flags = isNx ? '--autoFix --skipFormat' : '--auto-fix --skip-format';
+	const out = capture(`${gen} @spartan-ng/cli:healthcheck ${flags} 2>&1`, ws.dir);
+	console.log(out);
+	// printReport marks a failed check with "[ ✖ ]" (see libs/cli .../healthcheck/utils/reporter.ts).
+	// Ignore the "Dependency Check": it fetches the latest version from the public npm registry and flags
+	// our local-registry smoke version as "not the latest" - meaningless here, not a generator issue.
+	const failures = out
+		.split('\n')
+		.filter((line) => line.includes('[ ✖ ]'))
+		.filter((line) => !line.includes('Dependency Check'));
+	if (failures.length > 0) {
+		throw new Error(`Healthcheck reported issues on freshly generated output:\n${failures.join('\n')}`);
+	}
+}
+
+/**
+ * A standalone component that imports the generated entrypoints and uses them in a template. Dropping
+ * it into the app's source makes the build compile the generated code *through the public alias* - so
+ * it verifies the alias is genuinely consumable (exports + selectors + templates type-check), not just
+ * that the lib files compile in isolation. In non-buildable nx cells this is what compiles the generated
+ * libs at all (they have no build target). Calendar is imported (so its lib compiles) but not placed in
+ * the template, since it needs date inputs.
+ */
+const PROBE_SOURCE = `import { Component } from '@angular/core';
+import { HlmButtonImports } from '@spartan-ng/helm/button';
+import { HlmCardImports } from '@spartan-ng/helm/card';
+import { HlmCalendarImports } from '@spartan-ng/helm/calendar';
+
+@Component({
+	selector: 'spartan-probe',
+	imports: [...HlmButtonImports, ...HlmCardImports, ...HlmCalendarImports],
+	template: \`
+		<button hlmBtn>Click me</button>
+		<section hlmCard>
+			<h3 hlmCardTitle>Card title</h3>
+		</section>
+	\`,
+})
+export class SpartanProbe {}
+`;
+
+/** Write the probe component into the app source so the build compiles + consumes the generated code.
+ * The nx monorepo app lives under apps/<app>; the nx standalone and angular-cli apps live at the root. */
+export function useGeneratedComponents(ws: CellWorkspace): void {
+	const monorepo = ws.cell.workspace === 'nx' && ws.cell.nxLayout !== 'standalone';
+	const appDir = monorepo ? join('apps', ws.app, 'src', 'app') : join('src', 'app');
+	writeFileSync(join(ws.dir, appDir, 'spartan-probe.ts'), PROBE_SOURCE);
+}
+
+/**
+ * Build the workspace; throws (failing the test) on a non-zero exit. The probe component (written by
+ * useGeneratedComponents) makes the app build compile the generated code through the public alias, so a
+ * broken alias/export/template fails here. After the build we assert the theme styles reached the output.
+ */
+export function buildWorkspace(ws: CellWorkspace): void {
+	if (ws.cell.workspace === 'nx') {
+		// Build our app plus the spartan-generated buildable libs (the component libs in buildable cells,
+		// and the ui-helm parent in entrypoint+buildable cells) - the libs the generators added, diffed
+		// against the baseline. The app build compiles the probe, so the generated libs are compiled via
+		// the alias even in non-buildable cells, where they have no build target of their own.
+		const baseline = new Set(ws.baselineProjects ?? []);
+		const buildable: string[] = JSON.parse(capture(`npx nx show projects --with-target build --json`, ws.dir));
+		const spartanBuildable = buildable.filter((p) => !baseline.has(p));
+		const projects = [ws.app, ...spartanBuildable].join(',');
+		run(`npx nx run-many -t build -p ${projects} --parallel=1`, ws.dir);
+	} else {
+		run(`npx ng build`, ws.dir);
+	}
+
+	assertThemeStylesEmitted(ws);
+}
+
+/**
+ * Assert the theme actually made it into the built CSS. The theme generator writes CSS custom
+ * properties (`--background`, `--primary`, ...) into the styles entry point; if the styles/Tailwind/brain
+ * pipeline is wired correctly they appear in the build output. A clean build that produced no themed CSS
+ * would otherwise pass silently.
+ */
+function assertThemeStylesEmitted(ws: CellWorkspace): void {
+	const distDir = join(ws.dir, 'dist');
+	if (!existsSync(distDir)) {
+		throw new Error(`No dist directory at ${distDir} after build`);
+	}
+
+	const css = readdirSync(distDir, { recursive: true, withFileTypes: true })
+		.filter((entry) => entry.isFile() && entry.name.endsWith('.css'))
+		.map((entry) => readFileSync(join(entry.parentPath, entry.name), 'utf-8'))
+		.join('\n');
+
+	if (!/--(background|foreground|primary|ring|border)\b/.test(css)) {
+		throw new Error(
+			`Theme CSS variables not found in the built CSS under ${distDir}. The theme/Tailwind/brain ` +
+				`pipeline produced no themed styles for this setup.`,
+		);
+	}
+}
+
+export function cleanupWorkspace(ws: CellWorkspace): void {
+	rmSync(ws.dir, { recursive: true, force: true });
+}

--- a/apps/cli-smoke/tsconfig.json
+++ b/apps/cli-smoke/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"module": "commonjs",
+		"moduleResolution": "node"
+	},
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./tsconfig.spec.json"
+		}
+	]
+}

--- a/apps/cli-smoke/tsconfig.spec.json
+++ b/apps/cli-smoke/tsconfig.spec.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"module": "commonjs",
+		"types": ["jest", "node"],
+		"resolveJsonModule": true,
+		"moduleResolution": "node",
+		"esModuleInterop": true,
+		"isolatedModules": true
+	},
+	"include": ["jest.config.ts", "src/**/*.ts"]
+}

--- a/libs/cli/src/generators/base/generator.ts
+++ b/libs/cli/src/generators/base/generator.ts
@@ -8,7 +8,7 @@ import {
 	updateJson,
 	visitNotIgnoredFiles,
 } from '@nx/devkit';
-import { addTsConfigPath } from '@nx/js';
+import { addTsConfigPath, getRootTsConfigPathInTree } from '@nx/js';
 import * as path from 'node:path';
 
 import { readTsConfigPathsFromTree } from '../../utils/tsconfig';
@@ -63,7 +63,9 @@ async function generateEntrypointFiles(tree: Tree, alias: string, options: HlmBa
 			skipModule: true,
 		});
 	} else {
-		updateJson(tree, 'tsconfig.base.json', (json) => {
+		// Resolve the workspace's root tsconfig rather than assuming tsconfig.base.json - a standalone nx
+		// workspace registers paths in tsconfig.json (there is no base file).
+		updateJson(tree, getRootTsConfigPathInTree(tree), (json) => {
 			json.compilerOptions ||= {};
 			json.compilerOptions.paths ||= {};
 			json.compilerOptions.paths[alias] = [`./${joinPathFragments(targetLibDir, 'index.ts').replace(/\\/g, '/')}`];

--- a/libs/cli/src/generators/base/lib/initialize-angular-library.ts
+++ b/libs/cli/src/generators/base/lib/initialize-angular-library.ts
@@ -12,10 +12,11 @@ function addRulesToEslintOverride(tree: Tree, libRoot: string, filePattern: stri
 
 	const eslintFullPath = path.join(process.cwd(), eslintPath);
 
-	const project = new Project({
-		tsConfigFilePath: path.join(process.cwd(), 'tsconfig.base.json'),
-		skipAddingFilesFromTsConfig: true,
-	});
+	// Don't tie ts-morph to a specific on-disk tsconfig. During generation the root tsconfig may not be
+	// on disk yet - e.g. in a standalone nx workspace where @nx/angular:library has only just created
+	// tsconfig.base.json in the virtual tree - and pointing at a missing file throws "File not found".
+	// We only manipulate the eslint config's AST, so no tsconfig project context is needed.
+	const project = new Project({ useInMemoryFileSystem: true });
 
 	const sourceFile = project.createSourceFile(eslintFullPath, tree.read(eslintPath, 'utf-8')!, { overwrite: true });
 

--- a/libs/cli/src/generators/init/compat.ts
+++ b/libs/cli/src/generators/init/compat.ts
@@ -1,4 +1,7 @@
 import { convertNxGenerator, type Tree } from '@nx/devkit';
 import { spartanInitGenerator } from './generator';
+import type { SpartanInitGeneratorSchema } from './schema';
 
-export default convertNxGenerator((tree: Tree) => spartanInitGenerator(tree));
+export default convertNxGenerator((tree: Tree, options: SpartanInitGeneratorSchema) =>
+	spartanInitGenerator(tree, options),
+);

--- a/libs/cli/src/generators/init/generator.ts
+++ b/libs/cli/src/generators/init/generator.ts
@@ -4,8 +4,9 @@ import { buildDependencyArray, buildDevDependencyArray } from '../base/lib/build
 import type { HlmBaseGeneratorSchema } from '../base/schema';
 import { FALLBACK_ANGULAR_CDK_VERSION } from '../base/versions';
 import addThemeToApplicationGenerator from '../theme/generator';
+import type { SpartanInitGeneratorSchema } from './schema';
 
-export async function spartanInitGenerator(tree: Tree) {
+export async function spartanInitGenerator(tree: Tree, options: SpartanInitGeneratorSchema = {}) {
 	logger.info('Initializing Spartan UI Library...');
 
 	const cdkVersionStr = getInstalledPackageVersion(tree, '@angular/cdk', FALLBACK_ANGULAR_CDK_VERSION, true);
@@ -19,7 +20,7 @@ export async function spartanInitGenerator(tree: Tree) {
 		tasks.push(addDependenciesToPackageJson(tree, dependencies, devDependencies));
 	}
 
-	await addThemeToApplicationGenerator(tree, true);
+	await addThemeToApplicationGenerator(tree, { ...options, setupTailwindCss: true });
 
 	return runTasksInSerial(...tasks);
 }

--- a/libs/cli/src/generators/init/schema.d.ts
+++ b/libs/cli/src/generators/init/schema.d.ts
@@ -2,5 +2,5 @@ import type { HlmThemeGeneratorSchema } from '../theme/schema';
 
 export type SpartanInitGeneratorSchema = Pick<
 	HlmThemeGeneratorSchema,
-	'project' | 'theme' | 'stylesEntryPoint' | 'prefix' | 'acceptTailwindV3'
+	'project' | 'theme' | 'stylesEntryPoint' | 'prefix'
 >;

--- a/libs/cli/src/generators/init/schema.d.ts
+++ b/libs/cli/src/generators/init/schema.d.ts
@@ -1,0 +1,6 @@
+import type { HlmThemeGeneratorSchema } from '../theme/schema';
+
+export type SpartanInitGeneratorSchema = Pick<
+	HlmThemeGeneratorSchema,
+	'project' | 'theme' | 'stylesEntryPoint' | 'prefix' | 'acceptTailwindV3'
+>;

--- a/libs/cli/src/generators/init/schema.json
+++ b/libs/cli/src/generators/init/schema.json
@@ -20,10 +20,6 @@
 		"prefix": {
 			"type": "string",
 			"description": "Prefix class name applied to the theme's style definitions, e.g. theme-zinc. Leave empty for a global theme."
-		},
-		"acceptTailwindV3": {
-			"type": "boolean",
-			"description": "Skip the interactive Tailwind v3 compatibility warning and proceed. Defaults to true when a theme is passed."
 		}
 	},
 	"required": []

--- a/libs/cli/src/generators/init/schema.json
+++ b/libs/cli/src/generators/init/schema.json
@@ -3,6 +3,28 @@
 	"$id": "Init",
 	"title": "Initialize Spartan in your project",
 	"type": "object",
-	"properties": {},
+	"properties": {
+		"project": {
+			"type": "string",
+			"description": "The application to add the theme to. If omitted you will be prompted to choose one."
+		},
+		"theme": {
+			"type": "string",
+			"enum": ["neutral", "stone", "zinc", "gray", "slate"],
+			"description": "The theme to apply. Passing this runs the generator non-interactively (no prompts)."
+		},
+		"stylesEntryPoint": {
+			"type": "string",
+			"description": "Path to the styles entry point relative to the workspace root. Auto-detected when omitted."
+		},
+		"prefix": {
+			"type": "string",
+			"description": "Prefix class name applied to the theme's style definitions, e.g. theme-zinc. Leave empty for a global theme."
+		},
+		"acceptTailwindV3": {
+			"type": "boolean",
+			"description": "Skip the interactive Tailwind v3 compatibility warning and proceed. Defaults to true when a theme is passed."
+		}
+	},
 	"required": []
 }

--- a/libs/cli/src/generators/theme/generator.spec.ts
+++ b/libs/cli/src/generators/theme/generator.spec.ts
@@ -1,7 +1,9 @@
 import { applicationGenerator, E2eTestRunner, UnitTestRunner } from '@nx/angular/generators';
 import { readProjectConfiguration, type Tree, updateJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
+import addThemeToApplicationGenerator from './generator';
 import { addThemeToApplicationStyles } from './libs/add-theme-to-application-styles';
+import type { ThemeName } from './libs/colors';
 
 jest.mock('enquirer');
 jest.mock('@nx/devkit', () => {
@@ -94,5 +96,60 @@ describe('Theme generator', () => {
 		);
 		const styles = tree.read('website/src/styles.css', 'utf8');
 		expect(styles).toContain('.theme-zinc');
+	});
+});
+
+describe('addThemeToApplicationGenerator (non-interactive)', () => {
+	let tree: Tree;
+
+	const addApp = (name: string) =>
+		applicationGenerator(tree, {
+			name,
+			directory: name,
+			skipFormat: true,
+			e2eTestRunner: E2eTestRunner.None,
+			unitTestRunner: UnitTestRunner.None,
+			skipPackageJson: true,
+			skipTests: true,
+		});
+
+	beforeEach(async () => {
+		jest.clearAllMocks();
+		tree = createTreeWithEmptyWorkspace();
+		await addApp('website');
+		updateJson(tree, 'package.json', (json) => {
+			json.devDependencies = { ...json.devDependencies, tailwindcss: '^4.0.0' };
+			return json;
+		});
+		tree.write('website/src/styles.css', '@import "tailwindcss";');
+	});
+
+	// Non-interactive mode must not prompt. We assert that indirectly: a stray prompt would (under the
+	// enquirer mock) resolve the theme to undefined and no theme variables would be written.
+	it('applies the theme when a theme and project are provided', async () => {
+		await addThemeToApplicationGenerator(tree, { theme: 'zinc', project: 'website' });
+		expect(tree.read('website/src/styles.css', 'utf8')).toContain('--background');
+	});
+
+	it('auto-selects the only application when no project is given', async () => {
+		await addThemeToApplicationGenerator(tree, { theme: 'zinc' });
+		expect(tree.read('website/src/styles.css', 'utf8')).toContain('--background');
+	});
+
+	it('throws on an invalid theme', async () => {
+		await expect(
+			addThemeToApplicationGenerator(tree, { theme: 'not-a-theme' as unknown as ThemeName, project: 'website' }),
+		).rejects.toThrow(/not valid/);
+	});
+
+	it('throws on an unknown project', async () => {
+		await expect(addThemeToApplicationGenerator(tree, { theme: 'zinc', project: 'ghost' })).rejects.toThrow(
+			/not an application/,
+		);
+	});
+
+	it('throws when multiple applications exist and no project is given', async () => {
+		await addApp('second');
+		await expect(addThemeToApplicationGenerator(tree, { theme: 'zinc' })).rejects.toThrow(/Could not determine/);
 	});
 });

--- a/libs/cli/src/generators/theme/generator.ts
+++ b/libs/cli/src/generators/theme/generator.ts
@@ -91,7 +91,6 @@ export default async function addThemeToApplicationGenerator(tree: Tree, options
 			theme: theme as ThemeName,
 			stylesEntryPoint,
 			prefix,
-			acceptTailwindV3: options.acceptTailwindV3 ?? nonInteractive,
 		},
 		project,
 	);

--- a/libs/cli/src/generators/theme/generator.ts
+++ b/libs/cli/src/generators/theme/generator.ts
@@ -3,58 +3,95 @@ import { prompt } from 'enquirer';
 import { getProjectsAndNames } from '../../utils/get-project-names';
 import { addThemeToApplicationStyles } from './libs/add-theme-to-application-styles';
 import { type ThemeName, themeNames } from './libs/colors';
+import type { HlmThemeGeneratorSchema } from './schema';
 
-export default async function addThemeToApplicationGenerator(tree: Tree, setupTailwindCss = false) {
+export default async function addThemeToApplicationGenerator(tree: Tree, options: HlmThemeGeneratorSchema = {}) {
+	const setupTailwindCss = options.setupTailwindCss ?? true;
+	// Passing a theme opts into non-interactive mode: every remaining answer falls back to a sensible
+	// default (auto-detected styles entry point, global theme) instead of prompting. This lets the CLI be
+	// driven by flags (`ng g @spartan-ng/cli:ui-theme --theme=zinc`) and scripted in CI.
+	const nonInteractive = !!options.theme;
+
 	const { projects, projectNames } = getProjectsAndNames(tree);
 
-	const response: { app: string } = await prompt({
-		type: 'select',
-		required: true,
-		name: 'app',
-		message: 'Choose which application you want to add the theme to:',
-		choices: projectNames,
-	});
-	const project: ProjectConfiguration | undefined = projects.get(response.app);
+	let app = options.project;
+	if (app && !projectNames.includes(app)) {
+		throw new Error(
+			`The provided project "${app}" is not an application in this workspace. Choose one of: ${projectNames.join(', ')}.`,
+		);
+	}
+	if (!app) {
+		if (nonInteractive) {
+			if (projectNames.length === 1) {
+				app = projectNames[0];
+			} else {
+				throw new Error(
+					`Could not determine which application to add the theme to. Pass "--project" to choose one of: ${projectNames.join(
+						', ',
+					)}.`,
+				);
+			}
+		} else {
+			const response: { app: string } = await prompt({
+				type: 'select',
+				required: true,
+				name: 'app',
+				message: 'Choose which application you want to add the theme to:',
+				choices: projectNames,
+			});
+			app = response.app;
+		}
+	}
 
+	const project: ProjectConfiguration | undefined = projects.get(app);
 	if (!project) return;
 
-	const themeOptions: {
-		theme: ThemeName;
-		addCdkStyles: boolean;
-		stylesEntryPoint?: string;
-		prefix?: string;
-	} = await prompt([
-		{
-			type: 'select',
-			required: true,
-			name: 'theme',
-			message:
-				'Choose which theme to apply. You can always re-run this generator and add a custom prefix to add other themes.',
-			choices: themeNames,
-		},
-		{
-			type: 'input',
-			name: 'stylesEntryPoint',
-			message:
-				"Path to the styles entry point relative to the workspace root. If not provided the generator will do its best to find it and it will error if it can't.",
-		},
-		{
-			type: 'input',
-			name: 'prefix',
-			message:
-				"Prefix class name applied to your theme's style definitions: e.g., theme-zinc. Leave empty for global theme.",
-		},
-	]);
+	let theme = options.theme;
+	if (theme && !themeNames.includes(theme)) {
+		throw new Error(`The provided theme "${theme}" is not valid. Valid themes are: ${themeNames.join(', ')}.`);
+	}
+
+	let stylesEntryPoint = options.stylesEntryPoint;
+	let prefix = options.prefix;
+
+	if (!nonInteractive) {
+		const answers: { theme?: ThemeName; stylesEntryPoint?: string; prefix?: string } = await prompt([
+			{
+				type: 'select',
+				required: true,
+				name: 'theme',
+				message:
+					'Choose which theme to apply. You can always re-run this generator and add a custom prefix to add other themes.',
+				choices: themeNames,
+			},
+			{
+				type: 'input',
+				name: 'stylesEntryPoint',
+				message:
+					"Path to the styles entry point relative to the workspace root. If not provided the generator will do its best to find it and it will error if it can't.",
+			},
+			{
+				type: 'input',
+				name: 'prefix',
+				message:
+					"Prefix class name applied to your theme's style definitions: e.g., theme-zinc. Leave empty for global theme.",
+			},
+		]);
+
+		theme = answers.theme;
+		stylesEntryPoint = answers.stylesEntryPoint;
+		prefix = answers.prefix;
+	}
 
 	await addThemeToApplicationStyles(
 		tree,
 		{
 			setupTailwindCss,
 			project: project.name,
-			theme: themeOptions.theme,
-			addCdkStyles: themeOptions.addCdkStyles,
-			stylesEntryPoint: themeOptions.stylesEntryPoint,
-			prefix: themeOptions.prefix,
+			theme: theme as ThemeName,
+			stylesEntryPoint,
+			prefix,
+			acceptTailwindV3: options.acceptTailwindV3 ?? nonInteractive,
 		},
 		project,
 	);

--- a/libs/cli/src/generators/theme/libs/add-theme-to-application-styles.ts
+++ b/libs/cli/src/generators/theme/libs/add-theme-to-application-styles.ts
@@ -13,8 +13,6 @@ export interface AddThemeToApplicationStylesOptions {
 	stylesEntryPoint?: string;
 	prefix?: string;
 	setupTailwindCss?: boolean;
-	/** Skip the interactive Tailwind v3 compatibility warning and proceed. */
-	acceptTailwindV3?: boolean;
 }
 
 export async function addThemeToApplicationStyles(
@@ -23,7 +21,7 @@ export async function addThemeToApplicationStyles(
 	project: ProjectConfiguration,
 ): Promise<void> {
 	const tailwindVersion = getTailwindVersion(tree);
-	if (tailwindVersion === 3 && !options.acceptTailwindV3) {
+	if (tailwindVersion === 3) {
 		await prompt({
 			type: 'confirm',
 			name: 'Tailwind 3 detected',

--- a/libs/cli/src/generators/theme/libs/add-theme-to-application-styles.ts
+++ b/libs/cli/src/generators/theme/libs/add-theme-to-application-styles.ts
@@ -9,10 +9,12 @@ import { legacyThemes, type ThemeName, themes } from './colors';
 export interface AddThemeToApplicationStylesOptions {
 	project: string;
 	theme: ThemeName;
-	addCdkStyles: boolean;
+	addCdkStyles?: boolean;
 	stylesEntryPoint?: string;
 	prefix?: string;
 	setupTailwindCss?: boolean;
+	/** Skip the interactive Tailwind v3 compatibility warning and proceed. */
+	acceptTailwindV3?: boolean;
 }
 
 export async function addThemeToApplicationStyles(
@@ -21,7 +23,7 @@ export async function addThemeToApplicationStyles(
 	project: ProjectConfiguration,
 ): Promise<void> {
 	const tailwindVersion = getTailwindVersion(tree);
-	if (tailwindVersion === 3) {
+	if (tailwindVersion === 3 && !options.acceptTailwindV3) {
 		await prompt({
 			type: 'confirm',
 			name: 'Tailwind 3 detected',

--- a/libs/cli/src/generators/theme/schema.d.ts
+++ b/libs/cli/src/generators/theme/schema.d.ts
@@ -11,6 +11,9 @@ export interface HlmThemeGeneratorSchema {
 	prefix?: string;
 	/** Skip the Tailwind v3 compatibility warning. Defaults to true when a theme is supplied. */
 	acceptTailwindV3?: boolean;
-	/** Whether to also wire up the Tailwind CSS imports. Defaults to true. */
+	/**
+	 * Whether to also wire up the Tailwind CSS imports. Defaults to true. Internal only: set by the `init`
+	 * generator, so it is intentionally not exposed as a flag in schema.json.
+	 */
 	setupTailwindCss?: boolean;
 }

--- a/libs/cli/src/generators/theme/schema.d.ts
+++ b/libs/cli/src/generators/theme/schema.d.ts
@@ -9,8 +9,6 @@ export interface HlmThemeGeneratorSchema {
 	stylesEntryPoint?: string;
 	/** Prefix class name applied to the theme's styles, e.g. theme-zinc. Empty means a global theme. */
 	prefix?: string;
-	/** Skip the Tailwind v3 compatibility warning. Defaults to true when a theme is supplied. */
-	acceptTailwindV3?: boolean;
 	/**
 	 * Whether to also wire up the Tailwind CSS imports. Defaults to true. Internal only: set by the `init`
 	 * generator, so it is intentionally not exposed as a flag in schema.json.

--- a/libs/cli/src/generators/theme/schema.d.ts
+++ b/libs/cli/src/generators/theme/schema.d.ts
@@ -1,0 +1,16 @@
+import type { ThemeName } from './libs/colors';
+
+export interface HlmThemeGeneratorSchema {
+	/** The application to add the theme to. Prompted for when omitted (interactive mode). */
+	project?: string;
+	/** The theme to apply. Passing this opts the generator into non-interactive mode. */
+	theme?: ThemeName;
+	/** Path to the styles entry point relative to the workspace root. Auto-detected when omitted. */
+	stylesEntryPoint?: string;
+	/** Prefix class name applied to the theme's styles, e.g. theme-zinc. Empty means a global theme. */
+	prefix?: string;
+	/** Skip the Tailwind v3 compatibility warning. Defaults to true when a theme is supplied. */
+	acceptTailwindV3?: boolean;
+	/** Whether to also wire up the Tailwind CSS imports. Defaults to true. */
+	setupTailwindCss?: boolean;
+}

--- a/libs/cli/src/generators/theme/schema.json
+++ b/libs/cli/src/generators/theme/schema.json
@@ -20,10 +20,6 @@
 		"prefix": {
 			"type": "string",
 			"description": "Prefix class name applied to the theme's style definitions, e.g. theme-zinc. Leave empty for a global theme."
-		},
-		"acceptTailwindV3": {
-			"type": "boolean",
-			"description": "Skip the interactive Tailwind v3 compatibility warning and proceed. Defaults to true when a theme is passed."
 		}
 	}
 }

--- a/libs/cli/src/generators/theme/schema.json
+++ b/libs/cli/src/generators/theme/schema.json
@@ -3,5 +3,27 @@
 	"$id": "HlmThemeGeneratorSchema",
 	"title": "",
 	"type": "object",
-	"properties": {}
+	"properties": {
+		"project": {
+			"type": "string",
+			"description": "The application to add the theme to. If omitted you will be prompted to choose one."
+		},
+		"theme": {
+			"type": "string",
+			"enum": ["neutral", "stone", "zinc", "gray", "slate"],
+			"description": "The theme to apply. Passing this runs the generator non-interactively (no prompts)."
+		},
+		"stylesEntryPoint": {
+			"type": "string",
+			"description": "Path to the styles entry point relative to the workspace root. Auto-detected when omitted."
+		},
+		"prefix": {
+			"type": "string",
+			"description": "Prefix class name applied to the theme's style definitions, e.g. theme-zinc. Leave empty for a global theme."
+		},
+		"acceptTailwindV3": {
+			"type": "boolean",
+			"description": "Skip the interactive Tailwind v3 compatibility warning and proceed. Defaults to true when a theme is passed."
+		}
+	}
 }

--- a/libs/cli/src/generators/ui/libs/carousel/files/lib/hlm-carousel.ts.template
+++ b/libs/cli/src/generators/ui/libs/carousel/files/lib/hlm-carousel.ts.template
@@ -9,12 +9,10 @@ import {
 	viewChild,
 } from '@angular/core';
 import { classes } from '<%- importAlias %>/utils';
-import {
-	EmblaCarouselDirective,
-	type EmblaEventType,
-	type EmblaOptionsType,
-	type EmblaPluginType,
-} from 'embla-carousel-angular';
+import { EmblaCarouselDirective } from 'embla-carousel-angular';
+// Import the option/event/plugin types from the base embla-carousel package: embla-carousel-angular v22
+// no longer re-exports them (it declares them locally), so importing them from there fails to compile.
+import type { EmblaEventType, EmblaOptionsType, EmblaPluginType } from 'embla-carousel';
 
 @Component({
 	selector: 'hlm-carousel',

--- a/libs/cli/src/generators/ui/libs/carousel/files/lib/hlm-carousel.ts.template
+++ b/libs/cli/src/generators/ui/libs/carousel/files/lib/hlm-carousel.ts.template
@@ -12,8 +12,6 @@ import {
 } from '@angular/core';
 import { classes } from '<%- importAlias %>/utils';
 import { EmblaCarouselDirective } from 'embla-carousel-angular';
-// Import the option/event/plugin types from the base embla-carousel package: embla-carousel-angular v22
-// no longer re-exports them (it declares them locally), so importing them from there fails to compile.
 import type { EmblaEventType, EmblaOptionsType, EmblaPluginType } from 'embla-carousel';
 
 @Component({

--- a/libs/cli/src/generators/ui/supported-ui-libraries.json
+++ b/libs/cli/src/generators/ui/supported-ui-libraries.json
@@ -108,6 +108,7 @@
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
 			"clsx": "^2.1.1",
+			"embla-carousel": ">=8.0.0 <9.0.0",
 			"embla-carousel-angular": ">=21.0.0 <23.0.0"
 		}
 	},

--- a/libs/cli/src/generators/ui/supported-ui-libraries.json
+++ b/libs/cli/src/generators/ui/supported-ui-libraries.json
@@ -349,7 +349,8 @@
 	"scroll-area": {
 		"name": "scroll-area",
 		"peerDependencies": {
-			"@angular/core": ">=21.0.0 <23.0.0"
+			"@angular/core": ">=21.0.0 <23.0.0",
+			"ngx-scrollbar": ">=19.0.0 <20.0.0"
 		}
 	},
 	"select": {

--- a/libs/helm/carousel/src/lib/hlm-carousel.ts
+++ b/libs/helm/carousel/src/lib/hlm-carousel.ts
@@ -11,10 +11,8 @@ import {
 	viewChild,
 } from '@angular/core';
 import { classes } from '@spartan-ng/helm/utils';
-import { EmblaCarouselDirective } from 'embla-carousel-angular';
-// Import the option/event/plugin types from the base embla-carousel package: embla-carousel-angular v22
-// no longer re-exports them (it declares them locally), so importing them from there fails to compile.
 import type { EmblaEventType, EmblaOptionsType, EmblaPluginType } from 'embla-carousel';
+import { EmblaCarouselDirective } from 'embla-carousel-angular';
 
 @Component({
 	selector: 'hlm-carousel',

--- a/libs/helm/carousel/src/lib/hlm-carousel.ts
+++ b/libs/helm/carousel/src/lib/hlm-carousel.ts
@@ -11,12 +11,10 @@ import {
 	viewChild,
 } from '@angular/core';
 import { classes } from '@spartan-ng/helm/utils';
-import {
-	EmblaCarouselDirective,
-	type EmblaEventType,
-	type EmblaOptionsType,
-	type EmblaPluginType,
-} from 'embla-carousel-angular';
+import { EmblaCarouselDirective } from 'embla-carousel-angular';
+// Import the option/event/plugin types from the base embla-carousel package: embla-carousel-angular v22
+// no longer re-exports them (it declares them locally), so importing them from there fails to compile.
+import type { EmblaEventType, EmblaOptionsType, EmblaPluginType } from 'embla-carousel';
 
 @Component({
 	selector: 'hlm-carousel',

--- a/libs/helm/package.json
+++ b/libs/helm/package.json
@@ -13,6 +13,7 @@
 		"@spartan-ng/brain": "0.0.1-alpha.709",
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
+		"embla-carousel": ">=8.0.0 <9.0.0",
 		"embla-carousel-angular": ">=21.0.0 <23.0.0",
 		"ngx-scrollbar": "^19.1.5",
 		"rxjs": "^7.8.0",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
 		"cypress-axe": "^1.5.0",
 		"cypress-real-events": "^1.13.0",
 		"drizzle-kit": "0.24.2",
+		"embla-carousel": "^8.6.0",
 		"esbuild": "^0.24.0",
 		"eslint": "^9.28.0",
 		"eslint-config-prettier": "10.1.2",
@@ -204,6 +205,7 @@
 		"types-tsconfig": "^2.1.1",
 		"typescript": "5.9.3",
 		"typescript-eslint": "^8.33.1",
+		"verdaccio": "^6.7.2",
 		"vite": "6.2.1",
 		"vite-tsconfig-paths": "5.0.1",
 		"vitest": "^2.1.8"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"release-cli": "nx run-many --target=release --projects=tag:scope:cli --parallel=1",
 		"release-mcp": "nx run-many --target=release --projects=tag:scope:mcp --parallel=1",
 		"release-ui": "nx run-many --target=release --projects=tag:scope:brain --parallel=1",
+		"smoke": "nx run cli-smoke:smoke",
 		"start": "nx serve app",
 		"storybook": "nx storybook ui-storybook",
 		"test": "nx run-many --target test --all",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,13 +80,13 @@ importers:
         version: 32.4.0(@angular/common@21.2.16(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.16(@angular/compiler@21.2.16)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@nx/angular':
         specifier: 22.7.5
-        version: 22.7.5(ece2a8ec0f966546af8b2e676a7631e6)
+        version: 22.7.5(a0d9131a502e99315cb4c816a61aeac0)
       '@nx/devkit':
         specifier: 22.7.5
         version: 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
       '@nx/plugin':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(eslint@9.30.0(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+        version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(eslint@9.30.0(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@stackblitz/sdk':
         specifier: ^1.11.0
         version: 1.11.0
@@ -207,7 +207,7 @@ importers:
     devDependencies:
       '@analogjs/platform':
         specifier: 2.1.3
-        version: 2.1.3(87ff6ffc7f6d40e7f3f02a5565d5f73d)
+        version: 2.1.3(037112425c7061f2e5fe6864870250ab)
       '@angular-devkit/build-angular':
         specifier: 21.2.14
         version: 21.2.14(4a747c3f3bc50ef6c5e235e8b27e519f)
@@ -255,31 +255,31 @@ importers:
         version: 32.4.0
       '@nx/cypress':
         specifier: 22.7.5
-        version: 22.7.5(98208a0d2fcfb98f813fc2f9cb2fca3f)
+        version: 22.7.5(afa56f6386778f44b63bd3f4bc6e0c16)
       '@nx/eslint':
         specifier: 22.7.5
-        version: 22.7.5(7a53e3ce082135e88bcb6d42465fe5e5)
+        version: 22.7.5(aedb2675c584410d65a04131c31abe93)
       '@nx/eslint-plugin':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@typescript-eslint/parser@8.46.3(eslint@9.30.0(jiti@2.4.2))(typescript@5.9.3))(eslint-config-prettier@10.1.2(eslint@9.30.0(jiti@2.4.2)))(eslint@9.30.0(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+        version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@typescript-eslint/parser@8.46.3(eslint@9.30.0(jiti@2.4.2))(typescript@5.9.3))(eslint-config-prettier@10.1.2(eslint@9.30.0(jiti@2.4.2)))(eslint@9.30.0(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/jest':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+        version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+        version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/storybook':
         specifier: 22.7.5
-        version: 22.7.5(7c65fe5e7232c6afa56075b3cca7ce18)
+        version: 22.7.5(1539412a77a44de954047809fe7480e7)
       '@nx/vite':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(7a53e3ce082135e88bcb6d42465fe5e5))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)
+        version: 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(aedb2675c584410d65a04131c31abe93))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)
       '@nx/vitest':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(7a53e3ce082135e88bcb6d42465fe5e5))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)
+        version: 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(aedb2675c584410d65a04131c31abe93))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)
       '@nx/web':
         specifier: 22.7.5
-        version: 22.7.5(428176691eb5a00f2ecd435fb8f65075)
+        version: 22.7.5(644e51d51623b8b7b086e8c6da4deb68)
       '@nx/workspace':
         specifier: 22.7.5
         version: 22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))
@@ -406,6 +406,9 @@ importers:
       drizzle-kit:
         specifier: 0.24.2
         version: 0.24.2
+      embla-carousel:
+        specifier: ^8.6.0
+        version: 8.6.0
       esbuild:
         specifier: ^0.24.0
         version: 0.24.2
@@ -526,6 +529,9 @@ importers:
       typescript-eslint:
         specifier: ^8.33.1
         version: 8.46.3(eslint@9.30.0(jiti@2.4.2))(typescript@5.9.3)
+      verdaccio:
+        specifier: ^6.7.2
+        version: 6.7.2(encoding@0.1.13)(typanion@3.14.0)
       vite:
         specifier: 6.2.1
         version: 6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0)
@@ -1979,10 +1985,6 @@ packages:
 
   '@cypress/request@3.0.10':
     resolution: {integrity: sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==}
-    engines: {node: '>= 6'}
-
-  '@cypress/request@3.0.7':
-    resolution: {integrity: sha512-LzxlLEMbBOPYB85uXrDqvD4MgcenjRBLIns3zyhx7vTPj/0u2eQhzXvPiGcaJrV38Q9dbkExWp6cOHPJ+EtFYg==}
     engines: {node: '>= 6'}
 
   '@cypress/xvfb@1.2.4':
@@ -4699,6 +4701,9 @@ packages:
     peerDependencies:
       typescript: '>3.0.0'
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -5453,6 +5458,10 @@ packages:
   '@swc/types@0.1.26':
     resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
 
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
+
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
@@ -5952,6 +5961,9 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@types/responselike@1.0.0':
+    resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
+
   '@types/retry@0.12.2':
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
 
@@ -6211,89 +6223,80 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@verdaccio/auth@8.0.0-next-8.7':
-    resolution: {integrity: sha512-CSLBAsCJT1oOpJ4OWnVGmN6o/ZilDNa7Aa5+AU1LI2lbRblqgr4BVRn07GFqimJ//6+tPzl8BHgyiCbBhh1ZiA==}
+  '@verdaccio/auth@8.0.2':
+    resolution: {integrity: sha512-Qw5DhIIzNsM1ORbrnYDKQ2iA1ACWZkjWtxXrYFh577at9+H9QR45m3mMokcRVr3t2UBNFEmMb5cGTrReFa5Dzw==}
     engines: {node: '>=18'}
 
-  '@verdaccio/commons-api@10.2.0':
-    resolution: {integrity: sha512-F/YZANu4DmpcEV0jronzI7v2fGVWkQ5Mwi+bVmV+ACJ+EzR0c9Jbhtbe5QyLUuzR97t8R5E/Xe53O0cc2LukdQ==}
-    engines: {node: '>=8'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  '@verdaccio/config@8.0.0-next-8.7':
-    resolution: {integrity: sha512-pA0WCWvvWY6vPRav+X0EuFmuK6M08zIpRzTKkqSriCWk6JUCZ07TDnN054AS8TSSOy6EaWgHxnUw3nTd34Z4Sg==}
+  '@verdaccio/config@8.1.1':
+    resolution: {integrity: sha512-N9nS1AAME02iuhC2B3v67NnKQp2MkUoN5uUQ2JoS2seWQ6Bjs8dnkWfh4B9N5QTVjUQx4ETYOb3M+UqUJDJT8A==}
     engines: {node: '>=18'}
 
-  '@verdaccio/core@8.0.0-next-8.1':
-    resolution: {integrity: sha512-kQRCB2wgXEh8H88G51eQgAFK9IxmnBtkQ8sY5FbmB6PbBkyHrbGcCp+2mtRqqo36j0W1VAlfM3XzoknMy6qQnw==}
-    engines: {node: '>=14'}
-
-  '@verdaccio/core@8.0.0-next-8.7':
-    resolution: {integrity: sha512-pf8M2Z5EI/5Zdhdcm3aadb9Q9jiDsIredPD3+cIoDum8x3di2AIYvQD7i5BEramfzZlLXVICmFAulU7nUY11qg==}
+  '@verdaccio/core@8.1.1':
+    resolution: {integrity: sha512-IIgi8PucT67ymIwxwzc+5CGQF97xAPWlqb7M2nidfIpPtlghPjURDP6xHDcBLuE57adZKcklO24kr6zFSQa7cg==}
     engines: {node: '>=18'}
 
-  '@verdaccio/file-locking@10.3.1':
-    resolution: {integrity: sha512-oqYLfv3Yg3mAgw9qhASBpjD50osj2AX4IwbkUtyuhhKGyoFU9eZdrbeW6tpnqUnj6yBMtAPm2eGD4BwQuX400g==}
-    engines: {node: '>=12'}
-
-  '@verdaccio/file-locking@13.0.0-next-8.2':
-    resolution: {integrity: sha512-TcHgN3I/N28WBSvtukpGrJhBljl4jyIXq0vEv94vXAG6nUE3saK+vtgo8PfYA3Ueo88v/1zyAbiZM4uxwojCmQ==}
+  '@verdaccio/file-locking@13.0.1':
+    resolution: {integrity: sha512-SZ9uxnQKppiM+/67xTaaBP4AZ/Q+weUB22ci1gF861icYWhWFu3njA3ofYig/4yNqkYRVEKVAIwnH97BaBEYbg==}
     engines: {node: '>=18'}
 
-  '@verdaccio/loaders@8.0.0-next-8.4':
-    resolution: {integrity: sha512-Powlqb4SuMbe6RVgxyyOXaCjuHCcK7oZA+lygaKZDpV9NSHJtbkkV4L+rXyCfTX3b0tKsBh7FzaIdgWc1rDeGQ==}
+  '@verdaccio/hooks@8.0.2':
+    resolution: {integrity: sha512-lneKTW6MDo28+hHqkIin08ruAafTvMake2TYUMdXWp+ah1YFI9XVzj6eo/rKHUB6sC4NxrBVajsGo1NX0OCE+A==}
     engines: {node: '>=18'}
 
-  '@verdaccio/local-storage-legacy@11.0.2':
-    resolution: {integrity: sha512-7AXG7qlcVFmF+Nue2oKaraprGRtaBvrQIOvc/E89+7hAe399V01KnZI6E/ET56u7U9fq0MSlp92HBcdotlpUXg==}
-    engines: {node: '>=12'}
-
-  '@verdaccio/logger-commons@8.0.0-next-8.7':
-    resolution: {integrity: sha512-sXNx57G1LVp81xF4qHer3AOcMEZ90W4FjxtYF0vmULcVg3ybdtStKAT/9ocZtVMvLWTPAauhqylfnXoRZYf32A==}
+  '@verdaccio/loaders@8.0.2':
+    resolution: {integrity: sha512-Hm2xa47EXPI+Rnl3a0oTvEa1OIngze36YDHXNvHEhN35emID9iqJk1BoD5rA4Y2AdR9Jy34wRqzdqcwg9+ftSA==}
     engines: {node: '>=18'}
 
-  '@verdaccio/logger-prettify@8.0.0-next-8.1':
-    resolution: {integrity: sha512-vLhaGq0q7wtMCcqa0aQY6QOsMNarhTu/l4e6Z8mG/5LUH95GGLsBwpXLnKS94P3deIjsHhc9ycnEmG39txbQ1w==}
+  '@verdaccio/local-storage-legacy@11.3.3':
+    resolution: {integrity: sha512-F+cXs0Hy8tQsA6aE0hy0FaimgPfhqmetKbepOOZkstNlzOAhCzhue414VQaswKBJ/ylrmSgXP45HZjst+JNyjA==}
     engines: {node: '>=18'}
 
-  '@verdaccio/logger@8.0.0-next-8.7':
-    resolution: {integrity: sha512-5EMPdZhz2V08BP2rjhtN/Fz5KxCfPJBkYDitbk/eo+FCZ9nVdMCQE3WRbHEaXyJQcIso/LJ6RnL/zKN20E/rPg==}
+  '@verdaccio/logger-commons@8.0.2':
+    resolution: {integrity: sha512-PzR1+0tVWzDc6aQsPCi6LVywWTXD0bp61f97On8ia4Ihms6ahP9MZzF86Mub6laBw4mBsBo45EBFaqQfotvUoA==}
     engines: {node: '>=18'}
 
-  '@verdaccio/middleware@8.0.0-next-8.7':
-    resolution: {integrity: sha512-Zad7KcdOsI1DUBt1TjQb08rIi/IFFaJKdPhj7M6oy5BX9l/4OM0TtbBueHFNS1+aU+t5eo8ue7ZHbqmjDY/6VQ==}
+  '@verdaccio/logger-prettify@8.0.1':
+    resolution: {integrity: sha512-49a5LTi90TxjQPBk7rZUf0qCorAjOopq7uQzGRro6dOEFmyaZ/K2sNiOuRFJzVuC8C8jL/zPlJiln1vm5HsAMA==}
     engines: {node: '>=18'}
 
-  '@verdaccio/search-indexer@8.0.0-next-8.2':
-    resolution: {integrity: sha512-sWliVN5BkAGbZ3e/GD0CsZMfPJdRMRuN0tEKQFsvEJifxToq5UkfCw6vKaVvhezsTWqb+Rp5y+2d4n5BDOA49w==}
+  '@verdaccio/logger@8.0.2':
+    resolution: {integrity: sha512-yxCVJP9Inr6qfdsDaOUCWWj0g0SzLY6J+62QkBafZLqIqng8IfI1NRe/6n2O3AH+YPThbqxhgaAJQ5MJTvBxOw==}
     engines: {node: '>=18'}
 
-  '@verdaccio/signature@8.0.0-next-8.1':
-    resolution: {integrity: sha512-lHD/Z2FoPQTtDYz6ZlXhj/lrg0SFirHrwCGt/cibl1GlePpx78WPdo03tgAyl0Qf+I35n484/gR1l9eixBQqYw==}
+  '@verdaccio/middleware@8.0.2':
+    resolution: {integrity: sha512-CmSoXI1/5lfH25NP3Q7ic9TEUSn6gENqauU00EhYZ/RAk/jYyPCkokSJBi9RhsAsOjOUry4yM4c3vgxLdO8Iwg==}
     engines: {node: '>=18'}
 
-  '@verdaccio/streams@10.2.1':
-    resolution: {integrity: sha512-OojIG/f7UYKxC4dYX8x5ax8QhRx1b8OYUAMz82rUottCuzrssX/4nn5QE7Ank0DUSX3C9l/HPthc4d9uKRJqJQ==}
+  '@verdaccio/package-filter@13.0.2':
+    resolution: {integrity: sha512-y9X52mCpP9AKoAB6W/ymYS5XscBNOT7HdSfYIy3BMpNJxD4+rwMO/SwKn3uAY+2RaMAgU1N7NBUmPtQAYFGhww==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/search-indexer@8.0.2':
+    resolution: {integrity: sha512-Pd2vGmb69pMuZj+WyiUMcbPU9H9Zfm0xHy0p2jDhb4PfT0rnoGgM0a7GxlmywsRuIM5obm4OCUZdhw0N8BnwYw==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/signature@8.0.2':
+    resolution: {integrity: sha512-0vmv3D2SmyJsLoN0e+O+wvjYdUxu/cxsCSRbchmK3m1dFxrGNyxEdQkdBAKDyOr2sQit5xM0XSwHRIqYrmr8Lw==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/streams@10.2.5':
+    resolution: {integrity: sha512-nVnTYeMJ7h131Nkv2svqZCfL5aDkJbwUvQd4OGXssbJJR5BfB2PzNq8TD45lEXIBW3EMMMFs7mVY789ds9soIA==}
     engines: {node: '>=12', npm: '>=5'}
 
-  '@verdaccio/tarball@13.0.0-next-8.7':
-    resolution: {integrity: sha512-EWRuEOLgb3UETxUsYg6+Mml6DDRiwQqKIEsE4Ys6y6rcH2vgW6XMnTt+s/v5pFI+zlbi6fxjOgQB1e6IJAwxVA==}
+  '@verdaccio/tarball@13.0.2':
+    resolution: {integrity: sha512-LQHoAlp7yk5Tlhv+uHWJKtExwbMDBvwTvoAsdWMq4sRjCrdJSz8KTfWEBrb0EayxEwPr0LmI0ce8mIriId9Zow==}
     engines: {node: '>=18'}
 
-  '@verdaccio/ui-theme@8.0.0-next-8.7':
-    resolution: {integrity: sha512-+7f7XqqIU+TVCHjsP6lWzCdsD4sM7MEhn4cu3mLW1kJZ7eenWKEltoqixQnoXJzaBjCiz+yXW1WkjMyEFLNbpg==}
+  '@verdaccio/ui-theme@9.0.0-next-9.14':
+    resolution: {integrity: sha512-0PQW6PV+sHsQdV3gnHQqAcDcVGfT75vHq1TfIeEN2QY5KuEkvli8e5vut+sTe89p+GOTahHKgTMOcL0O3BvsgA==}
 
-  '@verdaccio/url@13.0.0-next-8.7':
-    resolution: {integrity: sha512-biFvwH3zIXYicA+SXNGvjMAe8oIQ5VddsfbO0ZXWlFs0lIz8cgI7QYPeSiCkU2VKpGzZ8pEKgqkxFsfFkU5kGA==}
+  '@verdaccio/url@13.0.2':
+    resolution: {integrity: sha512-dXVBJETBV5Q/jz7R/fTQxnzsTjgnDBEh2v8aOKtngwBEf7YkgzU7LrtyzkGmyRzXUvS5ZSAXWrBAKQ4DEIZ/6w==}
     engines: {node: '>=18'}
 
-  '@verdaccio/utils@7.0.1-next-8.1':
-    resolution: {integrity: sha512-cyJdRrVa+8CS7UuIQb3K3IJFjMe64v38tYiBnohSmhRbX7dX9IT3jWbjrwkqWh4KeS1CS6BYENrGG1evJ2ggrQ==}
-    engines: {node: '>=12'}
-
-  '@verdaccio/utils@8.1.0-next-8.7':
-    resolution: {integrity: sha512-4eqPCnPAJsL6gdVs0/oqZNgs2PnQW3HHBMgBHyEbb5A/ESI10TvRp+B7MRl9glUmy/aR5B6YSI68rgXvAFjdxA==}
-    engines: {node: '>=12'}
+  '@verdaccio/utils@8.1.2':
+    resolution: {integrity: sha512-LTV6/Kcr8pS//iDjDitfYi1bp0AlKBUuvNoHAbI8tMnj0PLOUtRWJxId5FwuE+z3oNBeDLeOWPoXVtqKjl277Q==}
+    engines: {node: '>=18'}
 
   '@vitejs/plugin-basic-ssl@2.1.4':
     resolution: {integrity: sha512-HXciTXN/sDBYWgeAD4V4s0DN0g72x5mlxQhHxtYu3Tt8BLa6MzcJZUyDVFCdtjNs3bfENVHVzOsmooTVuNgAAw==}
@@ -6590,9 +6593,6 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
-
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
@@ -6702,6 +6702,10 @@ packages:
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
@@ -6727,9 +6731,6 @@ packages:
 
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
-
-  async@3.2.4:
-    resolution: {integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -7027,6 +7028,10 @@ packages:
     resolution: {integrity: sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  cacheable-lookup@6.1.0:
+    resolution: {integrity: sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==}
+    engines: {node: '>=10.6.0'}
+
   cacheable-lookup@7.0.0:
     resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
     engines: {node: '>=14.16'}
@@ -7034,6 +7039,10 @@ packages:
   cacheable-request@10.2.14:
     resolution: {integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==}
     engines: {node: '>=14.16'}
+
+  cacheable-request@7.0.2:
+    resolution: {integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==}
+    engines: {node: '>=8'}
 
   cachedir@2.4.0:
     resolution: {integrity: sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==}
@@ -7233,6 +7242,9 @@ packages:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
 
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
@@ -7331,10 +7343,6 @@ packages:
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
-
-  compression@1.7.5:
-    resolution: {integrity: sha512-bQJ0YRck5ak3LgtnpKkiabX5pNF7tMUh1BSy2ZBOTh0Dim0BUu6aPPwByIns6/A5Prh8PufSPerMDUklpzes2Q==}
-    engines: {node: '>= 0.8.0'}
 
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
@@ -7502,9 +7510,6 @@ packages:
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
-  core-js@3.37.1:
-    resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
-
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
@@ -7513,6 +7518,10 @@ packages:
 
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
   corser@2.0.1:
@@ -7923,6 +7932,9 @@ packages:
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
+  dayjs@1.11.18:
+    resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
+
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
     peerDependencies:
@@ -7956,33 +7968,6 @@ packages:
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.3.7:
-    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
-    engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -8424,8 +8409,8 @@ packages:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  envinfo@7.14.0:
-    resolution: {integrity: sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==}
+  envinfo@7.21.0:
+    resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
     engines: {node: '>=4'}
     hasBin: true
 
@@ -8709,10 +8694,6 @@ packages:
     peerDependencies:
       express: '>= 4.11'
 
-  express@4.21.2:
-    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
-    engines: {node: '>= 0.10.0'}
-
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
@@ -8762,13 +8743,6 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  fast-redact@3.5.0:
-    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
-    engines: {node: '>=6'}
-
-  fast-safe-stringify@2.1.1:
-    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
@@ -8927,6 +8901,9 @@ packages:
       typescript: '>3.6.0'
       webpack: ^5.11.0
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
@@ -9008,6 +8985,10 @@ packages:
   function-timeout@1.0.2:
     resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
     engines: {node: '>=18'}
+
+  fuse.js@7.3.0:
+    resolution: {integrity: sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==}
+    engines: {node: '>=10'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -9158,6 +9139,10 @@ packages:
     resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
   globby@14.1.0:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
     engines: {node: '>=18'}
@@ -9172,6 +9157,10 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  got-cjs@12.5.4:
+    resolution: {integrity: sha512-Uas6lAsP8bRCt5WXGMhjFf/qEHTrm4v4qxGR02rLG2kdG9qedctvlkdwXVcDJ7Cs84X+r4dPU7vdwGjCaspXug==}
+    engines: {node: '>=12'}
 
   got@13.0.0:
     resolution: {integrity: sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==}
@@ -9359,9 +9348,6 @@ packages:
   http-signature@1.4.0:
     resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
     engines: {node: '>=0.10'}
-
-  http-status-codes@2.2.0:
-    resolution: {integrity: sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==}
 
   http-status-codes@2.3.0:
     resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
@@ -9962,8 +9948,8 @@ packages:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -10046,19 +10032,19 @@ packages:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
 
-  jsonwebtoken@9.0.2:
-    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
   jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
 
-  jwa@1.4.2:
-    resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
-  jws@3.2.2:
-    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   karma-source-map-support@1.4.0:
     resolution: {integrity: sha512-RsBECncGO17KAoJCYXjv+ckIz+Ii9NCi+9enk+rq6XC81ezYkb4/RHE6CTXdA7IOJqoF3wcaLfVG0CPmE5ca6A==}
@@ -10360,6 +10346,9 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
@@ -10392,6 +10381,10 @@ packages:
 
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
 
   lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
@@ -10568,11 +10561,6 @@ packages:
     engines: {node: '>=4.0.0'}
     hasBin: true
 
-  mime@2.6.0:
-    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
-    engines: {node: '>=4.0.0'}
-    hasBin: true
-
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
@@ -10594,6 +10582,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -10636,8 +10628,8 @@ packages:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
 
-  minimatch@7.4.6:
-    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
+  minimatch@7.4.9:
+    resolution: {integrity: sha512-Brg/fp/iAVDOQoHxkuN5bEYhyQlZhxddI78yWsCbeEwTHXQjlNLtiJDUsp1GIptVqMI7/gkJMz4vVAc01mpoBw==}
     engines: {node: '>=10'}
 
   minimatch@9.0.5:
@@ -10702,9 +10694,6 @@ packages:
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
-
-  ms@2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -10912,6 +10901,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
+
   normalize-url@8.0.2:
     resolution: {integrity: sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==}
     engines: {node: '>=14.16'}
@@ -11076,10 +11069,6 @@ packages:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
-  on-headers@1.0.2:
-    resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
-    engines: {node: '>= 0.8'}
-
   on-headers@1.1.0:
     resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
@@ -11143,6 +11132,10 @@ packages:
 
   oxc-resolver@11.20.0:
     resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
+
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
 
   p-cancelable@3.0.0:
     resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
@@ -11424,8 +11417,8 @@ packages:
   pino-std-serializers@7.0.0:
     resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
 
-  pino@9.5.0:
-    resolution: {integrity: sha512-xSEmD4pLnV54t0NOUN16yCl7RIB1c5UUOse5HSyEXtBp+FgFQyPeDutc+Q2ZO7/22vImV7VfEjH/1zV2QuqvYw==}
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
   pirates@4.0.7:
@@ -11464,10 +11457,6 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
-
-  pkginfo@0.4.1:
-    resolution: {integrity: sha512-8xCNE/aT/EXKenuMDZ+xTVwkT8gsoHN2z/Q29l80u0ppGEXVvsKRzNMbtKhg8LS8k1tJLAHHylf6p4VFmP6XUQ==}
-    engines: {node: '>= 0.4.0'}
 
   pkijs@3.4.0:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
@@ -12031,8 +12020,8 @@ packages:
   process-warning@1.0.0:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
 
-  process-warning@4.0.1:
-    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
@@ -12089,10 +12078,6 @@ packages:
 
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
-    engines: {node: '>=0.6'}
-
-  qs@6.13.1:
-    resolution: {integrity: sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==}
     engines: {node: '>=0.6'}
 
   qs@6.14.2:
@@ -12308,6 +12293,9 @@ packages:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
 
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
+
   responselike@3.0.0:
     resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
     engines: {node: '>=14.16'}
@@ -12421,6 +12409,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-filename@1.6.4:
+    resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
 
   sass-embedded-android-arm64@1.89.2:
     resolution: {integrity: sha512-+pq7a7AUpItNyPu61sRlP6G2A8pSPpyazASb+8AK2pVlFayCSPAEgpwpCE9A2/Xj86xJZeMizzKUHxM2CBCUxA==}
@@ -12628,6 +12619,11 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -13311,6 +13307,9 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  truncate-utf8-bytes@1.0.2:
+    resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -13722,6 +13721,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  utf8-byte-length@1.0.5:
+    resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -13755,8 +13757,8 @@ packages:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  validator@13.12.0:
-    resolution: {integrity: sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==}
+  validator@13.15.26:
+    resolution: {integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==}
     engines: {node: '>= 0.10'}
 
   varint@6.0.0:
@@ -13766,17 +13768,17 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  verdaccio-audit@13.0.0-next-8.7:
-    resolution: {integrity: sha512-kd6YdrDztkP1/GDZT7Ue2u41iGPvM9y+5aaUbIBUPvTY/YVv57K6MaCMfn9C/I+ZL4R7XOTSxTtWvz3JK4QrNg==}
+  verdaccio-audit@13.0.2:
+    resolution: {integrity: sha512-J2aq4b0Q6qj/3o+r8dBPCmKNj37x+8BjSZOEoH85zjR3kihiVYQgJ1+2UxKCJpLj4Z/04SekB1p+zTBiViyoMw==}
     engines: {node: '>=18'}
 
-  verdaccio-htpasswd@13.0.0-next-8.7:
-    resolution: {integrity: sha512-znyFnwt59mLKTAu6eHJrfWP07iaHUlYiQN7QoBo8KMAOT1AecUYreBqs93oKHdIOzjTI8j6tQLg57DpeVS5vgg==}
+  verdaccio-htpasswd@13.0.2:
+    resolution: {integrity: sha512-ObyN409utfLKQ4QdGAYyXOprVaOYz0tDvhi0WpK7U71QvL/LOjeXWleDFRJHeaEMTNNdrzPhtC/9kcpfnztabg==}
     engines: {node: '>=18'}
 
-  verdaccio@6.0.5:
-    resolution: {integrity: sha512-hv+v4mtG/rcNidGUHXAtNuVySiPE3/PM+7dYye5jCDrhCUmRJYOtnvDe/Ym1ZE/twti39g6izVRxEkjnSp52gA==}
-    engines: {node: '>=18'}
+  verdaccio@6.7.2:
+    resolution: {integrity: sha512-o9YQonYX94RxVKQncxcUbsPtLTV26IgDSPQTbcw6rFrtQ6zb7Fx75vTNBps2O7xStMtwROblGwnLlHF7akm0jQ==}
+    engines: {node: '>=20'}
     hasBin: true
 
   verror@1.10.0:
@@ -14434,7 +14436,7 @@ snapshots:
     optionalDependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
 
-  '@analogjs/platform@2.1.3(87ff6ffc7f6d40e7f3f02a5565d5f73d)':
+  '@analogjs/platform@2.1.3(037112425c7061f2e5fe6864870250ab)':
     dependencies:
       '@analogjs/vite-plugin-angular': 2.1.3(@angular-devkit/build-angular@21.2.14(4a747c3f3bc50ef6c5e235e8b27e519f))(@angular/build@21.2.14(4561576e35f225f35cffbecbd845ec83))
       '@analogjs/vite-plugin-nitro': 2.6.0(@netlify/blobs@9.1.2)(drizzle-orm@0.33.0(@types/react@18.3.23)(postgres@3.4.7)(react@19.1.0))(encoding@0.1.13)
@@ -14445,9 +14447,9 @@ snapshots:
       vite: 6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0)
       vitefu: 1.1.3(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))
     optionalDependencies:
-      '@nx/angular': 22.7.5(ece2a8ec0f966546af8b2e676a7631e6)
+      '@nx/angular': 22.7.5(a0d9131a502e99315cb4c816a61aeac0)
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/vite': 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(7a53e3ce082135e88bcb6d42465fe5e5))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)
+      '@nx/vite': 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(aedb2675c584410d65a04131c31abe93))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)
       marked-highlight: 2.2.2(marked@15.0.9)
       prismjs: 1.30.0
     transitivePeerDependencies:
@@ -16215,28 +16217,6 @@ snapshots:
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
       uuid: 8.3.2
-
-  '@cypress/request@3.0.7':
-    dependencies:
-      aws-sign2: 0.7.0
-      aws4: 1.13.2
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 4.0.5
-      http-signature: 1.4.0
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.35
-      performance-now: 2.1.0
-      qs: 6.13.1
-      safe-buffer: 5.2.1
-      tough-cookie: 5.1.2
-      tunnel-agent: 0.6.0
-      uuid: 8.3.2
-    optional: true
 
   '@cypress/xvfb@1.2.4(supports-color@8.1.1)':
     dependencies:
@@ -18110,17 +18090,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nx/angular@22.7.5(ece2a8ec0f966546af8b2e676a7631e6)':
+  '@nx/angular@22.7.5(a0d9131a502e99315cb4c816a61aeac0)':
     dependencies:
       '@angular-devkit/core': 21.2.14(chokidar@5.0.0)
       '@angular-devkit/schematics': 21.2.14(chokidar@5.0.0)
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/eslint': 22.7.5(7a53e3ce082135e88bcb6d42465fe5e5)
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/module-federation': 22.7.5(df94f35375a7b370352e09859f7c65d7)
-      '@nx/rspack': 22.7.5(ce4d16a504e719d4c1d95c0c435b6016)
-      '@nx/web': 22.7.5(428176691eb5a00f2ecd435fb8f65075)
-      '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)))(lightningcss@1.30.1)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/eslint': 22.7.5(aedb2675c584410d65a04131c31abe93)
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/module-federation': 22.7.5(3a923b8552536a3365ffa139d9a7b74d)
+      '@nx/rspack': 22.7.5(158cafe86ba169be4e579e674b10bc0d)
+      '@nx/web': 22.7.5(644e51d51623b8b7b086e8c6da4deb68)
+      '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)))(lightningcss@1.30.1)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/workspace': 22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       '@schematics/angular': 21.2.14(chokidar@5.0.0)
@@ -18176,11 +18156,11 @@ snapshots:
       - webpack-cli
       - webpack-hot-middleware
 
-  '@nx/cypress@22.7.5(98208a0d2fcfb98f813fc2f9cb2fca3f)':
+  '@nx/cypress@22.7.5(afa56f6386778f44b63bd3f4bc6e0c16)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/eslint': 22.7.5(7a53e3ce082135e88bcb6d42465fe5e5)
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/eslint': 22.7.5(aedb2675c584410d65a04131c31abe93)
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       detect-port: 2.1.0
       semver: 7.6.3
@@ -18212,10 +18192,10 @@ snapshots:
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/eslint-plugin@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@typescript-eslint/parser@8.46.3(eslint@9.30.0(jiti@2.4.2))(typescript@5.9.3))(eslint-config-prettier@10.1.2(eslint@9.30.0(jiti@2.4.2)))(eslint@9.30.0(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/eslint-plugin@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@typescript-eslint/parser@8.46.3(eslint@9.30.0(jiti@2.4.2))(typescript@5.9.3))(eslint-config-prettier@10.1.2(eslint@9.30.0(jiti@2.4.2)))(eslint@9.30.0(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       '@typescript-eslint/parser': 8.46.3(eslint@9.30.0(jiti@2.4.2))(typescript@5.9.3)
       '@typescript-eslint/type-utils': 8.46.3(eslint@9.30.0(jiti@2.4.2))(typescript@5.9.3)
@@ -18239,16 +18219,16 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/eslint@22.7.5(7a53e3ce082135e88bcb6d42465fe5e5)':
+  '@nx/eslint@22.7.5(aedb2675c584410d65a04131c31abe93)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       eslint: 9.30.0(jiti@2.4.2)
       semver: 7.6.3
       tslib: 2.8.1
       typescript: 5.9.3
     optionalDependencies:
-      '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@zkochan/js-yaml': 0.0.7
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -18259,12 +18239,12 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@jest/reporters': 30.4.1
       '@jest/test-result': 30.4.1
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       identity-obj-proxy: 3.0.0
       jest-config: 30.4.2(@types/node@22.6.2)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))
@@ -18291,7 +18271,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/js@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/js@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.27.1(@babel/core@7.29.0)
@@ -18320,7 +18300,7 @@ snapshots:
       tinyglobby: 0.2.15
       tslib: 2.8.1
     optionalDependencies:
-      verdaccio: 6.0.5(encoding@0.1.13)(typanion@3.14.0)
+      verdaccio: 6.7.2(encoding@0.1.13)(typanion@3.14.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -18329,14 +18309,14 @@ snapshots:
       - nx
       - supports-color
 
-  '@nx/module-federation@22.7.5(df94f35375a7b370352e09859f7c65d7)':
+  '@nx/module-federation@22.7.5(3a923b8552536a3365ffa139d9a7b74d)':
     dependencies:
       '@module-federation/enhanced': 2.5.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2))
       '@module-federation/node': 2.7.33(@rspack/core@1.6.8(@swc/helpers@0.5.23))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2))
       '@module-federation/sdk': 2.5.1(node-fetch@3.3.2)
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/web': 22.7.5(428176691eb5a00f2ecd435fb8f65075)
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/web': 22.7.5(644e51d51623b8b7b086e8c6da4deb68)
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
       express: 4.22.1
       http-proxy-middleware: 3.0.5
@@ -18399,12 +18379,12 @@ snapshots:
   '@nx/nx-win32-x64-msvc@22.7.5':
     optional: true
 
-  '@nx/plugin@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(eslint@9.30.0(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/plugin@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(eslint@9.30.0(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/eslint': 22.7.5(7a53e3ce082135e88bcb6d42465fe5e5)
-      '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/eslint': 22.7.5(aedb2675c584410d65a04131c31abe93)
+      '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -18423,14 +18403,14 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/rspack@22.7.5(ce4d16a504e719d4c1d95c0c435b6016)':
+  '@nx/rspack@22.7.5(158cafe86ba169be4e579e674b10bc0d)':
     dependencies:
       '@module-federation/enhanced': 2.5.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2))
       '@module-federation/node': 2.7.33(@rspack/core@1.6.8(@swc/helpers@0.5.23))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2))
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/module-federation': 22.7.5(df94f35375a7b370352e09859f7c65d7)
-      '@nx/web': 22.7.5(428176691eb5a00f2ecd435fb8f65075)
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/module-federation': 22.7.5(3a923b8552536a3365ffa139d9a7b74d)
+      '@nx/web': 22.7.5(644e51d51623b8b7b086e8c6da4deb68)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
       '@rspack/dev-server': 1.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(tslib@2.8.1)(webpack@5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2))
@@ -18488,18 +18468,18 @@ snapshots:
       - webpack-cli
       - webpack-hot-middleware
 
-  '@nx/storybook@22.7.5(7c65fe5e7232c6afa56075b3cca7ce18)':
+  '@nx/storybook@22.7.5(1539412a77a44de954047809fe7480e7)':
     dependencies:
-      '@nx/cypress': 22.7.5(98208a0d2fcfb98f813fc2f9cb2fca3f)
+      '@nx/cypress': 22.7.5(afa56f6386778f44b63bd3f4bc6e0c16)
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/eslint': 22.7.5(7a53e3ce082135e88bcb6d42465fe5e5)
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/eslint': 22.7.5(aedb2675c584410d65a04131c31abe93)
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       semver: 7.6.3
       storybook: 10.4.2(@testing-library/dom@10.4.0)(@types/react@18.3.23)(prettier@3.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/web': 22.7.5(428176691eb5a00f2ecd435fb8f65075)
+      '@nx/web': 22.7.5(644e51d51623b8b7b086e8c6da4deb68)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/jest'
@@ -18514,11 +18494,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(7a53e3ce082135e88bcb6d42465fe5e5))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)':
+  '@nx/vite@22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(aedb2675c584410d65a04131c31abe93))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vitest': 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(7a53e3ce082135e88bcb6d42465fe5e5))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/vitest': 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(aedb2675c584410d65a04131c31abe93))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       ajv: 8.18.0
       enquirer: 2.3.6
@@ -18539,15 +18519,15 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vitest@22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(7a53e3ce082135e88bcb6d42465fe5e5))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)':
+  '@nx/vitest@22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(aedb2675c584410d65a04131c31abe93))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       semver: 7.6.3
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/eslint': 22.7.5(7a53e3ce082135e88bcb6d42465fe5e5)
+      '@nx/eslint': 22.7.5(aedb2675c584410d65a04131c31abe93)
       vite: 6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0)
       vitest: 2.1.9(@types/node@22.6.2)(@vitest/ui@2.1.9)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)
     transitivePeerDependencies:
@@ -18560,20 +18540,20 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/web@22.7.5(428176691eb5a00f2ecd435fb8f65075)':
+  '@nx/web@22.7.5(644e51d51623b8b7b086e8c6da4deb68)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       detect-port: 2.1.0
       http-server: 14.1.1
       picocolors: 1.1.1
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/cypress': 22.7.5(98208a0d2fcfb98f813fc2f9cb2fca3f)
-      '@nx/eslint': 22.7.5(7a53e3ce082135e88bcb6d42465fe5e5)
-      '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vite': 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(7a53e3ce082135e88bcb6d42465fe5e5))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)
-      '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)))(lightningcss@1.30.1)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/cypress': 22.7.5(afa56f6386778f44b63bd3f4bc6e0c16)
+      '@nx/eslint': 22.7.5(aedb2675c584410d65a04131c31abe93)
+      '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.24.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.6.2)(typescript@5.9.3))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/vite': 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(aedb2675c584410d65a04131c31abe93))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))(vite@6.2.1(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))(vitest@2.1.9)
+      '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)))(lightningcss@1.30.1)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -18583,11 +18563,11 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/webpack@22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)))(lightningcss@1.30.1)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/webpack@22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)))(lightningcss@1.30.1)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.3)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
-      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       ajv: 8.18.0
       autoprefixer: 10.4.27(postcss@8.5.15)
@@ -19029,6 +19009,8 @@ snapshots:
       '@types/esquery': 1.5.4
       esquery: 1.7.0
       typescript: 5.9.3
+
+  '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -19753,6 +19735,10 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
+
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
@@ -20271,6 +20257,10 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@types/responselike@1.0.0':
+    dependencies:
+      '@types/node': 22.6.2
+
   '@types/retry@0.12.2': {}
 
   '@types/semver@7.5.8': {}
@@ -20550,188 +20540,165 @@ snapshots:
       - rollup
       - supports-color
 
-  '@verdaccio/auth@8.0.0-next-8.7':
+  '@verdaccio/auth@8.0.2':
     dependencies:
-      '@verdaccio/config': 8.0.0-next-8.7
-      '@verdaccio/core': 8.0.0-next-8.7
-      '@verdaccio/loaders': 8.0.0-next-8.4
-      '@verdaccio/signature': 8.0.0-next-8.1
-      '@verdaccio/utils': 8.1.0-next-8.7
-      debug: 4.4.0
-      lodash: 4.17.21
-      verdaccio-htpasswd: 13.0.0-next-8.7
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/loaders': 8.0.2
+      '@verdaccio/signature': 8.0.2
+      debug: 4.4.3(supports-color@8.1.1)
+      lodash: 4.18.1
+      verdaccio-htpasswd: 13.0.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  '@verdaccio/commons-api@10.2.0':
+  '@verdaccio/config@8.1.1':
     dependencies:
-      http-errors: 2.0.0
-      http-status-codes: 2.2.0
-    optional: true
-
-  '@verdaccio/config@8.0.0-next-8.7':
-    dependencies:
-      '@verdaccio/core': 8.0.0-next-8.7
-      '@verdaccio/utils': 8.1.0-next-8.7
-      debug: 4.4.0
-      js-yaml: 4.1.0
-      lodash: 4.17.21
-      minimatch: 7.4.6
+      '@verdaccio/core': 8.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+      js-yaml: 4.1.1
+      lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  '@verdaccio/core@8.0.0-next-8.1':
+  '@verdaccio/core@8.1.1':
     dependencies:
-      ajv: 8.17.1
-      core-js: 3.37.1
-      http-errors: 2.0.0
+      ajv: 8.18.0
+      http-errors: 2.0.1
       http-status-codes: 2.3.0
+      minimatch: 7.4.9
       process-warning: 1.0.0
-      semver: 7.6.3
-    optional: true
+      semver: 7.7.4
 
-  '@verdaccio/core@8.0.0-next-8.7':
-    dependencies:
-      ajv: 8.17.1
-      core-js: 3.37.1
-      http-errors: 2.0.0
-      http-status-codes: 2.3.0
-      process-warning: 1.0.0
-      semver: 7.6.3
-    optional: true
-
-  '@verdaccio/file-locking@10.3.1':
+  '@verdaccio/file-locking@13.0.1':
     dependencies:
       lockfile: 1.0.4
-    optional: true
 
-  '@verdaccio/file-locking@13.0.0-next-8.2':
+  '@verdaccio/hooks@8.0.2':
     dependencies:
-      lockfile: 1.0.4
-    optional: true
-
-  '@verdaccio/loaders@8.0.0-next-8.4':
-    dependencies:
-      debug: 4.3.7
-      lodash: 4.17.21
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/logger': 8.0.2
+      debug: 4.4.3(supports-color@8.1.1)
+      got-cjs: 12.5.4
+      handlebars: 4.7.9
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  '@verdaccio/local-storage-legacy@11.0.2':
+  '@verdaccio/loaders@8.0.2':
     dependencies:
-      '@verdaccio/commons-api': 10.2.0
-      '@verdaccio/file-locking': 10.3.1
-      '@verdaccio/streams': 10.2.1
-      async: 3.2.4
-      debug: 4.3.4
-      lodash: 4.17.21
+      '@verdaccio/core': 8.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+      lodash: 4.18.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/local-storage-legacy@11.3.3':
+    dependencies:
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/file-locking': 13.0.1
+      '@verdaccio/streams': 10.2.5
+      debug: 4.4.3(supports-color@8.1.1)
+      globby: 11.1.0
+      lodash: 4.18.1
       lowdb: 1.0.0
       mkdirp: 1.0.4
+      sanitize-filename: 1.6.4
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  '@verdaccio/logger-commons@8.0.0-next-8.7':
+  '@verdaccio/logger-commons@8.0.2':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.7
-      '@verdaccio/logger-prettify': 8.0.0-next-8.1
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/logger-prettify': 8.0.1
       colorette: 2.0.20
-      debug: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  '@verdaccio/logger-prettify@8.0.0-next-8.1':
+  '@verdaccio/logger-prettify@8.0.1':
     dependencies:
       colorette: 2.0.20
-      dayjs: 1.11.13
-      lodash: 4.17.21
+      dayjs: 1.11.18
+      lodash: 4.18.1
+      on-exit-leak-free: 2.1.2
       pino-abstract-transport: 1.2.0
       sonic-boom: 3.8.1
-    optional: true
 
-  '@verdaccio/logger@8.0.0-next-8.7':
+  '@verdaccio/logger@8.0.2':
     dependencies:
-      '@verdaccio/logger-commons': 8.0.0-next-8.7
-      pino: 9.5.0
+      '@verdaccio/logger-commons': 8.0.2
+      pino: 9.14.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  '@verdaccio/middleware@8.0.0-next-8.7':
+  '@verdaccio/middleware@8.0.2':
     dependencies:
-      '@verdaccio/config': 8.0.0-next-8.7
-      '@verdaccio/core': 8.0.0-next-8.7
-      '@verdaccio/url': 13.0.0-next-8.7
-      '@verdaccio/utils': 8.1.0-next-8.7
-      debug: 4.4.0
-      express: 4.21.2
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/url': 13.0.2
+      debug: 4.4.3(supports-color@8.1.1)
+      express: 4.22.1
       express-rate-limit: 5.5.1
-      lodash: 4.17.21
+      lodash: 4.18.1
       lru-cache: 7.18.3
-      mime: 2.6.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  '@verdaccio/search-indexer@8.0.0-next-8.2':
-    optional: true
-
-  '@verdaccio/signature@8.0.0-next-8.1':
+  '@verdaccio/package-filter@13.0.2':
     dependencies:
-      debug: 4.3.7
-      jsonwebtoken: 9.0.2
+      '@verdaccio/core': 8.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  '@verdaccio/streams@10.2.1':
-    optional: true
-
-  '@verdaccio/tarball@13.0.0-next-8.7':
+  '@verdaccio/search-indexer@8.0.2':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.7
-      '@verdaccio/url': 13.0.0-next-8.7
-      '@verdaccio/utils': 8.1.0-next-8.7
-      debug: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
+      fuse.js: 7.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/signature@8.0.2':
+    dependencies:
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+      jsonwebtoken: 9.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/streams@10.2.5': {}
+
+  '@verdaccio/tarball@13.0.2':
+    dependencies:
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/url': 13.0.2
+      debug: 4.4.3(supports-color@8.1.1)
       gunzip-maybe: 1.4.2
-      lodash: 4.17.21
       tar-stream: 3.1.7
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  '@verdaccio/ui-theme@8.0.0-next-8.7':
-    optional: true
-
-  '@verdaccio/url@13.0.0-next-8.7':
+  '@verdaccio/ui-theme@9.0.0-next-9.14':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.7
-      debug: 4.4.0
-      lodash: 4.17.21
-      validator: 13.12.0
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  '@verdaccio/utils@7.0.1-next-8.1':
+  '@verdaccio/url@13.0.2':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.1
-      lodash: 4.17.21
-      minimatch: 7.4.6
-      semver: 7.6.3
-    optional: true
+      '@verdaccio/core': 8.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+      validator: 13.15.26
+    transitivePeerDependencies:
+      - supports-color
 
-  '@verdaccio/utils@8.1.0-next-8.7':
+  '@verdaccio/utils@8.1.2':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.7
-      lodash: 4.17.21
-      minimatch: 7.4.6
-      semver: 7.6.3
-    optional: true
+      '@verdaccio/core': 8.1.1
+      lodash: 4.18.1
+      minimatch: 7.4.9
 
   '@vitejs/plugin-basic-ssl@2.1.4(vite@7.3.2(@types/node@22.6.2)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.89.2)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(yaml@2.9.0))':
     dependencies:
@@ -21076,7 +21043,6 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   agent-base@7.1.3: {}
 
@@ -21113,14 +21079,6 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  ajv@8.17.1:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.0.6
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-    optional: true
 
   ajv@8.18.0:
     dependencies:
@@ -21200,8 +21158,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  apache-md5@1.1.8:
-    optional: true
+  apache-md5@1.1.8: {}
 
   arch@2.2.0: {}
 
@@ -21249,6 +21206,8 @@ snapshots:
 
   array-ify@1.0.0: {}
 
+  array-union@2.1.0: {}
+
   asn1@0.2.6:
     dependencies:
       safer-buffer: 2.1.2
@@ -21271,17 +21230,13 @@ snapshots:
 
   async-sema@3.1.1: {}
 
-  async@3.2.4:
-    optional: true
-
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
 
   at-least-node@1.0.0: {}
 
-  atomic-sleep@1.0.0:
-    optional: true
+  atomic-sleep@1.0.0: {}
 
   autoprefixer@10.4.27(postcss@8.5.12):
     dependencies:
@@ -21465,8 +21420,7 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  bcryptjs@2.4.3:
-    optional: true
+  bcryptjs@2.4.3: {}
 
   beasties@0.4.1:
     dependencies:
@@ -21571,7 +21525,6 @@ snapshots:
   browserify-zlib@0.1.4:
     dependencies:
       pako: 0.2.9
-    optional: true
 
   browserslist@4.28.2:
     dependencies:
@@ -21597,8 +21550,7 @@ snapshots:
 
   buffer-crc32@1.0.0: {}
 
-  buffer-equal-constant-time@1.0.1:
-    optional: true
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -21653,6 +21605,8 @@ snapshots:
       ssri: 13.0.1
       unique-filename: 5.0.0
 
+  cacheable-lookup@6.1.0: {}
+
   cacheable-lookup@7.0.0: {}
 
   cacheable-request@10.2.14:
@@ -21664,6 +21618,16 @@ snapshots:
       mimic-response: 4.0.0
       normalize-url: 8.0.2
       responselike: 3.0.0
+
+  cacheable-request@7.0.2:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
 
   cachedir@2.4.0: {}
 
@@ -21846,7 +21810,6 @@ snapshots:
   clipanion@4.0.0-rc.4(typanion@3.14.0):
     dependencies:
       typanion: 3.14.0
-    optional: true
 
   cliui@7.0.4:
     dependencies:
@@ -21871,6 +21834,10 @@ snapshots:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
+
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
 
   clone@1.0.4: {}
 
@@ -21947,19 +21914,6 @@ snapshots:
   compressible@2.0.18:
     dependencies:
       mime-db: 1.54.0
-
-  compression@1.7.5:
-    dependencies:
-      bytes: 3.1.2
-      compressible: 2.0.18
-      debug: 2.6.9
-      negotiator: 0.6.4
-      on-headers: 1.0.2
-      safe-buffer: 5.2.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   compression@1.8.1:
     dependencies:
@@ -22140,14 +22094,16 @@ snapshots:
     dependencies:
       browserslist: 4.28.2
 
-  core-js@3.37.1:
-    optional: true
-
   core-util-is@1.0.2: {}
 
   core-util-is@1.0.3: {}
 
   cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
@@ -22657,6 +22613,8 @@ snapshots:
 
   dayjs@1.11.13: {}
 
+  dayjs@1.11.18: {}
+
   db0@0.3.4(drizzle-orm@0.33.0(@types/react@18.3.23)(postgres@3.4.7)(react@19.1.0)):
     optionalDependencies:
       drizzle-orm: 0.33.0(@types/react@18.3.23)(postgres@3.4.7)(react@19.1.0)
@@ -22670,21 +22628,6 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
-
-  debug@4.3.4:
-    dependencies:
-      ms: 2.1.2
-    optional: true
-
-  debug@4.3.7:
-    dependencies:
-      ms: 2.1.3
-    optional: true
-
-  debug@4.4.0:
-    dependencies:
-      ms: 2.1.3
-    optional: true
 
   debug@4.4.1:
     dependencies:
@@ -22893,7 +22836,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
       stream-shift: 1.0.3
-    optional: true
 
   eastasianwidth@0.2.0: {}
 
@@ -22905,7 +22847,6 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   ee-first@1.1.1: {}
 
@@ -22985,8 +22926,7 @@ snapshots:
   env-paths@3.0.0:
     optional: true
 
-  envinfo@7.14.0:
-    optional: true
+  envinfo@7.21.0: {}
 
   environment@1.1.0: {}
 
@@ -23465,50 +23405,12 @@ snapshots:
 
   exponential-backoff@3.1.2: {}
 
-  express-rate-limit@5.5.1:
-    optional: true
+  express-rate-limit@5.5.1: {}
 
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
       ip-address: 10.1.0
-
-  express@4.21.2:
-    dependencies:
-      accepts: 1.3.8
-      array-flatten: 1.1.1
-      body-parser: 1.20.3
-      content-disposition: 0.5.4
-      content-type: 1.0.5
-      cookie: 0.7.1
-      cookie-signature: 1.0.6
-      debug: 2.6.9
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 1.3.1
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      merge-descriptors: 1.0.3
-      methods: 1.1.2
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      path-to-regexp: 0.1.12
-      proxy-addr: 2.0.7
-      qs: 6.13.0
-      range-parser: 1.2.1
-      safe-buffer: 5.2.1
-      send: 0.19.0
-      serve-static: 1.16.2
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      type-is: 1.6.18
-      utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   express@4.22.1:
     dependencies:
@@ -23621,12 +23523,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fast-redact@3.5.0:
-    optional: true
-
-  fast-safe-stringify@2.1.1:
-    optional: true
 
   fast-uri@3.0.6: {}
 
@@ -23811,6 +23707,8 @@ snapshots:
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.24.2)
 
+  form-data-encoder@1.7.2: {}
+
   form-data-encoder@2.1.4: {}
 
   form-data@4.0.5:
@@ -23889,6 +23787,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   function-timeout@1.0.2: {}
+
+  fuse.js@7.3.0: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -24052,6 +23952,15 @@ snapshots:
 
   globals@17.6.0: {}
 
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
+
   globby@14.1.0:
     dependencies:
       '@sindresorhus/merge-streams': 2.3.0
@@ -24073,6 +23982,21 @@ snapshots:
   globrex@0.1.2: {}
 
   gopd@1.2.0: {}
+
+  got-cjs@12.5.4:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/responselike': 1.0.0
+      cacheable-lookup: 6.1.0
+      cacheable-request: 7.0.2
+      decompress-response: 6.0.0
+      form-data-encoder: 1.7.2
+      get-stream: 6.0.1
+      http2-wrapper: 2.2.1
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
 
   got@13.0.0:
     dependencies:
@@ -24102,7 +24026,6 @@ snapshots:
       peek-stream: 1.1.3
       pumpify: 1.5.1
       through2: 2.0.5
-    optional: true
 
   gzip-size@7.0.0:
     dependencies:
@@ -24331,11 +24254,7 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
-  http-status-codes@2.2.0:
-    optional: true
-
-  http-status-codes@2.3.0:
-    optional: true
+  http-status-codes@2.3.0: {}
 
   http2-wrapper@2.2.1:
     dependencies:
@@ -24348,7 +24267,6 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -24502,8 +24420,7 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
-  is-deflate@1.0.0:
-    optional: true
+  is-deflate@1.0.0: {}
 
   is-docker@2.2.1: {}
 
@@ -24523,8 +24440,7 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
-  is-gzip@1.0.0:
-    optional: true
+  is-gzip@1.0.0: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -24567,8 +24483,7 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
-  is-promise@2.2.2:
-    optional: true
+  is-promise@2.2.2: {}
 
   is-promise@4.0.0: {}
 
@@ -25077,10 +24992,9 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.0:
+  js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
-    optional: true
 
   js-yaml@4.2.0:
     dependencies:
@@ -25164,9 +25078,9 @@ snapshots:
 
   jsonparse@1.3.1: {}
 
-  jsonwebtoken@9.0.2:
+  jsonwebtoken@9.0.3:
     dependencies:
-      jws: 3.2.2
+      jws: 4.0.1
       lodash.includes: 4.3.0
       lodash.isboolean: 3.0.3
       lodash.isinteger: 4.0.4
@@ -25176,7 +25090,6 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.6.3
-    optional: true
 
   jsprim@2.0.2:
     dependencies:
@@ -25185,18 +25098,16 @@ snapshots:
       json-schema: 0.4.0
       verror: 1.10.0
 
-  jwa@1.4.2:
+  jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
-    optional: true
 
-  jws@3.2.2:
+  jws@4.0.1:
     dependencies:
-      jwa: 1.4.2
+      jwa: 2.0.1
       safe-buffer: 5.2.1
-    optional: true
 
   karma-source-map-support@1.4.0:
     dependencies:
@@ -25447,7 +25358,6 @@ snapshots:
   lockfile@1.0.4:
     dependencies:
       signal-exit: 3.0.7
-    optional: true
 
   lodash-es@4.17.21: {}
 
@@ -25463,19 +25373,15 @@ snapshots:
 
   lodash.escaperegexp@4.1.2: {}
 
-  lodash.includes@4.3.0:
-    optional: true
+  lodash.includes@4.3.0: {}
 
   lodash.isarguments@3.1.0: {}
 
-  lodash.isboolean@3.0.3:
-    optional: true
+  lodash.isboolean@3.0.3: {}
 
-  lodash.isinteger@4.0.4:
-    optional: true
+  lodash.isinteger@4.0.4: {}
 
-  lodash.isnumber@3.0.3:
-    optional: true
+  lodash.isnumber@3.0.3: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -25502,6 +25408,8 @@ snapshots:
   lodash.upperfirst@4.3.1: {}
 
   lodash@4.17.21: {}
+
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -25546,14 +25454,15 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       is-promise: 2.2.2
-      lodash: 4.17.21
+      lodash: 4.18.1
       pify: 3.0.0
       steno: 0.4.4
-    optional: true
 
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
+
+  lowercase-keys@2.0.0: {}
 
   lowercase-keys@3.0.0: {}
 
@@ -25565,8 +25474,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lru-cache@7.18.3:
-    optional: true
+  lru-cache@7.18.3: {}
 
   luxon@3.7.2: {}
 
@@ -25746,11 +25654,7 @@ snapshots:
 
   mime@2.5.2: {}
 
-  mime@2.6.0:
-    optional: true
-
-  mime@3.0.0:
-    optional: true
+  mime@3.0.0: {}
 
   mime@4.1.0: {}
 
@@ -25759,6 +25663,8 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
+
+  mimic-response@1.0.1: {}
 
   mimic-response@3.1.0: {}
 
@@ -25795,10 +25701,9 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
-  minimatch@7.4.6:
+  minimatch@7.4.9:
     dependencies:
       brace-expansion: 2.0.2
-    optional: true
 
   minimatch@9.0.5:
     dependencies:
@@ -25840,8 +25745,7 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  mkdirp@1.0.4:
-    optional: true
+  mkdirp@1.0.4: {}
 
   mkdirp@3.0.1: {}
 
@@ -25857,9 +25761,6 @@ snapshots:
   mrmime@2.0.1: {}
 
   ms@2.0.0: {}
-
-  ms@2.1.2:
-    optional: true
 
   ms@2.1.3: {}
 
@@ -26101,7 +26002,6 @@ snapshots:
       whatwg-url: 5.0.0
     optionalDependencies:
       encoding: 0.1.13
-    optional: true
 
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
@@ -26172,6 +26072,8 @@ snapshots:
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
+
+  normalize-url@6.1.0: {}
 
   normalize-url@8.0.2: {}
 
@@ -26382,15 +26284,11 @@ snapshots:
 
   ohash@2.0.11: {}
 
-  on-exit-leak-free@2.1.2:
-    optional: true
+  on-exit-leak-free@2.1.2: {}
 
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
-
-  on-headers@1.0.2:
-    optional: true
 
   on-headers@1.1.0: {}
 
@@ -26528,6 +26426,8 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
 
+  p-cancelable@2.1.1: {}
+
   p-cancelable@3.0.0: {}
 
   p-each-series@3.0.0: {}
@@ -26624,8 +26524,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  pako@0.2.9:
-    optional: true
+  pako@0.2.9: {}
 
   param-case@3.0.4:
     dependencies:
@@ -26751,7 +26650,6 @@ snapshots:
       buffer-from: 1.1.2
       duplexify: 3.7.1
       through2: 2.0.5
-    optional: true
 
   pend@1.2.0: {}
 
@@ -26776,30 +26674,26 @@ snapshots:
     dependencies:
       readable-stream: 4.7.0
       split2: 4.2.0
-    optional: true
 
   pino-abstract-transport@2.0.0:
     dependencies:
       split2: 4.2.0
-    optional: true
 
-  pino-std-serializers@7.0.0:
-    optional: true
+  pino-std-serializers@7.0.0: {}
 
-  pino@9.5.0:
+  pino@9.14.0:
     dependencies:
+      '@pinojs/redact': 0.4.0
       atomic-sleep: 1.0.0
-      fast-redact: 3.5.0
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 2.0.0
       pino-std-serializers: 7.0.0
-      process-warning: 4.0.1
+      process-warning: 5.0.0
       quick-format-unescaped: 4.0.4
       real-require: 0.2.0
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.0
       thread-stream: 3.1.0
-    optional: true
 
   pirates@4.0.7: {}
 
@@ -26841,9 +26735,6 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
-
-  pkginfo@0.4.1:
-    optional: true
 
   pkijs@3.4.0:
     dependencies:
@@ -27392,11 +27283,9 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
-  process-warning@1.0.0:
-    optional: true
+  process-warning@1.0.0: {}
 
-  process-warning@4.0.1:
-    optional: true
+  process-warning@5.0.0: {}
 
   process@0.11.10: {}
 
@@ -27427,7 +27316,6 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
-    optional: true
 
   pump@3.0.3:
     dependencies:
@@ -27439,7 +27327,6 @@ snapshots:
       duplexify: 3.7.1
       inherits: 2.0.4
       pump: 2.0.1
-    optional: true
 
   punycode@2.3.1: {}
 
@@ -27455,11 +27342,6 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  qs@6.13.1:
-    dependencies:
-      side-channel: 1.1.0
-    optional: true
-
   qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
@@ -27472,8 +27354,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  quick-format-unescaped@4.0.4:
-    optional: true
+  quick-format-unescaped@4.0.4: {}
 
   quick-lru@5.1.1: {}
 
@@ -27578,8 +27459,7 @@ snapshots:
 
   readdirp@5.0.0: {}
 
-  real-require@0.2.0:
-    optional: true
+  real-require@0.2.0: {}
 
   recast@0.23.11:
     dependencies:
@@ -27688,6 +27568,10 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
 
   responselike@3.0.0:
     dependencies:
@@ -27834,10 +27718,13 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  safe-stable-stringify@2.5.0:
-    optional: true
+  safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  sanitize-filename@1.6.4:
+    dependencies:
+      truncate-utf8-bytes: 1.0.2
 
   sass-embedded-android-arm64@1.89.2:
     optional: true
@@ -28046,6 +27933,8 @@ snapshots:
 
   semver@7.7.4: {}
 
+  semver@7.8.0: {}
+
   send@0.19.0:
     dependencies:
       debug: 2.6.9
@@ -28247,12 +28136,10 @@ snapshots:
   sonic-boom@3.8.1:
     dependencies:
       atomic-sleep: 1.0.0
-    optional: true
 
   sonic-boom@4.2.0:
     dependencies:
       atomic-sleep: 1.0.0
-    optional: true
 
   sort-keys-length@1.0.1:
     dependencies:
@@ -28419,7 +28306,6 @@ snapshots:
   steno@0.4.4:
     dependencies:
       graceful-fs: 4.2.11
-    optional: true
 
   storybook@10.4.2(@testing-library/dom@10.4.0)(@types/react@18.3.23)(prettier@3.8.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -28457,8 +28343,7 @@ snapshots:
     dependencies:
       duplexer: 0.1.2
 
-  stream-shift@1.0.3:
-    optional: true
+  stream-shift@1.0.3: {}
 
   streamroller@3.1.5:
     dependencies:
@@ -28741,7 +28626,6 @@ snapshots:
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
-    optional: true
 
   throttleit@1.0.1: {}
 
@@ -28825,6 +28709,10 @@ snapshots:
       tslib: 2.8.1
 
   tree-kill@1.2.2: {}
+
+  truncate-utf8-bytes@1.0.2:
+    dependencies:
+      utf8-byte-length: 1.0.5
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -28949,8 +28837,7 @@ snapshots:
 
   tweetnacl@0.14.5: {}
 
-  typanion@3.14.0:
-    optional: true
+  typanion@3.14.0: {}
 
   type-check@0.4.0:
     dependencies:
@@ -29096,8 +28983,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unix-crypt-td-js@1.1.4:
-    optional: true
+  unix-crypt-td-js@1.1.4: {}
 
   unpipe@1.0.0: {}
 
@@ -29208,6 +29094,8 @@ snapshots:
     dependencies:
       react: 19.1.0
 
+  utf8-byte-length@1.0.5: {}
+
   util-deprecate@1.0.2: {}
 
   utila@0.4.0: {}
@@ -29233,83 +29121,72 @@ snapshots:
 
   validate-npm-package-name@7.0.2: {}
 
-  validator@13.12.0:
-    optional: true
+  validator@13.15.26: {}
 
   varint@6.0.0: {}
 
   vary@1.1.2: {}
 
-  verdaccio-audit@13.0.0-next-8.7(encoding@0.1.13):
+  verdaccio-audit@13.0.2(encoding@0.1.13):
     dependencies:
-      '@verdaccio/config': 8.0.0-next-8.7
-      '@verdaccio/core': 8.0.0-next-8.7
-      express: 4.21.2
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      express: 4.22.1
       https-proxy-agent: 5.0.1
       node-fetch: 2.6.7(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
-  verdaccio-htpasswd@13.0.0-next-8.7:
+  verdaccio-htpasswd@13.0.2:
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.7
-      '@verdaccio/file-locking': 13.0.0-next-8.2
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/file-locking': 13.0.1
       apache-md5: 1.1.8
       bcryptjs: 2.4.3
-      core-js: 3.37.1
-      debug: 4.4.0
-      http-errors: 2.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      http-errors: 2.0.1
       unix-crypt-td-js: 1.1.4
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  verdaccio@6.0.5(encoding@0.1.13)(typanion@3.14.0):
+  verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0):
     dependencies:
-      '@cypress/request': 3.0.7
-      '@verdaccio/auth': 8.0.0-next-8.7
-      '@verdaccio/config': 8.0.0-next-8.7
-      '@verdaccio/core': 8.0.0-next-8.7
-      '@verdaccio/local-storage-legacy': 11.0.2
-      '@verdaccio/logger': 8.0.0-next-8.7
-      '@verdaccio/middleware': 8.0.0-next-8.7
-      '@verdaccio/search-indexer': 8.0.0-next-8.2
-      '@verdaccio/signature': 8.0.0-next-8.1
-      '@verdaccio/streams': 10.2.1
-      '@verdaccio/tarball': 13.0.0-next-8.7
-      '@verdaccio/ui-theme': 8.0.0-next-8.7
-      '@verdaccio/url': 13.0.0-next-8.7
-      '@verdaccio/utils': 7.0.1-next-8.1
+      '@cypress/request': 3.0.10
+      '@verdaccio/auth': 8.0.2
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/hooks': 8.0.2
+      '@verdaccio/loaders': 8.0.2
+      '@verdaccio/local-storage-legacy': 11.3.3
+      '@verdaccio/logger': 8.0.2
+      '@verdaccio/middleware': 8.0.2
+      '@verdaccio/package-filter': 13.0.2
+      '@verdaccio/search-indexer': 8.0.2
+      '@verdaccio/signature': 8.0.2
+      '@verdaccio/streams': 10.2.5
+      '@verdaccio/tarball': 13.0.2
+      '@verdaccio/ui-theme': 9.0.0-next-9.14
+      '@verdaccio/url': 13.0.2
+      '@verdaccio/utils': 8.1.2
       JSONStream: 1.3.5
       async: 3.2.6
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
-      compression: 1.7.5
-      cors: 2.8.5
-      debug: 4.4.0
-      envinfo: 7.14.0
-      express: 4.21.2
-      express-rate-limit: 5.5.1
-      fast-safe-stringify: 2.1.1
-      handlebars: 4.7.9
-      js-yaml: 4.1.0
-      jsonwebtoken: 9.0.2
-      kleur: 4.1.5
-      lodash: 4.17.21
+      compression: 1.8.1
+      cors: 2.8.6
+      debug: 4.4.3(supports-color@8.1.1)
+      envinfo: 7.21.0
+      express: 4.22.1
+      lodash: 4.18.1
       lru-cache: 7.18.3
       mime: 3.0.0
-      mkdirp: 1.0.4
-      pkginfo: 0.4.1
-      semver: 7.6.3
-      validator: 13.12.0
-      verdaccio-audit: 13.0.0-next-8.7(encoding@0.1.13)
-      verdaccio-htpasswd: 13.0.0-next-8.7
+      semver: 7.8.0
+      verdaccio-audit: 13.0.2(encoding@0.1.13)
+      verdaccio-htpasswd: 13.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
       - typanion
-    optional: true
 
   verror@1.10.0:
     dependencies:

--- a/project.json
+++ b/project.json
@@ -2,6 +2,14 @@
 	"name": "spartan",
 	"$schema": "node_modules/nx/schemas/project-schema.json",
 	"targets": {
+		"local-registry": {
+			"executor": "@nx/js:verdaccio",
+			"options": {
+				"port": 4873,
+				"config": ".verdaccio/config.yml",
+				"storage": "tmp/local-registry/storage"
+			}
+		},
 		"ui-api-definition": {
 			"executor": "@spartan-ng/tools:generate-ui-docs",
 			"options": {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (the cli-smoke harness)
- [x] Docs have been added / updated (apps/cli-smoke/README.md)

## PR Type

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [x] Other... Please describe: test infrastructure

## Which package are you modifying?

### Primitives

- [x] carousel
- [x] scroll-area

### Others

- [x] cli
- [x] repo

## What is the current behavior?

We support several CLI setup combinations (nx monorepo, nx standalone, Angular CLI; library vs
entrypoint; buildable vs non-buildable) but have no automated way to verify them, so per-setup and
per-component regressions ship undetected.

Building this harness immediately surfaced three real, previously-undetected bugs (all fixed here):

- **carousel** does not compile in a fresh workspace: `embla-carousel-angular@22` stopped re-exporting
  the embla option/event/plugin types (`TS2459`).
- **scroll-area** does not compile in a fresh workspace: the directive imports `provideScrollbarOptions`
  from `ngx-scrollbar`, but the generator never declared/installed it (`TS2307`).
- The **nx generators** assume a root `tsconfig.base.json`, so they fail on a standalone nx workspace
  with `File not found: tsconfig.base.json`.

## What is the new behavior?

**New: `cli-smoke` setup-matrix harness** (`apps/cli-smoke`). For every supported setup it scaffolds a
real workspace from the locally published CLI (via a verdaccio local registry), runs `init` + `ui`, runs
the CLI's own `healthcheck`, drops in a probe component that consumes the generated code through the
`@spartan-ng/helm/*` alias, builds it, and asserts the theme CSS reached the output.

- Matrix: nx monorepo `{library, entrypoint} x {buildable, non-buildable}`, an `nx-standalone` cell, an
  `acli` (Angular CLI, no Nx) cell, and an `all-components` cell that generates and builds every
  supported primitive (the per-component catch-all that found carousel and scroll-area).
- CI: a dedicated `cli-smoke.yml` fans each cell out to its own runner (parallel), with a single required
  `cli-smoke result` check. It runs on every PR but is cheap on unrelated ones (a `git diff` gate before
  install plus an in-runner affected check). `pnpm smoke` runs the full matrix locally.

**Fixes**

- `carousel` now imports the embla types from the base `embla-carousel` package (works on v21 and v22).
- `scroll-area` now declares `ngx-scrollbar` as a generator peer dependency, so a generated scroll-area
  installs it and compiles.
- The nx generators resolve the workspace root tsconfig with `getRootTsConfigPathInTree` instead of
  assuming `tsconfig.base.json`, so a standalone nx workspace works.

**Feature**

- `init` and `ui-theme` generators support a non-interactive mode (`--theme=...`) for scripting/CI;
  interactive prompts are unchanged when no theme is passed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

To enable as a required check after merge: add **`cli-smoke result`** to branch protection. Validated on
CI: full matrix green (every cell, including `all-components` at ~3 min). `cli` (167) and `helm` unit
tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI smoke testing infrastructure: CI workflows (per-PR and nightly), local test registry, and a matrix of workspace setups for end-to-end smoke tests
  * Added npm script to run the CLI smoke suite locally

* **Documentation**
  * Added user-facing docs describing the CLI smoke test suite and how to run matrix cells locally

* **Updates**
  * Non-interactive CLI init and theme generation for CI/automation
  * Carousel/scroll-area compatibility updated for newer peer dependency versions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->