### PR TITLE
fix(accordion): measure first element child in brn-accordion-content

### DIFF
--- a/libs/brain/accordion/src/lib/brn-accordion-content.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-content.ts
@@ -61,7 +61,10 @@ export class BrnAccordionContent {
 	}
 
 	private _measureAndSetDimensions(): boolean {
-		const content = this._elementRef.nativeElement.firstChild as HTMLElement | null;
+		// Measure the first ELEMENT child, not the first node: a leading text node
+		// (e.g. projected content compiled with `preserveWhitespaces: true`) has no
+		// `.style`, so measuring it throws "Cannot read properties of undefined".
+		const content = this._elementRef.nativeElement.firstElementChild as HTMLElement | null;
 		if (!content) return false;
 
 		const { width, height } = measureDimensions(content, this._config.measurementDisplay);

--- a/libs/brain/accordion/src/lib/brn-accordion.spec.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.spec.ts
@@ -94,12 +94,6 @@ class AccordionBlurDuringRenderSpec extends ProbeHost {}
 })
 class AccordionTriggerFocusDuringRenderSpec extends ProbeHost {}
 
-// brn-accordion-content measured `firstChild`, which is a Text node whenever the
-// projected content begins with a text node - the leading text below, or e.g. a
-// template compiled with `preserveWhitespaces: true` where the indentation before
-// the inner element survives as a Text node. measureDimensions then read `.style`
-// off that Text node and threw "Cannot read properties of undefined (reading
-// 'height')".
 @Component({
 	imports: [BrnAccordion, BrnAccordionItem, BrnAccordionTrigger, BrnAccordionContent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
@@ -153,16 +147,13 @@ describe('BrnAccordion', () => {
 		expect(ng0600Errors(errors)).toEqual([]);
 	});
 
-	// brn-accordion-content must measure its first ELEMENT child, not its first
-	// node: a leading Text node (e.g. from preserveWhitespaces) has no `.style`, so
-	// measuring it threw "Cannot read properties of undefined (reading 'height')".
+	// Content starting with a text node: measure the first element child, not firstChild (a Text node has no `.style`).
 	it('does not throw when the opened content has a leading text node', async () => {
 		const errors: unknown[] = [];
 		await render(AccordionContentLeadingTextNodeSpec, {
 			providers: [{ provide: ErrorHandler, useValue: { handleError: (error: unknown) => errors.push(error) } }],
 		});
-		// The dimension measuring runs in an afterNextRender hook that does not
-		// auto-run under jest - flush it so the regression actually exercises.
+		// flush the afterNextRender() that does the measuring
 		TestBed.inject(ApplicationRef).tick();
 
 		expect(errors).toEqual([]);

--- a/libs/brain/accordion/src/lib/brn-accordion.spec.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.spec.ts
@@ -1,5 +1,6 @@
 import { FocusMonitor, type FocusOrigin } from '@angular/cdk/a11y';
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ApplicationRef, ChangeDetectionStrategy, Component, ErrorHandler, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { render, screen } from '@testing-library/angular';
 import { config, type Observable, Subject } from 'rxjs';
 import { BrnAccordion } from './brn-accordion';
@@ -93,6 +94,31 @@ class AccordionBlurDuringRenderSpec extends ProbeHost {}
 })
 class AccordionTriggerFocusDuringRenderSpec extends ProbeHost {}
 
+// brn-accordion-content measured `firstChild`, which is a Text node whenever the
+// projected content begins with a text node - the leading text below, or e.g. a
+// template compiled with `preserveWhitespaces: true` where the indentation before
+// the inner element survives as a Text node. measureDimensions then read `.style`
+// off that Text node and threw "Cannot read properties of undefined (reading
+// 'height')".
+@Component({
+	imports: [BrnAccordion, BrnAccordionItem, BrnAccordionTrigger, BrnAccordionContent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div brnAccordion>
+			<div brnAccordionItem isOpened>
+				<h3>
+					<button brnAccordionTrigger>Item</button>
+				</h3>
+				<brn-accordion-content>
+					leading text
+					<div>Body</div>
+				</brn-accordion-content>
+			</div>
+		</div>
+	`,
+})
+class AccordionContentLeadingTextNodeSpec {}
+
 describe('BrnAccordion', () => {
 	// #1371: disabling a focused child blurs it during CD, so the FocusMonitor emits mid-render.
 	it('does not throw NG0600 when the focus monitor emits during change detection', async () => {
@@ -125,5 +151,20 @@ describe('BrnAccordion', () => {
 		});
 
 		expect(ng0600Errors(errors)).toEqual([]);
+	});
+
+	// brn-accordion-content must measure its first ELEMENT child, not its first
+	// node: a leading Text node (e.g. from preserveWhitespaces) has no `.style`, so
+	// measuring it threw "Cannot read properties of undefined (reading 'height')".
+	it('does not throw when the opened content has a leading text node', async () => {
+		const errors: unknown[] = [];
+		await render(AccordionContentLeadingTextNodeSpec, {
+			providers: [{ provide: ErrorHandler, useValue: { handleError: (error: unknown) => errors.push(error) } }],
+		});
+		// The dimension measuring runs in an afterNextRender hook that does not
+		// auto-run under jest - flush it so the regression actually exercises.
+		TestBed.inject(ApplicationRef).tick();
+
+		expect(errors).toEqual([]);
 	});
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] accordion

## What is the current behavior?

`BrnAccordionContent` measures its content in an `afterNextRender` hook to drive the open/close transition:

```ts
const content = this._elementRef.nativeElement.firstChild as HTMLElement | null;
if (!content) return false;
const { width, height } = measureDimensions(content, this._config.measurementDisplay);
```

`firstChild` returns the first **node**, which is a `Text` node whenever the projected content begins with a text node — a leading interpolation, or (very commonly) any consuming component compiled with `preserveWhitespaces: true`, where the indentation between `<brn-accordion-content>` and its first child element survives as a whitespace `Text` node.

`measureDimensions` then reads `elementToMeasure.style.height` on that `Text` node, and `Text.style` is `undefined`, so it throws:

```
ERROR TypeError: Cannot read properties of undefined (reading 'height')
    at measureDimensions
    at BrnAccordionContent._measureAndSetDimensions
```

The error surfaces through the `ErrorHandler` (so the app keeps running), but the content is never measured/sized and the console fills with the error for every opened accordion.

## What is the new behavior?

Measure `firstElementChild` instead of `firstChild`. It skips leading text/comment nodes and returns the first **element** — the node that actually needs measuring — so a leading whitespace/text node no longer crashes the hook. When there is no element child, the existing `if (!content) return false;` guard still falls back to the `IntersectionObserver` path.

A regression test renders an opened `brn-accordion-content` whose projected content starts with a text node and asserts the render hook does not throw.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- Reproduces in any app where a consuming component uses `preserveWhitespaces: true` (Angular's non-default but legitimate setting) and projects an element into `<brn-accordion-content>` on its own line.
- Verified against the latest `main`; the regression test fails before the change and passes after, and the full `brain` test suite stays green.
- I searched open issues/PRs and did not find an existing report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Fixed an accordion content dimension measurement edge case where leading whitespace/text nodes could cause incorrect calculations or failures. This improves reliability when content is projected or contains preserve-whitespace output, ensuring smoother accordion sizing and consistent rendering across supported scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->