### PR TITLE
Feat/sidebar blocks

### DIFF
--- a/apps/app/src/app/pages/(blocks)/blocks/sidebar/(sidebar).page.ts
+++ b/apps/app/src/app/pages/(blocks)/blocks/sidebar/(sidebar).page.ts
@@ -17,18 +17,69 @@ export const routeMeta: RouteMeta = {
 		class: 'flex flex-col',
 	},
 	template: `
-		<spartan-block-viewer block="sidebar-sticky-header" title="A sidebar with a sticky header" id="sidebar-1">
+		<spartan-block-viewer block="sidebar-01" title="Simple sidebar with version switcher" id="sidebar-1">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A simple sidebar with a version switcher, search form, and grouped navigation links. Uses
+				<code class="${hlmCode}">SidebarRail</code>
+				for quick collapse.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-02" title="Collapsible sidebar groups" id="sidebar-2">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				Sidebar with collapsible groups using
+				<code class="${hlmCode}">hlm-collapsible</code>
+				and a chevron toggle for each navigation section.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-03" title="Branded header with flat navigation" id="sidebar-3">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				Sidebar with a branded header showing app name and version, flat grouped navigation with sub-items using
+				<code class="${hlmCode}">hlm-sidebar-menu-sub</code>
+				.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-04" title="Floating variant sidebar" id="sidebar-4">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				Demonstrates the
+				<code class="${hlmCode}">variant="floating"</code>
+				option which renders the sidebar with a floating card appearance.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-05" title="Collapsible groups with Plus/Minus icons" id="sidebar-5">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				Sidebar with branded header, search form, and collapsible groups using Plus/Minus icons instead of chevrons.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-06" title="Dropdown navigation with opt-in form" id="sidebar-6">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				Sidebar with dropdown menu navigation items and a newsletter opt-in form in the footer.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-07" title="Icon collapse with team switcher" id="sidebar-7">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				Demonstrates
+				<code class="${hlmCode}">collapsible="icon"</code>
+				for icon-only collapse, with TeamSwitcher, collapsible nav, projects, and user dropdown.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-sticky-header" title="A sidebar with a sticky header" id="sidebar-8">
 			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
 				Setup a CSS variable for the header height by adding
 				<code class="${hlmCode}">[--header-height:--spacing(14)]</code>
 				to the body or page container and use
 				<code class="${hlmCode}">h-(--header-height)</code>
-				to set the height of your header. This variable is then used to offset the sidebar to account for the sticky
-				header height.
+				to set the height of your header.
 			</p>
 		</spartan-block-viewer>
 
-		<spartan-block-viewer block="sidebar-inset" title="An inset sidebar with secondary navigation" id="sidebar-2">
+		<spartan-block-viewer block="sidebar-inset" title="An inset sidebar with secondary navigation" id="sidebar-9">
 			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
 				Use the
 				<code class="${hlmCode}">inset</code>
@@ -38,7 +89,51 @@ export const routeMeta: RouteMeta = {
 				<code class="${hlmCode}">hlmSidebarInset</code>
 				directive on your
 				<code class="${hlmCode}">main</code>
-				element to create an inset sidebar layout. Both elements must be siblings for the styles to apply correctly.
+				element to create an inset sidebar layout.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-09" title="Dual sidebar mail client" id="sidebar-10">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A complex dual-sidebar layout with icon-only navigation and a mail list. Demonstrates nested sidebars with
+				different collapsible modes.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-10" title="Notion-like workspace sidebar" id="sidebar-11">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A Notion-inspired sidebar with TeamSwitcher, flat navigation, favorites, collapsible workspaces, and secondary
+				links.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-11" title="File tree sidebar" id="sidebar-12">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				Sidebar displaying a file tree with collapsible folders and file state badges. Great for code editors or file
+				browsers.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-12" title="Calendar sidebar" id="sidebar-13">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				Sidebar with an inline calendar date picker, checkbox-based calendar groups, and user avatar dropdown. Perfect
+				for calendar apps.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-14" title="Right-side table of contents" id="sidebar-14">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				Demonstrates
+				<code class="${hlmCode}">side="right"</code>
+				for a right-aligned sidebar used as a table of contents with
+				<code class="${hlmCode}">SidebarRail</code>
+				.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="sidebar-15" title="Dual sidebar: workspace + calendar" id="sidebar-15">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				Most complex layout combining a Notion-like workspace sidebar on the left with a calendar sidebar on the right.
 			</p>
 		</spartan-block-viewer>
 	`,

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/calendars.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/calendars.ts
@@ -1,0 +1,73 @@
+import { ChangeDetectionStrategy, Component, input, signal } from '@angular/core';
+import { HlmCheckboxImports } from '@spartan-ng/helm/checkbox';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+
+@Component({
+	selector: 'spartan-calendars',
+	imports: [HlmSidebarImports, HlmCheckboxImports],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		@for (group of calendars(); track group.name; let last = $last) {
+			<hlm-sidebar-group>
+				<div hlmSidebarGroupLabel>{{ group.name }}</div>
+				<ul hlmSidebarMenu>
+					@for (item of group.items; track item) {
+						<li hlmSidebarMenuItem>
+							<button
+								hlmSidebarMenuButton
+								class="data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground"
+								[class]="isActive(item) ? 'bg-sidebar-accent text-sidebar-accent-foreground' : ''"
+								(click)="toggle(item)"
+							>
+								<div
+									class="flex size-4 shrink-0 items-center justify-center rounded-sm border"
+									[class]="
+										isActive(item)
+											? 'bg-sidebar-primary text-sidebar-primary-foreground border-sidebar-primary'
+											: 'border-muted-foreground/25 opacity-50'
+									"
+								>
+									@if (isActive(item)) {
+										<svg class="size-3" viewBox="0 0 14 14" fill="none">
+											<path
+												d="M11.6666 3.5L5.24992 9.91667L2.33325 7"
+												stroke="currentColor"
+												stroke-width="2"
+												stroke-linecap="round"
+												stroke-linejoin="round"
+											/>
+										</svg>
+									}
+								</div>
+								<span>{{ item }}</span>
+							</button>
+						</li>
+					}
+				</ul>
+				@if (!last) {
+					<hlm-sidebar-separator class="mx-0" />
+				}
+			</hlm-sidebar-group>
+		}
+	`,
+})
+export class Calendars {
+	public readonly calendars = input.required<{ name: string; items: string[] }[]>();
+	protected readonly _activeItems = signal<Set<string>>(new Set(['Personal', 'Work', 'Holidays']));
+
+	protected isActive(item: string): boolean {
+		return this._activeItems().has(item);
+	}
+
+	protected toggle(item: string): void {
+		this._activeItems.update((set) => {
+			const next = new Set(set);
+			if (next.has(item)) {
+				next.delete(item);
+			} else {
+				next.add(item);
+			}
+			return next;
+		});
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/data.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/data.ts
@@ -4,6 +4,11 @@ export const data = {
 		email: 'hello@spartan.com',
 		avatar: '/assets/avatar.png',
 	},
+	teams: [
+		{ name: 'Acme Inc', icon: 'lucideGalleryVerticalEnd', plan: 'Enterprise' },
+		{ name: 'Acme Corp.', icon: 'lucideAudioWaveform', plan: 'Startup' },
+		{ name: 'Evil Corp.', icon: 'lucideCommand', plan: 'Free' },
+	],
 	navMain: [
 		{
 			title: 'Playground',
@@ -11,18 +16,9 @@ export const data = {
 			icon: 'lucideSquareTerminal',
 			isActive: true,
 			items: [
-				{
-					title: 'History',
-					url: '.',
-				},
-				{
-					title: 'Starred',
-					url: '.',
-				},
-				{
-					title: 'Settings',
-					url: '.',
-				},
+				{ title: 'History', url: '.' },
+				{ title: 'Starred', url: '.' },
+				{ title: 'Settings', url: '.' },
 			],
 		},
 		{
@@ -30,18 +26,9 @@ export const data = {
 			url: '.',
 			icon: 'lucideBot',
 			items: [
-				{
-					title: 'Genesis',
-					url: '.',
-				},
-				{
-					title: 'Explorer',
-					url: '.',
-				},
-				{
-					title: 'Quantum',
-					url: '.',
-				},
+				{ title: 'Genesis', url: '.' },
+				{ title: 'Explorer', url: '.' },
+				{ title: 'Quantum', url: '.' },
 			],
 		},
 		{
@@ -49,22 +36,10 @@ export const data = {
 			url: '.',
 			icon: 'lucideBookOpen',
 			items: [
-				{
-					title: 'Introduction',
-					url: '.',
-				},
-				{
-					title: 'Get Started',
-					url: '.',
-				},
-				{
-					title: 'Tutorials',
-					url: '.',
-				},
-				{
-					title: 'Changelog',
-					url: '.',
-				},
+				{ title: 'Introduction', url: '.' },
+				{ title: 'Get Started', url: '.' },
+				{ title: 'Tutorials', url: '.' },
+				{ title: 'Changelog', url: '.' },
 			],
 		},
 		{
@@ -72,52 +47,111 @@ export const data = {
 			url: '.',
 			icon: 'lucideSettings2',
 			items: [
-				{
-					title: 'General',
-					url: '.',
-				},
-				{
-					title: 'Team',
-					url: '.',
-				},
-				{
-					title: 'Billing',
-					url: '.',
-				},
-				{
-					title: 'Limits',
-					url: '.',
-				},
+				{ title: 'General', url: '.' },
+				{ title: 'Team', url: '.' },
+				{ title: 'Billing', url: '.' },
+				{ title: 'Limits', url: '.' },
 			],
 		},
 	],
 	navSecondary: [
-		{
-			title: 'Support',
-			url: '.',
-			icon: 'lucideLifeBuoy',
-		},
-		{
-			title: 'Feedback',
-			url: '.',
-			icon: 'lucideSend',
-		},
+		{ title: 'Support', url: '.', icon: 'lucideLifeBuoy' },
+		{ title: 'Feedback', url: '.', icon: 'lucideSend' },
 	],
 	projects: [
+		{ name: 'Design Engineering', url: '.', icon: 'lucideFrame' },
+		{ name: 'Sales & Marketing', url: '.', icon: 'lucideChartPie' },
+		{ name: 'Travel', url: '.', icon: 'lucideMap' },
+	],
+	favorites: [
+		{ emoji: '📋', name: 'Project Management & Task Tracking' },
+		{ emoji: '📅', name: 'Meeting Notes' },
+		{ emoji: '📖', name: 'Technical Documentation' },
+		{ emoji: '💼', name: 'Travel Plans' },
+		{ emoji: '⭐', name: 'Starred Items' },
+	],
+	workspaces: [
 		{
+			emoji: '📁',
 			name: 'Design Engineering',
-			url: '.',
-			icon: 'lucideFrame',
+			pages: ['Design System', 'Component Library', 'Brand Guidelines'],
 		},
 		{
+			emoji: '📊',
 			name: 'Sales & Marketing',
-			url: '.',
-			icon: 'lucideChartPie',
+			pages: ['Campaign Strategy', 'Lead Tracking', 'Analytics Dashboard'],
 		},
 		{
+			emoji: '✈️',
 			name: 'Travel',
-			url: '.',
-			icon: 'lucideMap',
+			pages: ['Upcoming Trips', 'Booking Confirmations', 'Travel Expenses'],
 		},
+	],
+	calendars: [
+		{ name: 'My Calendars', items: ['Personal', 'Work', 'Family'] },
+		{ name: 'Favorites', items: ['Holidays', 'Birthdays'] },
+		{ name: 'Other', items: ['Travel', 'Reminders', 'Deadlines'] },
+	],
+	versions: ['1.0.1', '1.1.0-alpha', '2.0.0-beta1'],
+	changes: [
+		{ file: 'README.md', state: 'M' },
+		{ file: 'api/hello/route.ts', state: 'U' },
+		{ file: 'app/layout.tsx', state: 'M' },
+	],
+	tree: [
+		['app', ['api', ['hello', ['route.ts']], 'page.tsx', 'layout.tsx', ['blog', ['page.tsx']]]],
+		['components', ['ui', 'button.tsx', 'card.tsx'], 'header.tsx', 'footer.tsx'],
+		['lib', ['util.ts']],
+		['public', 'favicon.ico', 'vercel.svg'],
+		'.eslintrc.json',
+		'.gitignore',
+		'next.config.js',
+		'tailwind.config.js',
+		'package.json',
+		'README.md',
+	],
+	mails: [
+		{
+			name: 'William Smith',
+			email: 'williamsmith@example.com',
+			subject: 'Meeting Tomorrow',
+			date: '09:34 AM',
+			teaser: 'Hi team, just a reminder about our meeting tomorrow at 10 AM.',
+		},
+		{
+			name: 'Alice Smith',
+			email: 'alicesmith@example.com',
+			subject: 'Re: Project Update',
+			date: 'Yesterday',
+			teaser: 'Thanks for the update. The progress looks great so far.',
+		},
+		{
+			name: 'Bob Johnson',
+			email: 'bobjohnson@example.com',
+			subject: 'Weekend Plans',
+			date: '2 days ago',
+			teaser: "Hey everyone! I'm thinking of organizing a team outing this weekend.",
+		},
+		{
+			name: 'Emily Davis',
+			email: 'emilydavis@example.com',
+			subject: 'Re: Question about Budget',
+			date: '2 days ago',
+			teaser: "I've reviewed the budget numbers you sent over.",
+		},
+		{
+			name: 'Michael Wilson',
+			email: 'michaelwilson@example.com',
+			subject: 'Important Announcement',
+			date: '1 week ago',
+			teaser: 'Please join us for an all-hands meeting this Friday at 3 PM.',
+		},
+	],
+	navMail: [
+		{ title: 'Inbox', url: '.', icon: 'lucideInbox', isActive: true },
+		{ title: 'Drafts', url: '.', icon: 'lucideFile', isActive: false },
+		{ title: 'Sent', url: '.', icon: 'lucideSend', isActive: false },
+		{ title: 'Junk', url: '.', icon: 'lucideArchiveX', isActive: false },
+		{ title: 'Trash', url: '.', icon: 'lucideTrash2', isActive: false },
 	],
 };

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/date-picker.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/date-picker.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { HlmCalendarImports } from '@spartan-ng/helm/calendar';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+
+@Component({
+	selector: 'spartan-date-picker',
+	imports: [HlmSidebarImports, HlmCalendarImports],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<hlm-sidebar-group class="px-0">
+			<div hlmSidebarGroupContent>
+				<hlm-calendar
+					class="[&_[role=gridcell].bg-accent]:bg-sidebar-primary [&_[role=gridcell].bg-accent]:text-sidebar-primary-foreground [&_[role=gridcell]]:w-[33px]"
+				/>
+			</div>
+		</hlm-sidebar-group>
+	`,
+})
+export class DatePicker {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/nav-actions.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/nav-actions.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideEllipsis, lucidePanelLeft, lucideStar } from '@ng-icons/lucide';
+import { HlmButton } from '@spartan-ng/helm/button';
+
+@Component({
+	selector: 'spartan-nav-actions',
+	imports: [NgIcon, HlmButton],
+	providers: [provideIcons({ lucidePanelLeft, lucideStar, lucideEllipsis })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'flex items-center gap-2',
+	},
+	template: `
+		<button hlmBtn variant="ghost" size="icon-sm">
+			<ng-icon name="lucideStar" class="size-4" />
+			<span class="sr-only">Star</span>
+		</button>
+		<button hlmBtn variant="ghost" size="icon-sm">
+			<ng-icon name="lucideEllipsis" class="size-4" />
+			<span class="sr-only">More</span>
+		</button>
+	`,
+})
+export class NavActions {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/nav-favorites.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/nav-favorites.ts
@@ -1,84 +1,56 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import {
-	lucideChartPie,
-	lucideEllipsis,
-	lucideFolder,
-	lucideFrame,
-	lucideMap,
-	lucideShare,
-	lucideTrash2,
-} from '@ng-icons/lucide';
+import { lucideEllipsis, lucideFolder, lucideForward, lucideStar, lucideTrash2 } from '@ng-icons/lucide';
 import { HlmDropdownMenuImports } from '@spartan-ng/helm/dropdown-menu';
 import { HlmSidebarImports, HlmSidebarService } from '@spartan-ng/helm/sidebar';
 
 @Component({
-	selector: 'spartan-nav-projects',
+	selector: 'spartan-nav-favorites',
 	imports: [HlmSidebarImports, NgIcon, HlmDropdownMenuImports],
-	providers: [
-		provideIcons({ lucideFrame, lucideChartPie, lucideMap, lucideEllipsis, lucideFolder, lucideShare, lucideTrash2 }),
-	],
+	providers: [provideIcons({ lucideStar, lucideEllipsis, lucideFolder, lucideForward, lucideTrash2 })],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		<hlm-sidebar-group class="group-data-[collapsible=icon]:hidden">
-			<div hlmSidebarGroupLabel>Projects</div>
+			<div hlmSidebarGroupLabel>Favorites</div>
 			<ul hlmSidebarMenu>
-				@for (project of projects(); track $index) {
+				@for (fav of favorites(); track fav.name) {
 					<li hlmSidebarMenuItem>
-						<button hlmSidebarMenuButton>
-							<ng-icon [name]="project.icon" />
-							{{ project.name }}
-						</button>
-						<button
-							hlmSidebarMenuAction
-							showOnHover
-							[hlmDropdownMenuTrigger]="menu"
-							[side]="_menuSide()"
-							[align]="_menuAlign()"
-						>
+						<a hlmSidebarMenuButton>
+							<span>{{ fav.emoji }}</span>
+							<span>{{ fav.name }}</span>
+						</a>
+						<button hlmSidebarMenuAction showOnHover [hlmDropdownMenuTrigger]="menu">
 							<ng-icon name="lucideEllipsis" />
 							<span class="sr-only">More</span>
 						</button>
 					</li>
 				}
-				<li hlmSidebarMenuItem>
-					<button hlmSidebarMenuButton>
-						<ng-icon name="lucideEllipsis" />
-						More
-					</button>
-				</li>
 			</ul>
 		</hlm-sidebar-group>
 
 		<ng-template #menu>
-			<hlm-dropdown-menu class="w-48">
+			<hlm-dropdown-menu class="w-48 rounded-lg">
 				<button hlmDropdownMenuItem>
-					<ng-icon name="lucideFolder" />
-					View Project
+					<ng-icon name="lucideStar" class="text-muted-foreground" />
+					Remove from Favorites
 				</button>
 				<button hlmDropdownMenuItem>
-					<ng-icon name="lucideShare" />
-					Share Project
+					<ng-icon name="lucideFolder" class="text-muted-foreground" />
+					Open in New Tab
 				</button>
 				<hlm-dropdown-menu-separator />
 				<button hlmDropdownMenuItem>
-					<ng-icon name="lucideTrash2" />
-					Delete Project
+					<ng-icon name="lucideTrash2" class="text-muted-foreground" />
+					Delete
 				</button>
 			</hlm-dropdown-menu>
 		</ng-template>
 	`,
 })
-export class NavProjects {
+export class NavFavorites {
 	private readonly _sidebarService = inject(HlmSidebarService);
 	protected readonly _menuSide = computed(() => (this._sidebarService.isMobile() ? 'bottom' : 'right'));
 	protected readonly _menuAlign = computed(() => (this._sidebarService.isMobile() ? 'end' : 'start'));
 
-	public readonly projects = input.required<
-		{
-			name: string;
-			url: string;
-			icon: string;
-		}[]
-	>();
+	public readonly favorites = input.required<{ emoji: string; name: string }[]>();
 }

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/nav-main-flat.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/nav-main-flat.ts
@@ -1,0 +1,70 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+	lucideBookOpen,
+	lucideBot,
+	lucideGalleryVerticalEnd,
+	lucideSettings2,
+	lucideSquareTerminal,
+} from '@ng-icons/lucide';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+
+@Component({
+	selector: 'spartan-nav-main-flat',
+	imports: [HlmSidebarImports, NgIcon, RouterLink],
+	providers: [
+		provideIcons({
+			lucideSquareTerminal,
+			lucideBot,
+			lucideBookOpen,
+			lucideSettings2,
+			lucideGalleryVerticalEnd,
+		}),
+	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<hlm-sidebar-group>
+			<div hlmSidebarGroupLabel>{{ groupLabel() }}</div>
+			<ul hlmSidebarMenu>
+				@for (item of items(); track item.title) {
+					<li hlmSidebarMenuItem>
+						<a hlmSidebarMenuButton [routerLink]="item.url" [isActive]="item.isActive">
+							@if (item.icon) {
+								<ng-icon [name]="item.icon" />
+							}
+							<span>{{ item.title }}</span>
+						</a>
+						@if (item.items; as subItems) {
+							<ul hlm-sidebar-menu-sub class="ml-0 border-l-0 px-1.5">
+								@for (subItem of subItems; track subItem.title) {
+									<li hlmSidebarMenuSubItem>
+										<a hlmSidebarMenuSubButton [routerLink]="subItem.url" [isActive]="subItem.isActive">
+											{{ subItem.title }}
+										</a>
+									</li>
+								}
+							</ul>
+						}
+					</li>
+				}
+			</ul>
+		</hlm-sidebar-group>
+	`,
+})
+export class NavMainFlat {
+	public readonly groupLabel = input('Getting Started');
+	public readonly items = input.required<
+		{
+			title: string;
+			url: string;
+			icon?: string;
+			isActive?: boolean;
+			items?: {
+				title: string;
+				url: string;
+				isActive?: boolean;
+			}[];
+		}[]
+	>();
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/nav-workspaces.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/nav-workspaces.ts
@@ -1,0 +1,53 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronRight, lucidePlus } from '@ng-icons/lucide';
+import { HlmCollapsibleImports } from '@spartan-ng/helm/collapsible';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+
+@Component({
+	selector: 'spartan-nav-workspaces',
+	imports: [HlmSidebarImports, NgIcon, HlmCollapsibleImports],
+	providers: [provideIcons({ lucideChevronRight, lucidePlus })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<hlm-sidebar-group>
+			<div hlmSidebarGroupLabel>Workspaces</div>
+			<ul hlmSidebarMenu>
+				@for (workspace of workspaces(); track workspace.name) {
+					<hlm-collapsible [expanded]="false">
+						<li hlmSidebarMenuItem>
+							<hlm-collapsible-trigger
+								class="data-[state=open]:bg-sidebar-accent [&>svg]:transition-transform [&>svg]:duration-200 [&>svg]:data-[state=open]:rotate-90"
+							>
+								<ng-icon name="lucideChevronRight" class="size-4" />
+							</hlm-collapsible-trigger>
+							<button
+								hlmSidebarMenuButton
+								class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+							>
+								<span>{{ workspace.emoji }}</span>
+								<span>{{ workspace.name }}</span>
+							</button>
+							<button hlmSidebarMenuAction>
+								<ng-icon name="lucidePlus" />
+								<span class="sr-only">Add page</span>
+							</button>
+							<hlm-collapsible-content>
+								<ul hlmSidebarMenuSub>
+									@for (page of workspace.pages; track page) {
+										<li hlmSidebarMenuSubItem>
+											<a hlmSidebarMenuSubButton>{{ page }}</a>
+										</li>
+									}
+								</ul>
+							</hlm-collapsible-content>
+						</li>
+					</hlm-collapsible>
+				}
+			</ul>
+		</hlm-sidebar-group>
+	`,
+})
+export class NavWorkspaces {
+	public readonly workspaces = input.required<{ emoji: string; name: string; pages: string[] }[]>();
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/search-form.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/search-form.ts
@@ -1,0 +1,27 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideSearch } from '@ng-icons/lucide';
+import { HlmLabel } from '@spartan-ng/helm/label';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+
+@Component({
+	selector: 'spartan-search-form',
+	imports: [HlmSidebarImports, NgIcon, HlmLabel],
+	providers: [provideIcons({ lucideSearch })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<form>
+			<hlm-sidebar-group class="py-0">
+				<div hlmSidebarGroupContent class="relative">
+					<label hlmLabel for="search" class="sr-only">Search</label>
+					<input hlmSidebarInput id="search" placeholder="Search the docs..." class="pl-8" />
+					<ng-icon
+						name="lucideSearch"
+						class="pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2 opacity-50 select-none"
+					/>
+				</div>
+			</hlm-sidebar-group>
+		</form>
+	`,
+})
+export class SearchForm {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/team-switcher.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/team-switcher.ts
@@ -1,0 +1,78 @@
+import { ChangeDetectionStrategy, Component, computed, effect, inject, input, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronsUpDown, lucidePlus } from '@ng-icons/lucide';
+import { HlmDropdownMenuImports } from '@spartan-ng/helm/dropdown-menu';
+import { HlmSidebarImports, HlmSidebarService } from '@spartan-ng/helm/sidebar';
+
+@Component({
+	selector: 'spartan-team-switcher',
+	imports: [HlmSidebarImports, NgIcon, HlmDropdownMenuImports],
+	providers: [provideIcons({ lucideChevronsUpDown, lucidePlus })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<ul hlmSidebarMenu>
+			<li hlmSidebarMenuItem>
+				<button
+					hlmSidebarMenuButton
+					size="lg"
+					[hlmDropdownMenuTrigger]="menu"
+					[side]="_menuSide()"
+					align="start"
+					sideOffset="4"
+					class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+				>
+					<div
+						class="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg"
+					>
+						<ng-icon [name]="_activeTeam()?.icon" class="text-base" />
+					</div>
+					<div class="grid flex-1 text-left text-sm leading-tight">
+						<span class="truncate font-medium">{{ _activeTeam()?.name }}</span>
+						<span class="truncate text-xs">{{ _activeTeam()?.plan }}</span>
+					</div>
+					<ng-icon name="lucideChevronsUpDown" class="ml-auto" />
+				</button>
+			</li>
+		</ul>
+
+		<ng-template #menu>
+			<hlm-dropdown-menu class="w-56 min-w-56 rounded-lg">
+				<hlm-dropdown-menu-label class="text-muted-foreground text-xs">Teams</hlm-dropdown-menu-label>
+				@for (team of teams(); track team.name) {
+					<button hlmDropdownMenuItem class="gap-2 p-2" (click)="activeTeam.set(team)">
+						<div class="flex size-6 items-center justify-center rounded-md border">
+							<ng-icon [name]="team.icon" class="text-xs" />
+						</div>
+						{{ team.name }}
+						<span class="text-muted-foreground ml-auto text-xs">&#8984;{{ $index + 1 }}</span>
+					</button>
+				}
+				<hlm-dropdown-menu-separator />
+				<button hlmDropdownMenuItem class="gap-2 p-2">
+					<div
+						class="border-muted-foreground/25 flex size-6 items-center justify-center rounded-md border bg-transparent"
+					>
+						<ng-icon name="lucidePlus" class="text-sm" />
+					</div>
+					<span class="text-muted-foreground font-medium">Add team</span>
+				</button>
+			</hlm-dropdown-menu>
+		</ng-template>
+	`,
+})
+export class TeamSwitcher {
+	private readonly _sidebarService = inject(HlmSidebarService);
+	protected readonly _menuSide = computed(() => (this._sidebarService.isMobile() ? 'bottom' : 'right'));
+
+	public readonly teams = input.required<{ name: string; icon: string; plan: string }[]>();
+	protected readonly _activeTeam = signal<{ name: string; icon: string; plan: string } | null>(null);
+
+	constructor() {
+		effect(() => {
+			const t = this.teams();
+			if (t.length > 0 && !this._activeTeam()) {
+				this._activeTeam.set(t[0]);
+			}
+		});
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/version-switcher.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/sidebar/version-switcher.ts
@@ -1,0 +1,61 @@
+import { ChangeDetectionStrategy, Component, effect, input, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideCheck, lucideChevronsUpDown, lucideGalleryVerticalEnd } from '@ng-icons/lucide';
+import { HlmDropdownMenuImports } from '@spartan-ng/helm/dropdown-menu';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+
+@Component({
+	selector: 'spartan-version-switcher',
+	imports: [HlmSidebarImports, NgIcon, HlmDropdownMenuImports],
+	providers: [provideIcons({ lucideGalleryVerticalEnd, lucideChevronsUpDown, lucideCheck })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<ul hlmSidebarMenu>
+			<li hlmSidebarMenuItem>
+				<button
+					hlmSidebarMenuButton
+					size="lg"
+					[hlmDropdownMenuTrigger]="menu"
+					class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+				>
+					<div
+						class="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg"
+					>
+						<ng-icon name="lucideGalleryVerticalEnd" class="text-base" />
+					</div>
+					<div class="flex flex-col gap-0.5 leading-none">
+						<span class="font-medium">Documentation</span>
+						<span>v{{ _selectedVersion() }}</span>
+					</div>
+					<ng-icon name="lucideChevronsUpDown" class="ml-auto" />
+				</button>
+			</li>
+		</ul>
+
+		<ng-template #menu>
+			<hlm-dropdown-menu class="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg" align="start">
+				@for (version of versions(); track version) {
+					<button hlmDropdownMenuItem (click)="_selectedVersion.set(version)">
+						v{{ version }}
+						@if (version === _selectedVersion()) {
+							<ng-icon name="lucideCheck" class="ml-auto" />
+						}
+					</button>
+				}
+			</hlm-dropdown-menu>
+		</ng-template>
+	`,
+})
+export class VersionSwitcher {
+	public readonly versions = input.required<string[]>();
+	protected readonly _selectedVersion = signal('');
+
+	constructor() {
+		effect(() => {
+			const v = this.versions();
+			if (v.length > 0 && !this._selectedVersion()) {
+				this._selectedVersion.set(v[0]);
+			}
+		});
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-01/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-01/index.page.ts
@@ -1,0 +1,47 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmBreadcrumbImports } from '@spartan-ng/helm/breadcrumb';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { AppSidebar01 } from './sidebar-01/app-sidebar';
+
+@Component({
+	selector: 'spartan-sidebar-01-preview',
+	imports: [HlmSidebarImports, AppSidebar01, HlmSeparatorImports, HlmBreadcrumbImports],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<spartan-app-sidebar-01 />
+			<main hlmSidebarInset>
+				<header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+					<button hlmSidebarTrigger class="-ml-1"></button>
+					<hlm-separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
+					<nav hlmBreadcrumb>
+						<ol hlmBreadcrumbList>
+							<li hlmBreadcrumbItem class="hidden md:block">
+								<a hlmBreadcrumbLink href="#">Build Your Application</a>
+							</li>
+							<li hlmBreadcrumbSeparator class="hidden md:block"></li>
+							<li hlmBreadcrumbItem>
+								<a hlmBreadcrumbPage>Data Fetching</a>
+							</li>
+						</ol>
+					</nav>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 p-4">
+					<div class="grid auto-rows-min gap-4 md:grid-cols-3">
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+					</div>
+					<div class="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min"></div>
+				</div>
+			</main>
+		</div>
+	`,
+})
+export default class Sidebar01Page {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-01/sidebar-01/app-sidebar.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-01/sidebar-01/app-sidebar.ts
@@ -1,0 +1,97 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { data } from '../../shared/sidebar/data';
+import { SearchForm } from '../../shared/sidebar/search-form';
+import { VersionSwitcher } from '../../shared/sidebar/version-switcher';
+
+@Component({
+	selector: 'spartan-sidebar-01',
+	imports: [HlmSidebarImports, SearchForm, VersionSwitcher],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<hlm-sidebar>
+			<hlm-sidebar-header>
+				<spartan-version-switcher [versions]="data.versions" />
+				<spartan-search-form />
+			</hlm-sidebar-header>
+			<hlm-sidebar-content>
+				@for (group of navGroups; track group.title) {
+					<hlm-sidebar-group>
+						<div hlmSidebarGroupLabel>{{ group.title }}</div>
+						<div hlmSidebarGroupContent>
+							<ul hlmSidebarMenu>
+								@for (item of group.items; track item.title) {
+									<li hlmSidebarMenuItem>
+										<a
+											hlmSidebarMenuButton
+											href="#"
+											[class]="item.isActive ? 'bg-sidebar-accent text-sidebar-accent-foreground' : ''"
+										>
+											{{ item.title }}
+										</a>
+									</li>
+								}
+							</ul>
+						</div>
+					</hlm-sidebar-group>
+				}
+			</hlm-sidebar-content>
+			<hlm-sidebar-rail />
+		</hlm-sidebar>
+	`,
+})
+export class AppSidebar01 {
+	public readonly data = data;
+	public readonly navGroups = [
+		{
+			title: 'Getting Started',
+			items: [
+				{ title: 'Installation', url: '.' },
+				{ title: 'Project Structure', url: '.' },
+			],
+		},
+		{
+			title: 'Build Your Application',
+			items: [
+				{ title: 'Routing', url: '.' },
+				{ title: 'Data Fetching', url: '.', isActive: true },
+				{ title: 'Rendering', url: '.' },
+				{ title: 'Caching', url: '.' },
+				{ title: 'Styling', url: '.' },
+				{ title: 'Optimizing', url: '.' },
+				{ title: 'Configuring', url: '.' },
+				{ title: 'Testing', url: '.' },
+				{ title: 'Authentication', url: '.' },
+				{ title: 'Deploying', url: '.' },
+				{ title: 'Upgrading', url: '.' },
+				{ title: 'Examples', url: '.' },
+			],
+		},
+		{
+			title: 'API Reference',
+			items: [
+				{ title: 'Components', url: '.' },
+				{ title: 'File Conventions', url: '.' },
+				{ title: 'Functions', url: '.' },
+				{ title: 'next.config.js Options', url: '.' },
+				{ title: 'CLI', url: '.' },
+				{ title: 'Edge Runtime', url: '.' },
+			],
+		},
+		{
+			title: 'Architecture',
+			items: [
+				{ title: 'Accessibility', url: '.' },
+				{ title: 'Fast Refresh', url: '.' },
+				{ title: 'Compiler', url: '.' },
+				{ title: 'Supported Browsers', url: '.' },
+				{ title: 'Turbopack', url: '.' },
+			],
+		},
+	];
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-02/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-02/index.page.ts
@@ -1,0 +1,39 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { AppSidebar02 } from './sidebar-02/app-sidebar';
+
+@Component({
+	selector: 'spartan-sidebar-02-preview',
+	imports: [HlmSidebarImports, AppSidebar02, HlmSeparatorImports],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<spartan-app-sidebar-02 />
+			<main hlmSidebarInset>
+				<header class="bg-background sticky top-0 flex h-16 shrink-0 items-center gap-2 border-b px-4">
+					<button hlmSidebarTrigger class="-ml-1"></button>
+					<hlm-separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
+					<div class="flex items-center gap-2">
+						<span class="text-muted-foreground text-sm">Building Your Application</span>
+						<span class="text-muted-foreground text-sm">/</span>
+						<span class="text-sm">Data Fetching</span>
+					</div>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 p-4">
+					@for (i of rows; track i) {
+						<div class="bg-muted/50 h-12 w-full rounded-lg"></div>
+					}
+				</div>
+			</main>
+		</div>
+	`,
+})
+export default class Sidebar02Page {
+	public readonly rows = Array.from({ length: 24 });
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-02/sidebar-02/app-sidebar.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-02/sidebar-02/app-sidebar.ts
@@ -1,0 +1,109 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronRight } from '@ng-icons/lucide';
+import { HlmCollapsibleImports } from '@spartan-ng/helm/collapsible';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { SearchForm } from '../../shared/sidebar/search-form';
+import { VersionSwitcher } from '../../shared/sidebar/version-switcher';
+
+@Component({
+	selector: 'spartan-sidebar-02',
+	imports: [HlmSidebarImports, NgIcon, HlmCollapsibleImports, SearchForm, VersionSwitcher],
+	providers: [provideIcons({ lucideChevronRight })],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<hlm-sidebar>
+			<hlm-sidebar-header>
+				<spartan-version-switcher [versions]="versions" />
+				<spartan-search-form />
+			</hlm-sidebar-header>
+			<hlm-sidebar-content class="gap-0">
+				@for (group of navGroups; track group.title) {
+					<hlm-collapsible [expanded]="true" class="group/collapsible">
+						<hlm-sidebar-group>
+							<div
+								hlmSidebarGroupLabel
+								class="group/label text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sm"
+							>
+								<button hlmCollapsibleTrigger>
+									{{ group.title }}
+									<ng-icon
+										name="lucideChevronRight"
+										class="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90"
+									/>
+								</button>
+							</div>
+							<hlm-collapsible-content>
+								<div hlmSidebarGroupContent>
+									<ul hlmSidebarMenu>
+										@for (item of group.items; track item.title) {
+											<li hlmSidebarMenuItem>
+												<a
+													hlmSidebarMenuButton
+													href="#"
+													[class]="item.isActive ? 'bg-sidebar-accent text-sidebar-accent-foreground' : ''"
+												>
+													{{ item.title }}
+												</a>
+											</li>
+										}
+									</ul>
+								</div>
+							</hlm-collapsible-content>
+						</hlm-sidebar-group>
+					</hlm-collapsible>
+				}
+			</hlm-sidebar-content>
+			<hlm-sidebar-rail />
+		</hlm-sidebar>
+	`,
+})
+export class AppSidebar02 {
+	public readonly versions = ['1.0.1', '1.1.0-alpha', '2.0.0-beta1'];
+	public readonly navGroups = [
+		{
+			title: 'Getting Started',
+			items: [
+				{ title: 'Installation', url: '.' },
+				{ title: 'Project Structure', url: '.' },
+			],
+		},
+		{
+			title: 'Build Your Application',
+			items: [
+				{ title: 'Routing', url: '.' },
+				{ title: 'Data Fetching', url: '.', isActive: true },
+				{ title: 'Rendering', url: '.' },
+				{ title: 'Caching', url: '.' },
+				{ title: 'Styling', url: '.' },
+				{ title: 'Optimizing', url: '.' },
+				{ title: 'Configuring', url: '.' },
+				{ title: 'Testing', url: '.' },
+				{ title: 'Authentication', url: '.' },
+				{ title: 'Deploying', url: '.' },
+				{ title: 'Upgrading', url: '.' },
+				{ title: 'Examples', url: '.' },
+			],
+		},
+		{
+			title: 'API Reference',
+			items: [
+				{ title: 'Components', url: '.' },
+				{ title: 'File Conventions', url: '.' },
+				{ title: 'Functions', url: '.' },
+				{ title: 'next.config.js Options', url: '.' },
+				{ title: 'CLI', url: '.' },
+				{ title: 'Edge Runtime', url: '.' },
+			],
+		},
+		{
+			title: 'Community',
+			items: [{ title: 'Contribution Guide', url: '.' }],
+		},
+	];
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-03/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-03/index.page.ts
@@ -1,0 +1,47 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmBreadcrumbImports } from '@spartan-ng/helm/breadcrumb';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { AppSidebar03 } from './sidebar-03/app-sidebar';
+
+@Component({
+	selector: 'spartan-sidebar-03-preview',
+	imports: [HlmSidebarImports, AppSidebar03, HlmSeparatorImports, HlmBreadcrumbImports],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<spartan-app-sidebar-03 />
+			<main hlmSidebarInset>
+				<header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+					<button hlmSidebarTrigger class="-ml-1"></button>
+					<hlm-separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
+					<nav hlmBreadcrumb>
+						<ol hlmBreadcrumbList>
+							<li hlmBreadcrumbItem class="hidden md:block">
+								<a hlmBreadcrumbLink href="#">Build Your Application</a>
+							</li>
+							<li hlmBreadcrumbSeparator class="hidden md:block"></li>
+							<li hlmBreadcrumbItem>
+								<a hlmBreadcrumbPage>Data Fetching</a>
+							</li>
+						</ol>
+					</nav>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 p-4">
+					<div class="grid auto-rows-min gap-4 md:grid-cols-3">
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+					</div>
+					<div class="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min"></div>
+				</div>
+			</main>
+		</div>
+	`,
+})
+export default class Sidebar03Page {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-03/sidebar-03/app-sidebar.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-03/sidebar-03/app-sidebar.ts
@@ -1,0 +1,89 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { NavMainFlat } from '../../shared/sidebar/nav-main-flat';
+
+@Component({
+	selector: 'spartan-sidebar-03',
+	imports: [HlmSidebarImports, NavMainFlat],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<hlm-sidebar>
+				<hlm-sidebar-header>
+					<ul hlmSidebarMenu>
+						<li hlmSidebarMenuItem>
+							<a hlmSidebarMenuButton size="lg" href="#">
+								<div
+									class="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg"
+								>
+									<span class="text-base">&#9670;</span>
+								</div>
+								<div class="grid flex-1 text-left text-sm leading-tight">
+									<span class="truncate font-medium">Documentation</span>
+									<span class="truncate text-xs">v1.0.0</span>
+								</div>
+							</a>
+						</li>
+					</ul>
+				</hlm-sidebar-header>
+				<hlm-sidebar-content>
+					<spartan-nav-main-flat groupLabel="Getting Started" [items]="flatNavItems" />
+				</hlm-sidebar-content>
+				<hlm-sidebar-rail />
+			</hlm-sidebar>
+			<ng-content />
+		</div>
+	`,
+})
+export class AppSidebar03 {
+	public readonly flatNavItems = [
+		{
+			title: 'Getting Started',
+			url: '.',
+			items: [
+				{ title: 'Installation', url: '.', isActive: false },
+				{ title: 'Project Structure', url: '.', isActive: false },
+			],
+		},
+		{
+			title: 'Build Your Application',
+			url: '.',
+			items: [
+				{ title: 'Routing', url: '.', isActive: false },
+				{ title: 'Data Fetching', url: '.', isActive: true },
+				{ title: 'Rendering', url: '.', isActive: false },
+				{ title: 'Caching', url: '.', isActive: false },
+				{ title: 'Styling', url: '.', isActive: false },
+				{ title: 'Optimizing', url: '.', isActive: false },
+				{ title: 'Configuring', url: '.', isActive: false },
+				{ title: 'Testing', url: '.', isActive: false },
+				{ title: 'Authentication', url: '.', isActive: false },
+				{ title: 'Deploying', url: '.', isActive: false },
+				{ title: 'Upgrading', url: '.', isActive: false },
+				{ title: 'Examples', url: '.', isActive: false },
+			],
+		},
+		{
+			title: 'API Reference',
+			url: '.',
+			items: [
+				{ title: 'Components', url: '.', isActive: false },
+				{ title: 'File Conventions', url: '.', isActive: false },
+				{ title: 'Functions', url: '.', isActive: false },
+				{ title: 'next.config.js Options', url: '.', isActive: false },
+				{ title: 'CLI', url: '.', isActive: false },
+				{ title: 'Edge Runtime', url: '.', isActive: false },
+			],
+		},
+		{
+			title: 'Community',
+			url: '.',
+			items: [{ title: 'Contribution Guide', url: '.', isActive: false }],
+		},
+	];
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-04/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-04/index.page.ts
@@ -1,0 +1,47 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmBreadcrumbImports } from '@spartan-ng/helm/breadcrumb';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { AppSidebar04 } from './sidebar-04/app-sidebar';
+
+@Component({
+	selector: 'spartan-sidebar-04-preview',
+	imports: [HlmSidebarImports, AppSidebar04, HlmSeparatorImports, HlmBreadcrumbImports],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block [--sidebar-width:19rem]',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<spartan-app-sidebar-04 />
+			<main hlmSidebarInset>
+				<header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+					<button hlmSidebarTrigger class="-ml-1"></button>
+					<hlm-separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
+					<nav hlmBreadcrumb>
+						<ol hlmBreadcrumbList>
+							<li hlmBreadcrumbItem class="hidden md:block">
+								<a hlmBreadcrumbLink href="#">Build Your Application</a>
+							</li>
+							<li hlmBreadcrumbSeparator class="hidden md:block"></li>
+							<li hlmBreadcrumbItem>
+								<a hlmBreadcrumbPage>Data Fetching</a>
+							</li>
+						</ol>
+					</nav>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 p-4">
+					<div class="grid auto-rows-min gap-4 md:grid-cols-3">
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+					</div>
+					<div class="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min"></div>
+				</div>
+			</main>
+		</div>
+	`,
+})
+export default class Sidebar04Page {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-04/sidebar-04/app-sidebar.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-04/sidebar-04/app-sidebar.ts
@@ -1,0 +1,88 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { NavMainFlat } from '../../shared/sidebar/nav-main-flat';
+
+@Component({
+	selector: 'spartan-sidebar-04',
+	imports: [HlmSidebarImports, NavMainFlat],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<hlm-sidebar variant="floating">
+				<hlm-sidebar-header>
+					<ul hlmSidebarMenu>
+						<li hlmSidebarMenuItem>
+							<a hlmSidebarMenuButton size="lg" href="#">
+								<div
+									class="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg"
+								>
+									<span class="text-base">&#9670;</span>
+								</div>
+								<div class="grid flex-1 text-left text-sm leading-tight">
+									<span class="truncate font-medium">Documentation</span>
+									<span class="truncate text-xs">v1.0.0</span>
+								</div>
+							</a>
+						</li>
+					</ul>
+				</hlm-sidebar-header>
+				<hlm-sidebar-content>
+					<spartan-nav-main-flat groupLabel="Getting Started" [items]="flatNavItems" />
+				</hlm-sidebar-content>
+			</hlm-sidebar>
+			<ng-content />
+		</div>
+	`,
+})
+export class AppSidebar04 {
+	public readonly flatNavItems = [
+		{
+			title: 'Getting Started',
+			url: '.',
+			items: [
+				{ title: 'Installation', url: '.' },
+				{ title: 'Project Structure', url: '.' },
+			],
+		},
+		{
+			title: 'Build Your Application',
+			url: '.',
+			items: [
+				{ title: 'Routing', url: '.' },
+				{ title: 'Data Fetching', url: '.', isActive: true },
+				{ title: 'Rendering', url: '.' },
+				{ title: 'Caching', url: '.' },
+				{ title: 'Styling', url: '.' },
+				{ title: 'Optimizing', url: '.' },
+				{ title: 'Configuring', url: '.' },
+				{ title: 'Testing', url: '.' },
+				{ title: 'Authentication', url: '.' },
+				{ title: 'Deploying', url: '.' },
+				{ title: 'Upgrading', url: '.' },
+				{ title: 'Examples', url: '.' },
+			],
+		},
+		{
+			title: 'API Reference',
+			url: '.',
+			items: [
+				{ title: 'Components', url: '.' },
+				{ title: 'File Conventions', url: '.' },
+				{ title: 'Functions', url: '.' },
+				{ title: 'next.config.js Options', url: '.' },
+				{ title: 'CLI', url: '.' },
+				{ title: 'Edge Runtime', url: '.' },
+			],
+		},
+		{
+			title: 'Community',
+			url: '.',
+			items: [{ title: 'Contribution Guide', url: '.' }],
+		},
+	];
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-05/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-05/index.page.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { AppSidebar05 } from './sidebar-05/app-sidebar';
+
+@Component({
+	selector: 'spartan-sidebar-05-preview',
+	imports: [HlmSidebarImports, AppSidebar05, HlmSeparatorImports],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<spartan-app-sidebar-05 />
+			<main hlmSidebarInset>
+				<header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+					<button hlmSidebarTrigger class="-ml-1"></button>
+					<hlm-separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
+					<span class="text-sm">Data Fetching</span>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 p-4">
+					<div class="grid auto-rows-min gap-4 md:grid-cols-3">
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+					</div>
+					<div class="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min"></div>
+				</div>
+			</main>
+		</div>
+	`,
+})
+export default class Sidebar05Page {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-05/sidebar-05/app-sidebar.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-05/sidebar-05/app-sidebar.ts
@@ -1,0 +1,112 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronRight, lucideGalleryVerticalEnd, lucideMinus, lucidePlus } from '@ng-icons/lucide';
+import { HlmCollapsibleImports } from '@spartan-ng/helm/collapsible';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { SearchForm } from '../../shared/sidebar/search-form';
+
+@Component({
+	selector: 'spartan-sidebar-05',
+	imports: [HlmSidebarImports, NgIcon, HlmCollapsibleImports, SearchForm],
+	providers: [provideIcons({ lucideGalleryVerticalEnd, lucidePlus, lucideMinus, lucideChevronRight })],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<hlm-sidebar>
+			<hlm-sidebar-header>
+				<ul hlmSidebarMenu>
+					<li hlmSidebarMenuItem>
+						<a hlmSidebarMenuButton size="lg" href="#">
+							<div
+								class="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg"
+							>
+								<ng-icon name="lucideGalleryVerticalEnd" class="text-base" />
+							</div>
+							<div class="flex flex-col gap-0.5 leading-none">
+								<span class="font-medium">Documentation</span>
+								<span>v1.0.0</span>
+							</div>
+						</a>
+					</li>
+				</ul>
+				<spartan-search-form />
+			</hlm-sidebar-header>
+			<hlm-sidebar-content>
+				<hlm-sidebar-group>
+					<ul hlmSidebarMenu>
+						@for (group of navGroups; track group.title; let idx = $index) {
+							<hlm-collapsible [expanded]="idx === 1" class="group/collapsible">
+								<li hlmSidebarMenuItem>
+									<button hlmCollapsibleTrigger hlmSidebarMenuButton>
+										{{ group.title }}
+										<ng-icon name="lucidePlus" class="ml-auto group-data-[state=open]/collapsible:hidden" />
+										<ng-icon name="lucideMinus" class="ml-auto group-data-[state=closed]/collapsible:hidden" />
+									</button>
+									<hlm-collapsible-content>
+										<ul hlmSidebarMenuSub class="ml-0 border-l-0 px-1.5">
+											@for (item of group.items; track item.title) {
+												<li hlmSidebarMenuSubItem>
+													<a
+														hlmSidebarMenuSubButton
+														href="#"
+														[class]="item.isActive ? 'bg-sidebar-accent text-sidebar-accent-foreground' : ''"
+													>
+														{{ item.title }}
+													</a>
+												</li>
+											}
+										</ul>
+									</hlm-collapsible-content>
+								</li>
+							</hlm-collapsible>
+						}
+					</ul>
+				</hlm-sidebar-group>
+			</hlm-sidebar-content>
+			<hlm-sidebar-rail />
+		</hlm-sidebar>
+	`,
+})
+export class AppSidebar05 {
+	public readonly navGroups = [
+		{
+			title: 'Getting Started',
+			items: [
+				{ title: 'Installation', url: '.' },
+				{ title: 'Project Structure', url: '.' },
+			],
+		},
+		{
+			title: 'Build Your Application',
+			items: [
+				{ title: 'Routing', url: '.' },
+				{ title: 'Data Fetching', url: '.', isActive: true },
+				{ title: 'Rendering', url: '.' },
+				{ title: 'Caching', url: '.' },
+				{ title: 'Styling', url: '.' },
+				{ title: 'Optimizing', url: '.' },
+				{ title: 'Configuring', url: '.' },
+				{ title: 'Testing', url: '.' },
+				{ title: 'Authentication', url: '.' },
+				{ title: 'Deploying', url: '.' },
+				{ title: 'Upgrading', url: '.' },
+				{ title: 'Examples', url: '.' },
+			],
+		},
+		{
+			title: 'API Reference',
+			items: [
+				{ title: 'Components', url: '.' },
+				{ title: 'File Conventions', url: '.' },
+				{ title: 'Functions', url: '.' },
+				{ title: 'next.config.js Options', url: '.' },
+				{ title: 'CLI', url: '.' },
+				{ title: 'Edge Runtime', url: '.' },
+			],
+		},
+	];
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-06/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-06/index.page.ts
@@ -1,0 +1,47 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmBreadcrumbImports } from '@spartan-ng/helm/breadcrumb';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { AppSidebar06 } from './sidebar-06/app-sidebar';
+
+@Component({
+	selector: 'spartan-sidebar-06-preview',
+	imports: [HlmSidebarImports, AppSidebar06, HlmSeparatorImports, HlmBreadcrumbImports],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<spartan-app-sidebar-06 />
+			<main hlmSidebarInset>
+				<header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+					<button hlmSidebarTrigger class="-ml-1"></button>
+					<hlm-separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
+					<nav hlmBreadcrumb>
+						<ol hlmBreadcrumbList>
+							<li hlmBreadcrumbItem class="hidden md:block">
+								<a hlmBreadcrumbLink href="#">Build Your Application</a>
+							</li>
+							<li hlmBreadcrumbSeparator class="hidden md:block"></li>
+							<li hlmBreadcrumbItem>
+								<a hlmBreadcrumbPage>Data Fetching</a>
+							</li>
+						</ol>
+					</nav>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 p-4">
+					<div class="grid auto-rows-min gap-4 md:grid-cols-3">
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+					</div>
+					<div class="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min"></div>
+				</div>
+			</main>
+		</div>
+	`,
+})
+export default class Sidebar06Page {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-06/sidebar-06/app-sidebar.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-06/sidebar-06/app-sidebar.ts
@@ -1,0 +1,49 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideGalleryVerticalEnd } from '@ng-icons/lucide';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { NavMainDropdown } from './nav-main';
+import { SidebarOptInForm } from './sidebar-opt-in-form';
+
+@Component({
+	selector: 'spartan-sidebar-06',
+	imports: [HlmSidebarImports, NgIcon, NavMainDropdown, SidebarOptInForm],
+	providers: [provideIcons({ lucideGalleryVerticalEnd })],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<hlm-sidebar>
+			<hlm-sidebar-header>
+				<ul hlmSidebarMenu>
+					<li hlmSidebarMenuItem>
+						<a hlmSidebarMenuButton size="lg" href="#">
+							<div
+								class="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg"
+							>
+								<ng-icon name="lucideGalleryVerticalEnd" class="text-base" />
+							</div>
+							<div class="flex flex-col gap-0.5 leading-none">
+								<span class="font-medium">Documentation</span>
+								<span>v1.0.0</span>
+							</div>
+						</a>
+					</li>
+				</ul>
+			</hlm-sidebar-header>
+			<hlm-sidebar-content>
+				<spartan-nav-main-dropdown />
+			</hlm-sidebar-content>
+			<hlm-sidebar-footer>
+				<div class="p-1">
+					<spartan-sidebar-opt-in-form />
+				</div>
+			</hlm-sidebar-footer>
+			<hlm-sidebar-rail />
+		</hlm-sidebar>
+	`,
+})
+export class AppSidebar06 {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-06/sidebar-06/nav-main.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-06/sidebar-06/nav-main.ts
@@ -1,0 +1,50 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideMoreHorizontal } from '@ng-icons/lucide';
+import { HlmDropdownMenuImports } from '@spartan-ng/helm/dropdown-menu';
+import { HlmSidebarImports, HlmSidebarService } from '@spartan-ng/helm/sidebar';
+import { data } from '../../shared/sidebar/data';
+
+@Component({
+	selector: 'spartan-nav-main-dropdown',
+	imports: [HlmSidebarImports, NgIcon, HlmDropdownMenuImports],
+	providers: [provideIcons({ lucideMoreHorizontal })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<hlm-sidebar-group>
+			<ul hlmSidebarMenu>
+				@for (item of items; track item.title) {
+					<li hlmSidebarMenuItem>
+						<button
+							hlmSidebarMenuButton
+							[hlmDropdownMenuTrigger]="menu"
+							[side]="_menuSide()"
+							[align]="_menuAlign()"
+							class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+						>
+							{{ item.title }}
+							<ng-icon name="lucideMoreHorizontal" class="ml-auto" />
+						</button>
+					</li>
+				}
+			</ul>
+		</hlm-sidebar-group>
+
+		<ng-template #menu>
+			<hlm-dropdown-menu class="w-56 min-w-56 rounded-lg">
+				<hlm-dropdown-menu-group>
+					<hlm-dropdown-menu-label>Navigation</hlm-dropdown-menu-label>
+				</hlm-dropdown-menu-group>
+				<hlm-dropdown-menu-separator />
+				<button hlmDropdownMenuItem>Documentation</button>
+			</hlm-dropdown-menu>
+		</ng-template>
+	`,
+})
+export class NavMainDropdown {
+	private readonly _sidebarService = inject(HlmSidebarService);
+	protected readonly _menuSide = computed(() => (this._sidebarService.isMobile() ? 'bottom' : 'right'));
+	protected readonly _menuAlign = computed(() => (this._sidebarService.isMobile() ? 'end' : 'start'));
+
+	public readonly items = data.navMain;
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-06/sidebar-06/sidebar-opt-in-form.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-06/sidebar-06/sidebar-opt-in-form.ts
@@ -1,0 +1,29 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmCardImports } from '@spartan-ng/helm/card';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+
+@Component({
+	selector: 'spartan-sidebar-opt-in-form',
+	imports: [HlmSidebarImports, HlmButton, HlmCardImports],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<hlm-card class="gap-2 py-4 shadow-none">
+			<hlm-card-header class="px-4">
+				<hlm-card-title class="text-sm">Subscribe to our newsletter</hlm-card-title>
+				<hlm-card-description>Opt-in to receive updates and news about the sidebar.</hlm-card-description>
+			</hlm-card-header>
+			<hlm-card-content class="px-4">
+				<form>
+					<div class="grid gap-2.5">
+						<input hlmSidebarInput type="email" placeholder="Email" />
+						<button hlmBtn class="bg-sidebar-primary text-sidebar-primary-foreground w-full shadow-none" size="sm">
+							Subscribe
+						</button>
+					</div>
+				</form>
+			</hlm-card-content>
+		</hlm-card>
+	`,
+})
+export class SidebarOptInForm {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-07/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-07/index.page.ts
@@ -1,0 +1,47 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmBreadcrumbImports } from '@spartan-ng/helm/breadcrumb';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { AppSidebar07 } from './sidebar-07/app-sidebar';
+
+@Component({
+	selector: 'spartan-sidebar-07-preview',
+	imports: [HlmSidebarImports, AppSidebar07, HlmSeparatorImports, HlmBreadcrumbImports],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<spartan-app-sidebar-07 />
+			<main hlmSidebarInset>
+				<header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+					<button hlmSidebarTrigger class="-ml-1"></button>
+					<hlm-separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
+					<nav hlmBreadcrumb>
+						<ol hlmBreadcrumbList>
+							<li hlmBreadcrumbItem class="hidden md:block">
+								<a hlmBreadcrumbLink href="#">Build Your Application</a>
+							</li>
+							<li hlmBreadcrumbSeparator class="hidden md:block"></li>
+							<li hlmBreadcrumbItem>
+								<a hlmBreadcrumbPage>Data Fetching</a>
+							</li>
+						</ol>
+					</nav>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 p-4">
+					<div class="grid auto-rows-min gap-4 md:grid-cols-3">
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+					</div>
+					<div class="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min"></div>
+				</div>
+			</main>
+		</div>
+	`,
+})
+export default class Sidebar07Page {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-07/sidebar-07/app-sidebar.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-07/sidebar-07/app-sidebar.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { data } from '../../shared/sidebar/data';
+import { NavMain } from '../../shared/sidebar/nav-main';
+import { NavProjects } from '../../shared/sidebar/nav-projects';
+import { NavUser } from '../../shared/sidebar/nav-user';
+import { TeamSwitcher } from '../../shared/sidebar/team-switcher';
+
+@Component({
+	selector: 'spartan-sidebar-07',
+	imports: [HlmSidebarImports, TeamSwitcher, NavMain, NavProjects, NavUser],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<hlm-sidebar collapsible="icon">
+			<hlm-sidebar-header>
+				<spartan-team-switcher [teams]="data.teams" />
+			</hlm-sidebar-header>
+			<hlm-sidebar-content>
+				<spartan-nav-main [items]="data.navMain" />
+				<spartan-nav-projects [projects]="data.projects" />
+			</hlm-sidebar-content>
+			<hlm-sidebar-footer>
+				<spartan-nav-user [user]="data.user" />
+			</hlm-sidebar-footer>
+			<hlm-sidebar-rail />
+		</hlm-sidebar>
+	`,
+})
+export class AppSidebar07 {
+	public readonly data = data;
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-09/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-09/index.page.ts
@@ -1,0 +1,46 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmBreadcrumbImports } from '@spartan-ng/helm/breadcrumb';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { AppSidebar09 } from './sidebar-09/app-sidebar';
+
+@Component({
+	selector: 'spartan-sidebar-09-preview',
+	imports: [HlmSidebarImports, AppSidebar09, HlmSeparatorImports, HlmBreadcrumbImports],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block [--sidebar-width:350px]',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<spartan-app-sidebar-09 />
+			<main hlmSidebarInset>
+				<header class="bg-background sticky top-0 flex shrink-0 items-center gap-2 border-b p-4">
+					<button hlmSidebarTrigger class="-ml-1"></button>
+					<hlm-separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
+					<nav hlmBreadcrumb>
+						<ol hlmBreadcrumbList>
+							<li hlmBreadcrumbItem class="hidden md:block">
+								<a hlmBreadcrumbLink href="#">All Inboxes</a>
+							</li>
+							<li hlmBreadcrumbSeparator class="hidden md:block"></li>
+							<li hlmBreadcrumbItem>
+								<a hlmBreadcrumbPage>Inbox</a>
+							</li>
+						</ol>
+					</nav>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 p-4">
+					@for (i of rows; track i) {
+						<div class="bg-muted/50 h-12 w-full rounded-lg"></div>
+					}
+				</div>
+			</main>
+		</div>
+	`,
+})
+export default class Sidebar09Page {
+	public readonly rows = Array.from({ length: 24 });
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-09/sidebar-09/app-sidebar.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-09/sidebar-09/app-sidebar.ts
@@ -1,0 +1,124 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideArchiveX, lucideCommand, lucideFile, lucideInbox, lucideSend, lucideTrash2 } from '@ng-icons/lucide';
+import { HlmLabel } from '@spartan-ng/helm/label';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { HlmSwitchImports } from '@spartan-ng/helm/switch';
+import { data } from '../../shared/sidebar/data';
+import { NavUser } from '../../shared/sidebar/nav-user';
+
+@Component({
+	selector: 'spartan-sidebar-09',
+	imports: [HlmSidebarImports, NgIcon, HlmLabel, HlmSwitchImports, NavUser],
+	providers: [
+		provideIcons({
+			lucideInbox,
+			lucideFile,
+			lucideSend,
+			lucideArchiveX,
+			lucideTrash2,
+			lucideCommand,
+		}),
+	],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<hlm-sidebar collapsible="icon" class="overflow-hidden *:data-[sidebar=sidebar]:flex-row">
+			<!-- Outer sidebar: icon-only nav -->
+			<hlm-sidebar collapsible="none" class="w-[calc(var(--sidebar-width-icon)+1px)]! border-r">
+				<hlm-sidebar-header>
+					<ul hlmSidebarMenu>
+						<li hlmSidebarMenuItem>
+							<a hlmSidebarMenuButton size="lg" href="#" class="md:h-8 md:p-0">
+								<div
+									class="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg"
+								>
+									<ng-icon name="lucideCommand" class="text-base" />
+								</div>
+								<div class="grid flex-1 text-left text-sm leading-tight">
+									<span class="truncate font-medium">Acme Inc</span>
+									<span class="truncate text-xs">Enterprise</span>
+								</div>
+							</a>
+						</li>
+					</ul>
+				</hlm-sidebar-header>
+				<hlm-sidebar-content>
+					<hlm-sidebar-group>
+						<div hlmSidebarGroupContent class="px-1.5 md:px-0">
+							<ul hlmSidebarMenu>
+								@for (item of navMail; track item.title) {
+									<li hlmSidebarMenuItem>
+										<button
+											hlmSidebarMenuButton
+											[isActive]="_activeItem()?.title === item.title"
+											class="px-2.5 md:px-2"
+											(click)="selectItem(item)"
+										>
+											<ng-icon [name]="item.icon" />
+											<span>{{ item.title }}</span>
+										</button>
+									</li>
+								}
+							</ul>
+						</div>
+					</hlm-sidebar-group>
+				</hlm-sidebar-content>
+				<hlm-sidebar-footer>
+					<spartan-nav-user [user]="data.user" />
+				</hlm-sidebar-footer>
+			</hlm-sidebar>
+
+			<!-- Inner sidebar: mail list -->
+			<hlm-sidebar collapsible="none" class="hidden flex-1 md:flex">
+				<hlm-sidebar-header class="gap-3.5 border-b p-4">
+					<div class="flex w-full items-center justify-between">
+						<div class="text-foreground text-base font-medium">{{ _activeItem()?.title }}</div>
+						<label hlmLabel class="flex items-center gap-2 text-sm">
+							<span>Unreads</span>
+							<hlm-switch class="shadow-none" />
+						</label>
+					</div>
+					<input hlmSidebarInput placeholder="Type to search..." />
+				</hlm-sidebar-header>
+				<hlm-sidebar-content>
+					<hlm-sidebar-group class="px-0">
+						<div hlmSidebarGroupContent>
+							@for (mail of _mails(); track mail.email) {
+								<a
+									href="#"
+									class="border-border hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex flex-col items-start gap-2 border-b p-4 text-sm leading-tight whitespace-nowrap last:border-b-0"
+								>
+									<div class="flex w-full items-center gap-2">
+										<span>{{ mail.name }}</span>
+										<span class="text-muted-foreground ml-auto text-xs">{{ mail.date }}</span>
+									</div>
+									<span class="font-medium">{{ mail.subject }}</span>
+									<span class="text-muted-foreground line-clamp-2 w-[260px] text-xs whitespace-break-spaces">
+										{{ mail.teaser }}
+									</span>
+								</a>
+							}
+						</div>
+					</hlm-sidebar-group>
+				</hlm-sidebar-content>
+			</hlm-sidebar>
+		</hlm-sidebar>
+	`,
+})
+export class AppSidebar09 {
+	public readonly data = data;
+	public readonly navMail = data.navMail;
+	protected readonly _activeItem = signal(this.navMail[0]);
+	protected readonly _mails = signal(data.mails);
+
+	protected selectItem(item: { title: string; url: string; icon: string; isActive: boolean }): void {
+		this._activeItem.set(item);
+		const shuffled = [...data.mails].sort(() => Math.random() - 0.5);
+		this._mails.set(shuffled.slice(0, Math.max(5, Math.floor(Math.random() * 10) + 1)));
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-10/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-10/index.page.ts
@@ -1,0 +1,46 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmBreadcrumbImports } from '@spartan-ng/helm/breadcrumb';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { NavActions } from '../shared/sidebar/nav-actions';
+import { AppSidebar10 } from './sidebar-10/app-sidebar';
+import { NavMainFlatItems } from './sidebar-10/nav-main-flat-items';
+
+@Component({
+	selector: 'spartan-sidebar-10-preview',
+	imports: [HlmSidebarImports, AppSidebar10, HlmSeparatorImports, HlmBreadcrumbImports, NavActions, NavMainFlatItems],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<spartan-app-sidebar-10 />
+			<main hlmSidebarInset>
+				<header class="flex h-14 shrink-0 items-center gap-2">
+					<div class="flex flex-1 items-center gap-2 px-3">
+						<button hlmSidebarTrigger></button>
+						<hlm-separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
+						<nav hlmBreadcrumb>
+							<ol hlmBreadcrumbList>
+								<li hlmBreadcrumbItem>
+									<a hlmBreadcrumbPage class="line-clamp-1">Project Management & Task Tracking</a>
+								</li>
+							</ol>
+						</nav>
+					</div>
+					<div class="ml-auto px-3">
+						<spartan-nav-actions />
+					</div>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 px-4 py-10">
+					<div class="bg-muted/50 mx-auto h-24 w-full max-w-3xl rounded-xl"></div>
+					<div class="bg-muted/50 mx-auto h-full w-full max-w-3xl rounded-xl"></div>
+				</div>
+			</main>
+		</div>
+	`,
+})
+export default class Sidebar10Page {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-10/sidebar-10/app-sidebar.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-10/sidebar-10/app-sidebar.ts
@@ -1,0 +1,69 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+	lucideBlocks,
+	lucideCalendar,
+	lucideEllipsis,
+	lucideGalleryVerticalEnd,
+	lucideHome,
+	lucideInbox,
+	lucideLifeBuoy,
+	lucideMessageCircleQuestion,
+	lucidePlus,
+	lucideSearch,
+	lucideSend,
+	lucideSparkles,
+	lucideTrash2,
+} from '@ng-icons/lucide';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { data } from '../../shared/sidebar/data';
+import { NavFavorites } from '../../shared/sidebar/nav-favorites';
+import { NavSecondary } from '../../shared/sidebar/nav-secondary';
+import { NavWorkspaces } from '../../shared/sidebar/nav-workspaces';
+import { TeamSwitcher } from '../../shared/sidebar/team-switcher';
+import { NavMainFlatItems } from './nav-main-flat-items';
+
+@Component({
+	selector: 'spartan-sidebar-10',
+	imports: [HlmSidebarImports, NgIcon, TeamSwitcher, NavMainFlatItems, NavFavorites, NavWorkspaces, NavSecondary],
+	providers: [
+		provideIcons({
+			lucideGalleryVerticalEnd,
+			lucidePlus,
+			lucideEllipsis,
+			lucideHome,
+			lucideInbox,
+			lucideMessageCircleQuestion,
+			lucideSearch,
+			lucideSparkles,
+			lucideTrash2,
+			lucideCalendar,
+			lucideBlocks,
+			lucideLifeBuoy,
+			lucideSend,
+		}),
+	],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<hlm-sidebar class="border-r-0">
+			<hlm-sidebar-header>
+				<spartan-team-switcher [teams]="data.teams" />
+				<spartan-nav-main-flat-items />
+			</hlm-sidebar-header>
+			<hlm-sidebar-content>
+				<spartan-nav-favorites [favorites]="data.favorites" />
+				<spartan-nav-workspaces [workspaces]="data.workspaces" />
+				<spartan-nav-secondary [items]="data.navSecondary" class="mt-auto" />
+			</hlm-sidebar-content>
+			<hlm-sidebar-rail />
+		</hlm-sidebar>
+	`,
+})
+export class AppSidebar10 {
+	public readonly data = data;
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-10/sidebar-10/nav-main-flat-items.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-10/sidebar-10/nav-main-flat-items.ts
@@ -1,0 +1,62 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+	lucideHome,
+	lucideInbox,
+	lucideMessageCircleQuestion,
+	lucideSearch,
+	lucideSettings2,
+	lucideSparkles,
+	lucideSquareTerminal,
+} from '@ng-icons/lucide';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+
+@Component({
+	selector: 'spartan-nav-main-flat-items',
+	imports: [HlmSidebarImports, NgIcon],
+	providers: [
+		provideIcons({
+			lucideSquareTerminal,
+			lucideHome,
+			lucideInbox,
+			lucideSearch,
+			lucideSettings2,
+			lucideSparkles,
+			lucideMessageCircleQuestion,
+		}),
+	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<hlm-sidebar-group>
+			<div hlmSidebarGroupContent>
+				<ul hlmSidebarMenu>
+					<li hlmSidebarMenuItem>
+						<button hlmSidebarMenuButton>
+							<ng-icon name="lucideSearch" />
+							<span>Search</span>
+						</button>
+					</li>
+					<li hlmSidebarMenuItem>
+						<button hlmSidebarMenuButton [isActive]="true">
+							<ng-icon name="lucideInbox" />
+							<span>Inbox</span>
+						</button>
+					</li>
+					<li hlmSidebarMenuItem>
+						<button hlmSidebarMenuButton>
+							<ng-icon name="lucideHome" />
+							<span>Home</span>
+						</button>
+					</li>
+					<li hlmSidebarMenuItem>
+						<button hlmSidebarMenuButton>
+							<ng-icon name="lucideSettings2" />
+							<span>Settings</span>
+						</button>
+					</li>
+				</ul>
+			</div>
+		</hlm-sidebar-group>
+	`,
+})
+export class NavMainFlatItems {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-11/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-11/index.page.ts
@@ -1,0 +1,52 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmBreadcrumbImports } from '@spartan-ng/helm/breadcrumb';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { AppSidebar11 } from './sidebar-11/app-sidebar';
+import { TreeItemComponent } from './sidebar-11/tree-item';
+
+@Component({
+	selector: 'spartan-sidebar-11-preview',
+	imports: [HlmSidebarImports, AppSidebar11, HlmSeparatorImports, HlmBreadcrumbImports, TreeItemComponent],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<spartan-app-sidebar-11 />
+			<main hlmSidebarInset>
+				<header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+					<button hlmSidebarTrigger class="-ml-1"></button>
+					<hlm-separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
+					<nav hlmBreadcrumb>
+						<ol hlmBreadcrumbList>
+							<li hlmBreadcrumbItem class="hidden md:block">
+								<a hlmBreadcrumbLink href="#">components</a>
+							</li>
+							<li hlmBreadcrumbSeparator class="hidden md:block"></li>
+							<li hlmBreadcrumbItem class="hidden md:block">
+								<a hlmBreadcrumbLink href="#">ui</a>
+							</li>
+							<li hlmBreadcrumbSeparator class="hidden md:block"></li>
+							<li hlmBreadcrumbItem>
+								<a hlmBreadcrumbPage>button.tsx</a>
+							</li>
+						</ol>
+					</nav>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 p-4">
+					<div class="grid auto-rows-min gap-4 md:grid-cols-3">
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+					</div>
+					<div class="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min"></div>
+				</div>
+			</main>
+		</div>
+	`,
+})
+export default class Sidebar11Page {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-11/sidebar-11/app-sidebar.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-11/sidebar-11/app-sidebar.ts
@@ -1,0 +1,72 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronRight, lucideFile, lucideFolder } from '@ng-icons/lucide';
+import { HlmCollapsibleImports } from '@spartan-ng/helm/collapsible';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { TreeItemComponent } from './tree-item';
+
+type TreeItem = string | TreeItem[];
+
+@Component({
+	selector: 'spartan-sidebar-11',
+	imports: [HlmSidebarImports, NgIcon, HlmCollapsibleImports, TreeItemComponent],
+	providers: [provideIcons({ lucideChevronRight, lucideFile, lucideFolder })],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<hlm-sidebar>
+			<hlm-sidebar-content>
+				<hlm-sidebar-group>
+					<div hlmSidebarGroupLabel>Changes</div>
+					<div hlmSidebarGroupContent>
+						<ul hlmSidebarMenu>
+							@for (change of changes; track change.file) {
+								<li hlmSidebarMenuItem>
+									<button hlmSidebarMenuButton>
+										<ng-icon name="lucideFile" />
+										{{ change.file }}
+									</button>
+									<hlm-sidebar-menu-badge>{{ change.state }}</hlm-sidebar-menu-badge>
+								</li>
+							}
+						</ul>
+					</div>
+				</hlm-sidebar-group>
+				<hlm-sidebar-group>
+					<div hlmSidebarGroupLabel>Files</div>
+					<div hlmSidebarGroupContent>
+						<ul hlmSidebarMenu>
+							@for (item of tree; track $index) {
+								<spartan-tree-item [item]="item" />
+							}
+						</ul>
+					</div>
+				</hlm-sidebar-group>
+			</hlm-sidebar-content>
+			<hlm-sidebar-rail />
+		</hlm-sidebar>
+	`,
+})
+export class AppSidebar11 {
+	public readonly changes = [
+		{ file: 'README.md', state: 'M' },
+		{ file: 'api/hello/route.ts', state: 'U' },
+		{ file: 'app/layout.tsx', state: 'M' },
+	];
+	public readonly tree: TreeItem[] = [
+		['app', ['api', ['hello', ['route.ts']], 'page.tsx', 'layout.tsx', ['blog', ['page.tsx']]]],
+		['components', ['ui', 'button.tsx', 'card.tsx'], 'header.tsx', 'footer.tsx'],
+		['lib', ['util.ts']],
+		['public', 'favicon.ico', 'vercel.svg'],
+		'.eslintrc.json',
+		'.gitignore',
+		'next.config.js',
+		'tailwind.config.js',
+		'package.json',
+		'README.md',
+	];
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-11/sidebar-11/tree-item.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-11/sidebar-11/tree-item.ts
@@ -1,0 +1,61 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronRight, lucideFile, lucideFolder } from '@ng-icons/lucide';
+import { HlmCollapsibleImports } from '@spartan-ng/helm/collapsible';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+
+type TreeItemType = string | TreeItemType[];
+
+@Component({
+	selector: 'spartan-tree-item',
+	imports: [HlmSidebarImports, NgIcon, HlmCollapsibleImports],
+	providers: [provideIcons({ lucideChevronRight, lucideFile, lucideFolder })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		@if (!isArray()) {
+			<li hlmSidebarMenuItem>
+				<button hlmSidebarMenuButton class="data-[active=true]:bg-transparent">
+					<ng-icon name="lucideFile" />
+					{{ item() }}
+				</button>
+			</li>
+		} @else {
+			<li hlmSidebarMenuItem>
+				<hlm-collapsible
+					class="group/collapsible [&[data-state=open]>button>svg:first-child]:rotate-90"
+					[expanded]="getName() === 'components' || getName() === 'ui'"
+				>
+					<button hlmCollapsibleTrigger hlmSidebarMenuButton>
+						<ng-icon name="lucideChevronRight" class="transition-transform" />
+						<ng-icon name="lucideFolder" />
+						{{ getName() }}
+					</button>
+					<hlm-collapsible-content>
+						<ul hlmSidebarMenuSub>
+							@for (child of getChildren(); track $index) {
+								<spartan-tree-item [item]="child" />
+							}
+						</ul>
+					</hlm-collapsible-content>
+				</hlm-collapsible>
+			</li>
+		}
+	`,
+})
+export class TreeItemComponent {
+	public readonly item = input.required<TreeItemType>();
+
+	protected isArray(): boolean {
+		return Array.isArray(this.item());
+	}
+
+	protected getName(): string {
+		const val = this.item();
+		return Array.isArray(val) ? (val[0] as string) : val;
+	}
+
+	protected getChildren(): TreeItemType[] {
+		const val = this.item();
+		return Array.isArray(val) ? (val.slice(1) as TreeItemType[]) : [];
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-12/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-12/index.page.ts
@@ -1,0 +1,44 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmBreadcrumbImports } from '@spartan-ng/helm/breadcrumb';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { AppSidebar12 } from './sidebar-12/app-sidebar';
+
+@Component({
+	selector: 'spartan-sidebar-12-preview',
+	imports: [HlmSidebarImports, AppSidebar12, HlmSeparatorImports, HlmBreadcrumbImports],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<spartan-app-sidebar-12 />
+			<main hlmSidebarInset>
+				<header class="bg-background sticky top-0 flex h-16 shrink-0 items-center gap-2 border-b px-4">
+					<button hlmSidebarTrigger class="-ml-1"></button>
+					<hlm-separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
+					<nav hlmBreadcrumb>
+						<ol hlmBreadcrumbList>
+							<li hlmBreadcrumbItem>
+								<a hlmBreadcrumbPage>October 2024</a>
+							</li>
+						</ol>
+					</nav>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 p-4">
+					<div class="grid auto-rows-min gap-4 md:grid-cols-5">
+						@for (i of calendarGrid; track i) {
+							<div class="bg-muted/50 aspect-square rounded-xl"></div>
+						}
+					</div>
+				</div>
+			</main>
+		</div>
+	`,
+})
+export default class Sidebar12Page {
+	public readonly calendarGrid = Array.from({ length: 20 });
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-12/sidebar-12/app-sidebar.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-12/sidebar-12/app-sidebar.ts
@@ -1,0 +1,46 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucidePlus } from '@ng-icons/lucide';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { Calendars } from '../../shared/sidebar/calendars';
+import { data } from '../../shared/sidebar/data';
+import { DatePicker } from '../../shared/sidebar/date-picker';
+import { NavUser } from '../../shared/sidebar/nav-user';
+
+@Component({
+	selector: 'spartan-sidebar-12',
+	imports: [HlmSidebarImports, NgIcon, Calendars, DatePicker, NavUser],
+	providers: [provideIcons({ lucidePlus })],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<hlm-sidebar>
+			<hlm-sidebar-header class="border-sidebar-border h-16 border-b">
+				<spartan-nav-user [user]="data.user" />
+			</hlm-sidebar-header>
+			<hlm-sidebar-content>
+				<spartan-date-picker />
+				<hlm-sidebar-separator class="mx-0" />
+				<spartan-calendars [calendars]="data.calendars" />
+			</hlm-sidebar-content>
+			<hlm-sidebar-footer>
+				<ul hlmSidebarMenu>
+					<li hlmSidebarMenuItem>
+						<button hlmSidebarMenuButton>
+							<ng-icon name="lucidePlus" />
+							<span>New Calendar</span>
+						</button>
+					</li>
+				</ul>
+			</hlm-sidebar-footer>
+			<hlm-sidebar-rail />
+		</hlm-sidebar>
+	`,
+})
+export class AppSidebar12 {
+	public readonly data = data;
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-14/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-14/index.page.ts
@@ -1,0 +1,45 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmBreadcrumbImports } from '@spartan-ng/helm/breadcrumb';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { AppSidebar14 } from './sidebar-14/app-sidebar';
+
+@Component({
+	selector: 'spartan-sidebar-14-preview',
+	imports: [HlmSidebarImports, AppSidebar14, HlmBreadcrumbImports],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<main hlmSidebarInset class="flex flex-1 flex-col">
+				<header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+					<nav hlmBreadcrumb>
+						<ol hlmBreadcrumbList>
+							<li hlmBreadcrumbItem class="hidden md:block">
+								<a hlmBreadcrumbLink href="#">Build Your Application</a>
+							</li>
+							<li hlmBreadcrumbSeparator class="hidden md:block"></li>
+							<li hlmBreadcrumbItem>
+								<a hlmBreadcrumbPage>Data Fetching</a>
+							</li>
+						</ol>
+					</nav>
+					<button hlmSidebarTrigger class="-mr-1 ml-auto rotate-180"></button>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 p-4">
+					<div class="grid auto-rows-min gap-4 md:grid-cols-3">
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+						<div class="bg-muted/50 aspect-video rounded-xl"></div>
+					</div>
+					<div class="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min"></div>
+				</div>
+			</main>
+			<spartan-app-sidebar-14 />
+		</div>
+	`,
+})
+export default class Sidebar14Page {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-14/sidebar-14/app-sidebar.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-14/sidebar-14/app-sidebar.ts
@@ -1,0 +1,69 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { NavMainFlat } from '../../shared/sidebar/nav-main-flat';
+
+@Component({
+	selector: 'spartan-sidebar-14',
+	imports: [HlmSidebarImports, NavMainFlat],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<hlm-sidebar side="right">
+			<hlm-sidebar-content>
+				<spartan-nav-main-flat groupLabel="Table of Contents" [items]="flatNavItems" />
+			</hlm-sidebar-content>
+			<hlm-sidebar-rail />
+		</hlm-sidebar>
+	`,
+})
+export class AppSidebar14 {
+	public readonly flatNavItems = [
+		{
+			title: 'Getting Started',
+			url: '.',
+			items: [
+				{ title: 'Installation', url: '.' },
+				{ title: 'Project Structure', url: '.' },
+			],
+		},
+		{
+			title: 'Build Your Application',
+			url: '.',
+			items: [
+				{ title: 'Routing', url: '.' },
+				{ title: 'Data Fetching', url: '.', isActive: true },
+				{ title: 'Rendering', url: '.' },
+				{ title: 'Caching', url: '.' },
+				{ title: 'Styling', url: '.' },
+				{ title: 'Optimizing', url: '.' },
+				{ title: 'Configuring', url: '.' },
+				{ title: 'Testing', url: '.' },
+				{ title: 'Authentication', url: '.' },
+				{ title: 'Deploying', url: '.' },
+				{ title: 'Upgrading', url: '.' },
+				{ title: 'Examples', url: '.' },
+			],
+		},
+		{
+			title: 'API Reference',
+			url: '.',
+			items: [
+				{ title: 'Components', url: '.' },
+				{ title: 'File Conventions', url: '.' },
+				{ title: 'Functions', url: '.' },
+				{ title: 'next.config.js Options', url: '.' },
+				{ title: 'CLI', url: '.' },
+				{ title: 'Edge Runtime', url: '.' },
+			],
+		},
+		{
+			title: 'Community',
+			url: '.',
+			items: [{ title: 'Contribution Guide', url: '.' }],
+		},
+	];
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-15/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-15/index.page.ts
@@ -1,0 +1,46 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideHome, lucideInbox, lucideSearch, lucideSettings2 } from '@ng-icons/lucide';
+import { HlmBreadcrumbImports } from '@spartan-ng/helm/breadcrumb';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { SidebarLeft } from './sidebar-15/sidebar-left';
+import { SidebarRight } from './sidebar-15/sidebar-right';
+
+@Component({
+	selector: 'spartan-sidebar-15-preview',
+	imports: [HlmSidebarImports, HlmSeparatorImports, HlmBreadcrumbImports, SidebarLeft, SidebarRight, NgIcon],
+	providers: [provideIcons({ lucideSearch, lucideInbox, lucideHome, lucideSettings2 })],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div hlmSidebarWrapper>
+			<spartan-sidebar-left />
+			<main hlmSidebarInset>
+				<header class="bg-background sticky top-0 flex h-14 shrink-0 items-center gap-2">
+					<div class="flex flex-1 items-center gap-2 px-3">
+						<button hlmSidebarTrigger></button>
+						<hlm-separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
+						<nav hlmBreadcrumb>
+							<ol hlmBreadcrumbList>
+								<li hlmBreadcrumbItem>
+									<a hlmBreadcrumbPage class="line-clamp-1">Project Management & Task Tracking</a>
+								</li>
+							</ol>
+						</nav>
+					</div>
+				</header>
+				<div class="flex flex-1 flex-col gap-4 p-4">
+					<div class="bg-muted/50 mx-auto h-24 w-full max-w-3xl rounded-xl"></div>
+					<div class="bg-muted/50 mx-auto h-[100vh] w-full max-w-3xl rounded-xl"></div>
+				</div>
+			</main>
+			<spartan-sidebar-right />
+		</div>
+	`,
+})
+export default class Sidebar15Page {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-15/sidebar-15/sidebar-left.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-15/sidebar-15/sidebar-left.ts
@@ -1,0 +1,57 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideHome, lucideInbox, lucidePlus, lucideSearch, lucideSettings2 } from '@ng-icons/lucide';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { data } from '../../shared/sidebar/data';
+import { NavFavorites } from '../../shared/sidebar/nav-favorites';
+import { NavSecondary } from '../../shared/sidebar/nav-secondary';
+import { NavWorkspaces } from '../../shared/sidebar/nav-workspaces';
+import { TeamSwitcher } from '../../shared/sidebar/team-switcher';
+
+@Component({
+	selector: 'spartan-sidebar-left',
+	imports: [HlmSidebarImports, NgIcon, TeamSwitcher, NavFavorites, NavWorkspaces, NavSecondary],
+	providers: [provideIcons({ lucidePlus, lucideSearch, lucideInbox, lucideHome, lucideSettings2 })],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<hlm-sidebar class="border-r-0">
+			<hlm-sidebar-header>
+				<spartan-team-switcher [teams]="data.teams" />
+				<hlm-sidebar-group>
+					<div hlmSidebarGroupContent>
+						<ul hlmSidebarMenu>
+							@for (item of flatItems; track item.title) {
+								<li hlmSidebarMenuItem>
+									<button hlmSidebarMenuButton [isActive]="item.isActive">
+										<ng-icon [name]="item.icon" />
+										<span>{{ item.title }}</span>
+									</button>
+								</li>
+							}
+						</ul>
+					</div>
+				</hlm-sidebar-group>
+			</hlm-sidebar-header>
+			<hlm-sidebar-content>
+				<spartan-nav-favorites [favorites]="data.favorites" />
+				<spartan-nav-workspaces [workspaces]="data.workspaces" />
+				<spartan-nav-secondary [items]="data.navSecondary" class="mt-auto" />
+			</hlm-sidebar-content>
+			<hlm-sidebar-rail />
+		</hlm-sidebar>
+	`,
+})
+export class SidebarLeft {
+	public readonly data = data;
+	public readonly flatItems = [
+		{ title: 'Search', icon: 'lucideSearch', isActive: false },
+		{ title: 'Inbox', icon: 'lucideInbox', isActive: true },
+		{ title: 'Home', icon: 'lucideHome', isActive: false },
+		{ title: 'Settings', icon: 'lucideSettings2', isActive: false },
+	];
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-15/sidebar-15/sidebar-right.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/sidebar-15/sidebar-15/sidebar-right.ts
@@ -1,0 +1,45 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucidePlus } from '@ng-icons/lucide';
+import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
+import { Calendars } from '../../shared/sidebar/calendars';
+import { data } from '../../shared/sidebar/data';
+import { DatePicker } from '../../shared/sidebar/date-picker';
+import { NavUser } from '../../shared/sidebar/nav-user';
+
+@Component({
+	selector: 'spartan-sidebar-right',
+	imports: [HlmSidebarImports, NgIcon, Calendars, DatePicker, NavUser],
+	providers: [provideIcons({ lucidePlus })],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'block',
+	},
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<hlm-sidebar collapsible="none" class="sticky top-0 hidden h-svh border-l lg:flex">
+			<hlm-sidebar-header class="border-sidebar-border h-16 border-b">
+				<spartan-nav-user [user]="data.user" />
+			</hlm-sidebar-header>
+			<hlm-sidebar-content>
+				<spartan-date-picker />
+				<hlm-sidebar-separator class="mx-0" />
+				<spartan-calendars [calendars]="data.calendars" />
+			</hlm-sidebar-content>
+			<hlm-sidebar-footer>
+				<ul hlmSidebarMenu>
+					<li hlmSidebarMenuItem>
+						<button hlmSidebarMenuButton>
+							<ng-icon name="lucidePlus" />
+							<span>New Calendar</span>
+						</button>
+					</li>
+				</ul>
+			</hlm-sidebar-footer>
+		</hlm-sidebar>
+	`,
+})
+export class SidebarRight {
+	public readonly data = data;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] sidebar

### Others

- [x] repo

## What is the current behavior?

The blocks page only has 2 sidebar blocks (sticky-header and inset). shadcn/ui ships 14 sidebar block variants that showcase different sidebar patterns — the blocks page is missing most of them.

## What is the new behavior?

Added 13 new sidebar block variants ported from shadcn's React implementations to Angular:

- **sidebar-01**: Simple sidebar with version switcher and search form
- **sidebar-02**: Collapsible sidebar groups with chevron toggle
- **sidebar-03**: Branded header with flat navigation and sub-items
- **sidebar-04**: Floating variant sidebar
- **sidebar-05**: Collapsible groups with Plus/Minus icons and search
- **sidebar-06**: Dropdown menu navigation with newsletter opt-in form
- **sidebar-07**: Icon collapse mode with TeamSwitcher, nav, projects, and user dropdown
- **sidebar-09**: Dual sidebar layout (mail client with icon nav + mail list)
- **sidebar-10**: Notion-like workspace sidebar with favorites and workspaces
- **sidebar-11**: File tree sidebar with collapsible folders
- **sidebar-12**: Calendar sidebar with inline date picker and checkbox groups
- **sidebar-14**: Right-side table of contents (`side="right"`)
- **sidebar-15**: Dual sidebar (Notion workspace left + calendar right)

New shared components: `team-switcher`, `search-form`, `version-switcher`, `nav-favorites`, `nav-workspaces`, `nav-actions`, `calendars`, `date-picker`, `nav-main-flat`

All blocks use existing spartan helm sidebar primitives (`hlm-sidebar`, `hlm-sidebar-menu-*`, `hlm-sidebar-group-*`, etc.) — no changes to the underlying component library.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- TypeScript typecheck passes clean
- Lint passes with 0 errors (12 pre-existing warnings in unrelated files)
- Branch: `feat/sidebar-blocks`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added 15 new sidebar block preview examples showcasing various layout patterns and configurations
  * Introduced interactive sidebar components including team switcher, calendar integration, favorites navigation, and workspace management
  * Expanded documentation sidebar variants with collapsible groups, search functionality, and version selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->