### PR TITLE
fix(cli): avoid @nx/workspace barrel import in migrate-helm-libraries

### DIFF
--- a/libs/cli/src/generators/migrate-helm-libraries/generator.spec.ts
+++ b/libs/cli/src/generators/migrate-helm-libraries/generator.spec.ts
@@ -8,6 +8,10 @@ jest.mock('enquirer');
 describe('migrate-helm-libraries generator', () => {
 	let tree: Tree;
 
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
 	beforeEach(() => {
 		tree = createTreeWithEmptyWorkspace();
 
@@ -37,7 +41,7 @@ describe('migrate-helm-libraries generator', () => {
 				buildable: true,
 				importAlias: '@spartan-ng/helm',
 			}),
-		).resolves.not.toThrow();
+		).resolves.toBeUndefined();
 
 		expect(infoSpy).toHaveBeenCalledWith('No libraries to migrate');
 	});

--- a/libs/cli/src/generators/migrate-helm-libraries/generator.spec.ts
+++ b/libs/cli/src/generators/migrate-helm-libraries/generator.spec.ts
@@ -1,0 +1,44 @@
+import { logger, type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { migrateHelmLibrariesGenerator } from './generator';
+
+// patch some imports to avoid running the actual code
+jest.mock('enquirer');
+
+describe('migrate-helm-libraries generator', () => {
+	let tree: Tree;
+
+	beforeEach(() => {
+		tree = createTreeWithEmptyWorkspace();
+
+		// provide a valid config so the generator does not prompt
+		tree.write(
+			'components.json',
+			JSON.stringify({
+				componentsPath: 'libs/ui',
+				importAlias: '@spartan-ng/helm',
+				generateAs: 'library',
+				buildable: true,
+			}),
+		);
+	});
+
+	// Regression test for the `@nx/workspace` barrel import.
+	// Importing `removeGenerator` from the `@nx/workspace` entry point eagerly evaluates the
+	// barrel, which loads `convert-to-nx-project` -> `output.js`. On nx 22 that module crashes
+	// with "Cannot read properties of undefined (reading 'inverse')", so the generator threw
+	// before doing any work. Loading the generator and running it must not throw.
+	it('should run without crashing on the @nx/workspace barrel import', async () => {
+		const infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+
+		await expect(
+			migrateHelmLibrariesGenerator(tree, {
+				generateAs: 'library',
+				buildable: true,
+				importAlias: '@spartan-ng/helm',
+			}),
+		).resolves.not.toThrow();
+
+		expect(infoSpy).toHaveBeenCalledWith('No libraries to migrate');
+	});
+});

--- a/libs/cli/src/generators/migrate-helm-libraries/generator.ts
+++ b/libs/cli/src/generators/migrate-helm-libraries/generator.ts
@@ -1,6 +1,11 @@
 import { formatFiles, logger, readJson, type Tree, updateJson } from '@nx/devkit';
 import { getRootTsConfigPathInTree } from '@nx/js';
-import { removeGenerator } from '@nx/workspace';
+// Import `removeGenerator` from its module directly rather than the `@nx/workspace` barrel.
+// The barrel eagerly evaluates `convert-to-nx-project`, whose `output.js` crashes on nx 22
+// ("Cannot read properties of undefined (reading 'inverse')") due to a chalk/tslib interop
+// issue in nx itself. Importing the generator directly avoids loading that module.
+// See https://github.com/nrwl/nx/issues/35521 - revert to the barrel once nx ships the fix.
+import { removeGenerator } from '@nx/workspace/src/generators/remove/remove';
 import { prompt } from 'enquirer';
 import { dirname, join } from 'path';
 import { getOrCreateConfig } from '../../utils/config';

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -5088,7 +5088,13 @@ exports[`generate-ui-docs executor produces stable output 1`] = `
         "selector": "[hlmSidebarSeparator],hlm-sidebar-separator",
       },
       "HlmSidebarTrigger": {
-        "inputs": [],
+        "inputs": [
+          {
+            "name": "srOnlyText",
+            "required": false,
+            "type": "unknown",
+          },
+        ],
         "models": [],
         "outputs": [],
         "selector": "button[hlmSidebarTrigger]",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Others

- [x] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `migrate-helm-libraries` generator imports `removeGenerator` from the
`@nx/workspace` barrel entry point. On nx 22 that barrel eagerly evaluates
`convert-to-nx-project`, which loads `output.js` and crashes with
"Cannot read properties of undefined (reading 'inverse')". As a result the
generator throws on import, before doing any work, and the migration cannot run.

Closes #1364

## What is the new behavior?

`removeGenerator` is now imported directly from its module
(`@nx/workspace/src/generators/remove/remove`) instead of the barrel, so the
crashing `convert-to-nx-project` / `output.js` module is never loaded. The
generator runs as expected again.

A regression test was added that runs the generator against an empty workspace
and asserts it does not throw (and logs "No libraries to migrate").

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The direct import is a workaround for an upstream nx issue; once nx ships a fix
the import can be reverted to the `@nx/workspace` barrel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash in the migrate-helm-libraries generator when certain import patterns are present.

* **Tests**
  * Added a regression test ensuring the generator runs without throwing and reports when there are no libraries to migrate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Note: this branch also regenerates the `generate-ui-docs` stable-output snapshot
(`libs/tools/.../executor.spec.ts.snap`) to add the `srOnlyText` input on
`HlmSidebarTrigger`. That snapshot had drifted on `main` but was masked by the
nx task cache; running `tools:test` uncached on this PR surfaced it. The
regeneration is unrelated to the cli fix and only matches the current component API.