### PR TITLE
fix(native-select): use system colors for options in dark mode

### DIFF
--- a/libs/registry/src/styles/style-luma.css
+++ b/libs/registry/src/styles/style-luma.css
@@ -226,6 +226,11 @@
 		@apply text-muted-foreground end-2.5 top-1/2 -translate-y-1/2 text-[calc(var(--spacing)*4)];
 	}
 
+	.spartan-native-select [data-slot='native-select-option'],
+	.spartan-native-select [data-slot='native-select-optgroup'] {
+		@apply bg-[color:Canvas] text-[color:CanvasText];
+	}
+
 	/* MARK: Combobox */
 	.spartan-combobox-content {
 		@apply bg-popover text-popover-foreground data-open:animate-in **:has-[[data-slot=input-group-control]:focus-visible]:border-input data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/5 dark:ring-foreground/10 **:data-[slot=input-group]:bg-input/50 **:data-[slot=input-group]:border-input/30 max-h-72 min-w-36 overflow-hidden rounded-3xl shadow-lg ring-1 duration-100 **:has-[[data-slot=input-group-control]:focus-visible]:ring-0 **:data-[slot=input-group]:m-1.5 **:data-[slot=input-group]:mb-0 **:data-[slot=input-group]:h-8 **:data-[slot=input-group]:shadow-none;

--- a/libs/registry/src/styles/style-lyra.css
+++ b/libs/registry/src/styles/style-lyra.css
@@ -889,6 +889,11 @@
 		@apply text-muted-foreground end-2.5 top-1/2 -translate-y-1/2 text-[calc(var(--spacing)*4)];
 	}
 
+	.spartan-native-select [data-slot='native-select-option'],
+	.spartan-native-select [data-slot='native-select-optgroup'] {
+		@apply bg-[color:Canvas] text-[color:CanvasText];
+	}
+
 	/* MARK: Pagination */
 	.spartan-pagination-content {
 		@apply gap-0.5;

--- a/libs/registry/src/styles/style-maia.css
+++ b/libs/registry/src/styles/style-maia.css
@@ -911,6 +911,11 @@
 		@apply text-muted-foreground end-3.5 top-1/2 -translate-y-1/2 text-[calc(var(--spacing)*4)];
 	}
 
+	.spartan-native-select [data-slot='native-select-option'],
+	.spartan-native-select [data-slot='native-select-optgroup'] {
+		@apply bg-[color:Canvas] text-[color:CanvasText];
+	}
+
 	/* MARK: Pagination */
 	.spartan-pagination-content {
 		@apply gap-1;

--- a/libs/registry/src/styles/style-mira.css
+++ b/libs/registry/src/styles/style-mira.css
@@ -911,6 +911,11 @@
 		@apply text-muted-foreground end-1.5 top-1/2 -translate-y-1.5 text-[calc(var(--spacing)*3.5)] group-data-[size=sm]/native-select:-translate-y-1.25 group-data-[size=sm]/native-select:text-[calc(var(--spacing)*3)];
 	}
 
+	.spartan-native-select [data-slot='native-select-option'],
+	.spartan-native-select [data-slot='native-select-optgroup'] {
+		@apply bg-[color:Canvas] text-[color:CanvasText];
+	}
+
 	/* MARK: Pagination */
 	.spartan-pagination-content {
 		@apply gap-0.5;

--- a/libs/registry/src/styles/style-nova.css
+++ b/libs/registry/src/styles/style-nova.css
@@ -911,6 +911,11 @@
 		@apply text-muted-foreground end-2.5 top-1/2 -translate-y-1/2 text-[calc(var(--spacing)*4)];
 	}
 
+	.spartan-native-select [data-slot='native-select-option'],
+	.spartan-native-select [data-slot='native-select-optgroup'] {
+		@apply bg-[color:Canvas] text-[color:CanvasText];
+	}
+
 	/* MARK: Pagination */
 	.spartan-pagination-content {
 		@apply gap-0.5;

--- a/libs/registry/src/styles/style-vega.css
+++ b/libs/registry/src/styles/style-vega.css
@@ -907,6 +907,11 @@
 		@apply text-muted-foreground end-2.5 top-1/2 -translate-y-1/2 text-[calc(var(--spacing)*4)];
 	}
 
+	&.spartan-native-select [data-slot='native-select-option'],
+	&.spartan-native-select [data-slot='native-select-optgroup'] {
+		@apply bg-[color:Canvas] text-[color:CanvasText];
+	}
+
 	/* MARK: Pagination */
 	&.spartan-pagination-content {
 		@apply gap-1;


### PR DESCRIPTION
Chromium renders native select option popups using the select's translucent dark background, breaking contrast in dark mode. Style options and optgroups with the Canvas/CanvasText system colors so the dropdown adapts to the active color-scheme, matching shadcn.

Closes #1426

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [x] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1426

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated native select option and optgroup styling across all theme variants to consistently use system Canvas and CanvasText colors for improved visual rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->