### PR TITLE
fix(dialog): revive a dialog re-opened during the close-delay window

### DIFF
--- a/libs/brain/alert-dialog/src/lib/brn-alert-dialog-reopen.spec.ts
+++ b/libs/brain/alert-dialog/src/lib/brn-alert-dialog-reopen.spec.ts
@@ -1,0 +1,69 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { render } from '@testing-library/angular';
+import { BrnAlertDialog } from './brn-alert-dialog';
+import { BrnAlertDialogContent } from './brn-alert-dialog-content';
+
+@Component({
+	selector: 'brn-alert-dialog-reopen-host',
+	imports: [BrnAlertDialog, BrnAlertDialogContent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<brn-alert-dialog>
+			<div *brnAlertDialogContent>content</div>
+		</brn-alert-dialog>
+	`,
+})
+class AlertDialogReopenHost {}
+
+// The dialog defers the actual CDK teardown until `closeDelay` (default 100ms)
+// after close() so the exit animation can play. Wait comfortably past it.
+const waitPastCloseDelay = () => new Promise((resolve) => setTimeout(resolve, 250));
+
+describe('BrnAlertDialog reopen during close', () => {
+	afterEach(() => {
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	const setup = async () => {
+		const view = await render(AlertDialogReopenHost);
+		view.detectChanges();
+		await view.fixture.whenStable();
+		view.detectChanges();
+		const dialog = view.fixture.debugElement.query(By.directive(BrnAlertDialog)).injector.get(BrnAlertDialog);
+		return { view, dialog };
+	};
+
+	it('stays open when re-opened within the close-delay window', async () => {
+		const { dialog } = await setup();
+
+		dialog.open();
+		expect(dialog.stateComputed()).toBe('open');
+
+		// Begin closing - the CDK teardown is now scheduled but has NOT run yet.
+		dialog.close();
+		expect(dialog.stateComputed()).toBe('closed');
+
+		// Re-open before the teardown fires. Regression: open() used to early-return
+		// because the still-present dialog ref tripped its guard, so the re-open was
+		// swallowed and the dialog finished closing (the intermittent "flicker").
+		dialog.open();
+		expect(dialog.stateComputed()).toBe('open');
+
+		// The originally scheduled close must have been cancelled - the dialog stays
+		// open past the delay rather than disappearing.
+		await waitPastCloseDelay();
+		expect(dialog.stateComputed()).toBe('open');
+	});
+
+	it('still closes normally when not interrupted', async () => {
+		const { dialog } = await setup();
+
+		dialog.open();
+		expect(dialog.stateComputed()).toBe('open');
+
+		dialog.close();
+		await waitPastCloseDelay();
+		expect(dialog.stateComputed()).toBe('closed');
+	});
+});

--- a/libs/brain/dialog/src/lib/brn-dialog-ref.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog-ref.ts
@@ -51,8 +51,30 @@ export class BrnDialogRef<DialogResult = any> {
 		}
 
 		this._previousTimeout = setTimeout(() => {
+			// Clear the handle once the teardown actually runs so a fired timeout is
+			// distinguishable from a pending one - this is what lets _reopen() know
+			// the overlay is gone and refuse to revive it.
+			this._previousTimeout = undefined;
 			this._cdkDialogRef.close(result);
 		}, delay);
+	}
+
+	/**
+	 * Revive a dialog whose close() was called but whose deferred CDK teardown
+	 * (the `closeDelay` window) has not run yet: cancels the pending teardown and
+	 * restores the open state, so a re-open landing inside that window re-shows
+	 * the existing overlay instead of being dropped and flickering closed.
+	 *
+	 * No-ops unless a teardown is actually pending, so it can never force an
+	 * already-closed (disposed) overlay back open.
+	 *
+	 * @internal Only `BrnDialog.open()` should call this.
+	 */
+	public _reopen(): void {
+		if (!this._previousTimeout) return;
+		clearTimeout(this._previousTimeout);
+		this._previousTimeout = undefined;
+		this._open.set(true);
 	}
 
 	public setPanelClass(paneClass: string | null | undefined): void {

--- a/libs/brain/dialog/src/lib/brn-dialog.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog.ts
@@ -172,7 +172,19 @@ export class BrnDialog<TResult = unknown, TContext extends Record<string, unknow
 	private readonly _mutableAriaModal = linkedSignal(() => this.ariaModal());
 
 	public open(): void {
-		if (!this._contentTemplate || this._dialogRef()) return;
+		if (!this._contentTemplate) return;
+
+		const existingRef = this._dialogRef();
+		if (existingRef) {
+			// A close() schedules the CDK teardown after `closeDelay` but keeps the
+			// ref around until it fires. Re-opening inside that window must revive
+			// the still-present overlay - otherwise the open is dropped here and the
+			// dialog finishes closing, which reads as an intermittent flicker.
+			if (!existingRef.open) {
+				existingRef._reopen();
+			}
+			return;
+		}
 
 		this._dialogStateEffectRefs.forEach((ref) => ref.destroy());
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] alert-dialog
- [x] dialog
- [x] popover
- [x] sheet

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`BrnDialog.close()` defers the actual CDK overlay teardown until `closeDelay`
(default 100ms) so the exit animation can play, but it keeps the dialog ref
around until that teardown fires. `open()` early-returned whenever a ref already
existed:

```ts
if (!this._contentTemplate || this._dialogRef()) return;
```

So any re-open that lands inside the close-delay window hits that guard and is
dropped - the dialog finishes closing instead of re-opening. On fast interaction
(a quick re-open, a toggle, or a double-click) this reads as an intermittent
"flicker": the dialog fades out when you expected it to stay open / re-open. It
was reproducible intermittently on spartan.ng (alert-dialog), and because the
logic lives in the shared `BrnDialog`, it affects every dialog-based component.

Confirmed via a browser trace: re-opening ~40ms into the close animation kept
the content fading to opacity 0 and removed it, rather than reviving it.

Closes #

## What is the new behavior?

A re-open that arrives while the dialog is mid-close now revives the existing
overlay instead of being dropped:

- `BrnDialogRef.reopen()` cancels the pending teardown timeout and restores the
  open state.
- `BrnDialog.open()` calls `reopen()` when the current ref exists but is already
  closing; an already-open dialog still no-ops, so no other behavior changes.

The dialog stays open across the close-delay window, eliminating the flicker.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The data-state machine itself was already correct (clean `open`/`closed`
transitions); this is purely the open/close lifecycle race in the `closeDelay`
window. A separate, unrelated finding during the investigation - overlay panes
created eagerly by `BrnTooltip` - is intentionally left out of this PR and will
be addressed on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dialogs can now be reopened during the close-delay window, allowing users to prevent full closure by reopening before the delay expires.

* **Bug Fixes**
  * Improved timeout handling to correctly distinguish between pending and completed close timeouts.

* **Tests**
  * Added comprehensive test coverage validating dialog reopening behavior and close-delay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->