### PR TITLE
Feat/charts blocks

### DIFF
--- a/apps/app/src/app/pages/(blocks)/blocks.page.ts
+++ b/apps/app/src/app/pages/(blocks)/blocks.page.ts
@@ -38,6 +38,7 @@ export const routeMeta: RouteMeta = {
 					class="bg-background dark:[&>a]:bg-background [&>a]:text-muted-foreground [&>a]:data-[state=active]:text-primary [&>a]:hover:text-primary dark:[&>a]:data-[state=active]:bg-background [&>a]:cursor-pointer [&>a]:data-[state=active]:shadow-none dark:[&>a]:data-[state=active]:border-none"
 				>
 					<a hlmTabsTrigger="sidebar" routerLink="/blocks/sidebar">Sidebar</a>
+					<a hlmTabsTrigger="charts" routerLink="/blocks/charts">Charts</a>
 					<a hlmTabsTrigger="login" routerLink="/blocks/login">Login</a>
 					<a hlmTabsTrigger="signup" routerLink="/blocks/signup">Signup</a>
 					<a hlmTabsTrigger="calendar" routerLink="/blocks/calendar">Calendar</a>

--- a/apps/app/src/app/pages/(blocks)/blocks/charts/(charts).page.ts
+++ b/apps/app/src/app/pages/(blocks)/blocks/charts/(charts).page.ts
@@ -114,7 +114,7 @@ export const routeMeta: RouteMeta = {
 
 		<spartan-block-viewer block="chart-bar-mixed" title="A mixed bar chart" id="chart-bar-7">
 			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
-				A mixed chart combining bar and line representations.
+				A horizontal bar chart with individual bar colors for each browser.
 			</p>
 		</spartan-block-viewer>
 

--- a/apps/app/src/app/pages/(blocks)/blocks/charts/(charts).page.ts
+++ b/apps/app/src/app/pages/(blocks)/blocks/charts/(charts).page.ts
@@ -1,0 +1,429 @@
+import type { RouteMeta } from '@analogjs/router';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { BlockViewer } from '@spartan-ng/app/app/shared/blocks/block-viewer';
+import { metaWith } from '@spartan-ng/app/app/shared/meta/meta.util';
+
+export const routeMeta: RouteMeta = {
+	meta: metaWith('spartan/blocks - Charts', 'Chart blocks using spartan/ui primitives'),
+	title: 'spartan/blocks - Charts',
+};
+
+@Component({
+	selector: 'spartan-charts',
+	imports: [BlockViewer],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'flex flex-col',
+	},
+	template: `
+		<!-- Area Charts -->
+		<spartan-block-viewer block="chart-area-default" title="A simple area chart" id="chart-area-1">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				An area chart with gradient fill showing total visitors for the last 6 months.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-area-gradient" title="An area chart with gradient fill" id="chart-area-2">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				An area chart with gradient fill showing total visitors for the last 6 months.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-area-stacked" title="A stacked area chart" id="chart-area-3">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A stacked area chart showing desktop, mobile, and other visitors for the last 6 months.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-area-stacked-expand" title="A stacked area chart with expand" id="chart-area-4">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A stacked area chart with an expand animation showing desktop, mobile, and other visitors.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-area-axes" title="An area chart with axes" id="chart-area-5">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				An area chart with axes labels showing total visitors for the last 6 months.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-area-icons" title="An area chart with icons" id="chart-area-6">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				An area chart with icons in the legend showing total visitors for the last 6 months.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-area-legend" title="An area chart with a legend" id="chart-area-7">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				An area chart with a custom legend showing desktop and mobile visitors.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-area-linear" title="An area chart with linear scale" id="chart-area-8">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				An area chart using a linear scale for the x-axis.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-area-step" title="An area chart with step" id="chart-area-9">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				An area chart with step interpolation showing total visitors for the last 6 months.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-area-interactive" title="An interactive area chart" id="chart-area-10">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				An interactive area chart with a tooltip showing visitors over the last 90 days.
+			</p>
+		</spartan-block-viewer>
+
+		<!-- Bar Charts -->
+		<spartan-block-viewer block="chart-bar-default" title="A simple bar chart" id="chart-bar-1">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A bar chart showing total visitors for the last 6 months.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-bar-horizontal" title="A horizontal bar chart" id="chart-bar-2">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A horizontal bar chart showing total visitors for the last 6 months.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-bar-multiple" title="A bar chart with multiple series" id="chart-bar-3">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A bar chart showing desktop and mobile visitors for the last 6 months.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-bar-stacked" title="A stacked bar chart" id="chart-bar-4">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A stacked bar chart showing desktop, mobile, and other visitors.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-bar-label" title="A bar chart with labels" id="chart-bar-5">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A bar chart with data labels on each bar.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-bar-label-custom" title="A bar chart with custom labels" id="chart-bar-6">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A bar chart with custom formatted labels on each bar.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-bar-mixed" title="A mixed bar chart" id="chart-bar-7">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A mixed chart combining bar and line representations.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-bar-negative" title="A bar chart with negative values" id="chart-bar-8">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A bar chart showing both positive and negative values.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-bar-active" title="A bar chart with active bar" id="chart-bar-9">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A bar chart with an active/highlighted bar.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-bar-interactive" title="An interactive bar chart" id="chart-bar-10">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				An interactive bar chart with a tooltip showing visitors over the last 90 days.
+			</p>
+		</spartan-block-viewer>
+
+		<!-- Line Charts -->
+		<spartan-block-viewer block="chart-line-default" title="A simple line chart" id="chart-line-1">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A line chart showing total visitors for the last 6 months.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-line-dots" title="A line chart with dots" id="chart-line-2">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A line chart with circular data points showing total visitors.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-line-dots-colors" title="A line chart with colored dots" id="chart-line-3">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A line chart with different colored dots for each data point.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-line-dots-custom" title="A line chart with custom dots" id="chart-line-4">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A line chart with custom-sized dots for each data point.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-line-linear" title="A line chart with linear scale" id="chart-line-5">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A line chart using a linear scale for the x-axis.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-line-multiple" title="A line chart with multiple series" id="chart-line-6">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A line chart showing desktop and mobile visitors for the last 6 months.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-line-step" title="A line chart with step" id="chart-line-7">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A line chart with step interpolation showing total visitors.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-line-label" title="A line chart with labels" id="chart-line-8">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A line chart with data labels on each point.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-line-label-custom" title="A line chart with custom labels" id="chart-line-9">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A line chart with custom formatted labels on each point.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-line-interactive" title="An interactive line chart" id="chart-line-10">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				An interactive line chart with a tooltip showing visitors over the last 90 days.
+			</p>
+		</spartan-block-viewer>
+
+		<!-- Pie Charts -->
+		<spartan-block-viewer block="chart-pie-simple" title="A simple pie chart" id="chart-pie-1">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A pie chart showing browser usage distribution.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-pie-donut" title="A donut chart" id="chart-pie-2">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A donut chart showing browser usage distribution.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-pie-donut-text" title="A donut chart with text" id="chart-pie-3">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A donut chart with centered text showing the total count.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-pie-donut-active" title="A donut chart with active segment" id="chart-pie-4">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A donut chart with an active/highlighted segment.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-pie-label" title="A pie chart with labels" id="chart-pie-5">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A pie chart with external labels for each segment.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-pie-label-custom" title="A pie chart with custom labels" id="chart-pie-6">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A pie chart with custom formatted labels for each segment.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-pie-label-list" title="A pie chart with label list" id="chart-pie-7">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A pie chart with a list-style label layout.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-pie-legend" title="A pie chart with a legend" id="chart-pie-8">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A pie chart with a custom legend component.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-pie-separator-none" title="A pie chart without separator" id="chart-pie-9">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A pie chart with no separator lines between segments.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-pie-stacked" title="A stacked pie chart" id="chart-pie-10">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A stacked/nested pie chart showing multiple data layers.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-pie-interactive" title="An interactive pie chart" id="chart-pie-11">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				An interactive pie chart with hover effects and tooltips.
+			</p>
+		</spartan-block-viewer>
+
+		<!-- Radar Charts -->
+		<spartan-block-viewer block="chart-radar-default" title="A simple radar chart" id="chart-radar-1">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A radar chart showing desktop and mobile visitors by month.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radar-dots" title="A radar chart with dots" id="chart-radar-2">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A radar chart with circular data points.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radar-grid-circle" title="A radar chart with circular grid" id="chart-radar-3">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A radar chart with circular grid lines.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer
+			block="chart-radar-grid-circle-fill"
+			title="A radar chart with filled circular grid"
+			id="chart-radar-4"
+		>
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A radar chart with filled circular grid background.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer
+			block="chart-radar-grid-circle-no-lines"
+			title="A radar chart without grid lines"
+			id="chart-radar-5"
+		>
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A radar chart with circular grid but no radial lines.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radar-grid-custom" title="A radar chart with custom grid" id="chart-radar-6">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A radar chart with a custom grid configuration.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radar-grid-fill" title="A radar chart with filled grid" id="chart-radar-7">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A radar chart with a filled grid background.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radar-grid-none" title="A radar chart without grid" id="chart-radar-8">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A radar chart with no grid lines.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radar-icons" title="A radar chart with icons" id="chart-radar-9">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A radar chart with icons in the legend.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radar-label-custom" title="A radar chart with custom labels" id="chart-radar-10">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A radar chart with custom formatted axis labels.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radar-legend" title="A radar chart with a legend" id="chart-radar-11">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A radar chart with a custom legend component.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radar-lines-only" title="A radar chart with lines only" id="chart-radar-12">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A radar chart showing only the lines without fill.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radar-multiple" title="A radar chart with multiple series" id="chart-radar-13">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A radar chart showing multiple data series.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radar-radius" title="A radar chart with radius axis" id="chart-radar-14">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A radar chart with a radius axis for scale reference.
+			</p>
+		</spartan-block-viewer>
+
+		<!-- Radial Charts -->
+		<spartan-block-viewer block="chart-radial-simple" title="A simple radial chart" id="chart-radial-1">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A radial bar chart showing browser usage distribution.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radial-grid" title="A radial chart with grid" id="chart-radial-2">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A radial bar chart with grid lines for scale reference.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radial-label" title="A radial chart with labels" id="chart-radial-3">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A radial bar chart with labels showing the value.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radial-shape" title="A radial chart with custom shape" id="chart-radial-4">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A radial bar chart with a custom shape configuration.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radial-stacked" title="A stacked radial chart" id="chart-radial-5">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A stacked radial bar chart showing multiple data layers.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-radial-text" title="A radial chart with text" id="chart-radial-6">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A radial bar chart with centered text showing the total count.
+			</p>
+		</spartan-block-viewer>
+
+		<!-- Tooltip Charts -->
+		<spartan-block-viewer block="chart-tooltip-default" title="A chart with default tooltip" id="chart-tooltip-1">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A chart with the default tooltip configuration.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-tooltip-advanced" title="A chart with advanced tooltip" id="chart-tooltip-2">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A chart with an advanced tooltip showing additional information.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-tooltip-formatter" title="A chart with formatted tooltip" id="chart-tooltip-3">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A chart with a tooltip using a custom formatter function.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-tooltip-icons" title="A chart with icons in tooltip" id="chart-tooltip-4">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A chart with icons displayed in the tooltip.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-tooltip-indicator-line" title="A chart with indicator line" id="chart-tooltip-5">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A chart with a vertical indicator line following the cursor.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer block="chart-tooltip-indicator-none" title="A chart without indicator" id="chart-tooltip-6">
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A chart with no indicator line in the tooltip.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer
+			block="chart-tooltip-label-custom"
+			title="A chart with custom label tooltip"
+			id="chart-tooltip-7"
+		>
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A chart with a tooltip using custom labels.</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer
+			block="chart-tooltip-label-formatter"
+			title="A chart with formatted label tooltip"
+			id="chart-tooltip-8"
+		>
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">
+				A chart with a tooltip using a custom label formatter.
+			</p>
+		</spartan-block-viewer>
+
+		<spartan-block-viewer
+			block="chart-tooltip-label-none"
+			title="A chart without label in tooltip"
+			id="chart-tooltip-9"
+		>
+			<p class="text-muted-foreground max-w-3xl text-sm text-pretty">A chart with a tooltip that hides the label.</p>
+		</spartan-block-viewer>
+	`,
+})
+export default class ChartsPage {}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-axes/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-axes/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-area-axes',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-axes/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-axes/index.page.ts
@@ -1,0 +1,78 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-area-axes',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Area Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Desktop</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Mobile</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartAreaAxesComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsla(173, 58%, 39%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { color: 'hsl(240, 5.9%, 90%)' }, ticks: { color: 'hsl(240, 3.8%, 46.1%)' } },
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-axes/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-axes/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-area-axes',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-axes/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-axes/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartAreaAxesComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-default/index.page.ts
@@ -1,0 +1,65 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-area-default',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Area Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartAreaDefaultComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { display: false },
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-default/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-area-default',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-default/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-area-default',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-default/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartAreaDefaultComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-gradient/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-gradient/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-area-gradient',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-gradient/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-gradient/index.page.ts
@@ -1,0 +1,86 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-area-gradient',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Area Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Desktop</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Mobile</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartAreaGradientComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		const ctx = canvas.getContext('2d');
+		const gradientDesktop = ctx?.createLinearGradient(0, 0, 0, 400);
+		gradientDesktop?.addColorStop(0, 'hsla(12, 76%, 61%, 0.4)');
+		gradientDesktop?.addColorStop(1, 'hsla(12, 76%, 61%, 0.05)');
+		const gradientMobile = ctx?.createLinearGradient(0, 0, 0, 400);
+		gradientMobile?.addColorStop(0, 'hsla(173, 58%, 39%, 0.4)');
+		gradientMobile?.addColorStop(1, 'hsla(173, 58%, 39%, 0.05)');
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: gradientDesktop ?? 'hsla(12, 76%, 61%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: gradientMobile ?? 'hsla(173, 58%, 39%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { display: false },
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-gradient/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-gradient/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-area-gradient',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-gradient/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-gradient/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartAreaGradientComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-icons/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-area-icons',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-icons/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartAreaIconsComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-icons/index.page.ts
@@ -1,0 +1,90 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-area-icons',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Area Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Desktop</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Mobile</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartAreaIconsComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsla(173, 58%, 39%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: {
+						display: true,
+						position: 'bottom',
+						labels: {
+							usePointStyle: true,
+							pointStyle: 'circle',
+							boxHeight: 8,
+							boxWidth: 8,
+							padding: 16,
+						},
+					},
+				},
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { display: false },
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-icons/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-area-icons',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-interactive/index.page.ts
@@ -1,0 +1,86 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+import { INTERACTIVE_CHART_DATA } from '../shared/chart/chart-data';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-area-interactive',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Area Chart - Interactive</h3>
+			<p class="text-muted-foreground text-sm">Showing daily visitors for the last 90 days</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Desktop</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Mobile</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartAreaInteractiveComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		const labels = INTERACTIVE_CHART_DATA.map((d) => {
+			const date = new Date(d.date);
+			return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+		});
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels,
+				datasets: [
+					{
+						label: 'Desktop',
+						data: INTERACTIVE_CHART_DATA.map((d) => d.desktop),
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+					{
+						label: 'Mobile',
+						data: INTERACTIVE_CHART_DATA.map((d) => d.mobile),
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsla(173, 58%, 39%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: {
+						grid: { display: false },
+						ticks: { maxRotation: 0, maxTicksLimit: 10 },
+					},
+					y: { display: false },
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-interactive/index.page.ts
@@ -30,7 +30,7 @@ Chart.register(...registerables);
 })
 export default class ChartAreaInteractiveComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-interactive/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 import { INTERACTIVE_CHART_DATA } from '../shared/chart/chart-data';
 
 @Component({

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-interactive/index.page.ts
@@ -1,7 +1,6 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
+import { Chart } from 'chart.js';
 import { INTERACTIVE_CHART_DATA } from '../shared/chart/chart-data';
-Chart.register(...registerables);
 
 @Component({
 	selector: 'spartan-chart-area-interactive',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-legend/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-legend/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartAreaLegendComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-legend/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-legend/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-area-legend',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-legend/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-legend/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-area-legend',
@@ -63,16 +62,7 @@ export default class ChartAreaLegendComponent implements AfterViewInit, OnDestro
 				responsive: true,
 				maintainAspectRatio: true,
 				plugins: {
-					legend: {
-						display: true,
-						position: 'bottom',
-						labels: {
-							usePointStyle: true,
-							boxHeight: 8,
-							boxWidth: 8,
-							padding: 16,
-						},
-					},
+					legend: { display: false },
 				},
 				scales: {
 					x: { grid: { display: false }, ticks: { maxRotation: 0 } },

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-legend/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-legend/index.page.ts
@@ -1,0 +1,89 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-area-legend',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Area Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Desktop</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Mobile</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartAreaLegendComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsla(173, 58%, 39%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: {
+						display: true,
+						position: 'bottom',
+						labels: {
+							usePointStyle: true,
+							boxHeight: 8,
+							boxWidth: 8,
+							padding: 16,
+						},
+					},
+				},
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { display: false },
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-linear/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-linear/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-area-linear',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-linear/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-linear/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-area-linear',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-linear/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-linear/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartAreaLinearComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-linear/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-linear/index.page.ts
@@ -1,0 +1,65 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-area-linear',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Area Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartAreaLinearComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.4)',
+						fill: true,
+						tension: 0,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { display: false },
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked-expand/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked-expand/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-area-stacked-expand',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked-expand/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked-expand/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-area-stacked-expand',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked-expand/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked-expand/index.page.ts
@@ -33,7 +33,7 @@ Chart.register(...registerables);
 })
 export default class ChartAreaStackedExpandComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked-expand/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked-expand/index.page.ts
@@ -1,0 +1,91 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-area-stacked-expand',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Area Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Desktop</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Mobile</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(197, 37%, 24%)"></span>
+				<span class="text-muted-foreground">Other</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartAreaStackedExpandComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsla(173, 58%, 39%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+					{
+						label: 'Other',
+						data: [45, 100, 150, 50, 100, 160],
+						borderColor: 'hsl(197, 37%, 24%)',
+						backgroundColor: 'hsla(197, 37%, 24%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { stacked: true, grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { stacked: true, display: false },
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked/index.page.ts
@@ -1,0 +1,78 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-area-stacked',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Area Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Desktop</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Mobile</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartAreaStackedComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsla(173, 58%, 39%, 0.4)',
+						fill: true,
+						tension: 0.4,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { display: false },
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-area-stacked',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartAreaStackedComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-stacked/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-area-stacked',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-step/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-step/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-area-step',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-step/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-step/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartAreaStepComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-step/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-step/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-area-step',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-step/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-area-step/index.page.ts
@@ -1,0 +1,65 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-area-step',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Area Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartAreaStepComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.4)',
+						fill: true,
+						stepped: 'before',
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { display: false },
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-active/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-active/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 const activeBarPlugin = {
 	id: 'activeBar',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-active/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-active/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 const activeBarPlugin = {
 	id: 'activeBar',
@@ -15,11 +14,20 @@ const activeBarPlugin = {
 		ctx.lineWidth = 2;
 		ctx.setLineDash([4, 4]);
 		const { x, y, width, base } = element;
-		const barX = x - width / 2 - 4;
-		const barY = Math.min(y, base);
-		const barW = width + 8;
-		const barH = Math.abs(base - y) + 8;
-		ctx.strokeRect(barX, barY - 4, barW, barH);
+		const isHorizontal = (chart.config.options as any)?.indexAxis === 'y';
+		if (isHorizontal) {
+			const left = Math.min(base, x) - 4;
+			const top = y - width / 2 - 4;
+			const barW = Math.abs(x - base) + 8;
+			const barH = width + 8;
+			ctx.strokeRect(left, top, barW, barH);
+		} else {
+			const barX = x - width / 2 - 4;
+			const barY = Math.min(y, base);
+			const barW = width + 8;
+			const barH = Math.abs(base - y) + 8;
+			ctx.strokeRect(barX, barY - 4, barW, barH);
+		}
 		ctx.restore();
 	},
 };

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-active/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-active/index.page.ts
@@ -41,7 +41,7 @@ const activeBarPlugin = {
 })
 export default class ChartBarActiveComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-active/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-active/index.page.ts
@@ -1,0 +1,88 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+const activeBarPlugin = {
+	id: 'activeBar',
+	afterDatasetsDraw(chart: Chart) {
+		const { ctx } = chart;
+		const meta = chart.getDatasetMeta(0);
+		const activeIndex = 2;
+		const element = meta.data[activeIndex] as any;
+		if (!element) return;
+		ctx.save();
+		ctx.strokeStyle = 'hsl(12, 76%, 61%)';
+		ctx.lineWidth = 2;
+		ctx.setLineDash([4, 4]);
+		const { x, y, width, base } = element;
+		const barX = x - width / 2 - 4;
+		const barY = Math.min(y, base);
+		const barW = width + 8;
+		const barH = Math.abs(base - y) + 8;
+		ctx.strokeRect(barX, barY - 4, barW, barH);
+		ctx.restore();
+	},
+};
+
+@Component({
+	selector: 'spartan-chart-bar-active',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Bar Chart - Active</h3>
+			<p class="text-muted-foreground text-sm">Showing visitors by browser</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartBarActiveComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		const bgColors = [
+			'hsl(12, 76%, 61%)',
+			'hsl(12, 76%, 61%)',
+			'hsl(173, 58%, 39%)',
+			'hsl(12, 76%, 61%)',
+			'hsl(12, 76%, 61%)',
+		];
+
+		this._chartInstance = new Chart(canvas, {
+			plugins: [activeBarPlugin],
+			type: 'bar',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						label: 'Visitors',
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: bgColors,
+						borderRadius: 5,
+					},
+				],
+			},
+			options: {
+				indexAxis: 'y',
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, border: { display: false } },
+					y: { grid: { display: false }, border: { display: false } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-default/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-bar-default',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-default/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-bar-default',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-default/index.page.ts
@@ -1,0 +1,61 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-bar-default',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Bar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartBarDefaultComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						borderRadius: 8,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, border: { display: false } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-default/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartBarDefaultComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-horizontal/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-horizontal/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-bar-horizontal',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-horizontal/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-horizontal/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-bar-horizontal',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-horizontal/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-horizontal/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartBarHorizontalComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-horizontal/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-horizontal/index.page.ts
@@ -1,0 +1,62 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-bar-horizontal',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Horizontal Bar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartBarHorizontalComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						borderRadius: 5,
+					},
+				],
+			},
+			options: {
+				indexAxis: 'y',
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, border: { display: false } },
+					y: { grid: { display: false }, border: { display: false } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-interactive/index.page.ts
@@ -1,0 +1,104 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+import { INTERACTIVE_CHART_DATA } from '../shared/chart/chart-data';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-bar-interactive',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Interactive Bar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 90 days</p>
+		</div>
+		<div class="mt-4 flex gap-2">
+			<button
+				class="inline-flex h-8 items-center justify-center rounded-md px-3 text-sm font-medium transition-colors"
+				[class]="
+					_activeTab === 'desktop'
+						? 'bg-primary text-primary-foreground'
+						: 'bg-muted text-muted-foreground hover:bg-muted/80'
+				"
+				(click)="switchTab('desktop')"
+			>
+				Desktop
+			</button>
+			<button
+				class="inline-flex h-8 items-center justify-center rounded-md px-3 text-sm font-medium transition-colors"
+				[class]="
+					_activeTab === 'mobile'
+						? 'bg-primary text-primary-foreground'
+						: 'bg-muted text-muted-foreground hover:bg-muted/80'
+				"
+				(click)="switchTab('mobile')"
+			>
+				Mobile
+			</button>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartBarInteractiveComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+	protected _activeTab: 'desktop' | 'mobile' = 'desktop';
+
+	ngAfterViewInit(): void {
+		this.renderChart();
+	}
+
+	switchTab(tab: 'desktop' | 'mobile'): void {
+		this._activeTab = tab;
+		this.renderChart();
+	}
+
+	private renderChart(): void {
+		if (this._chartInstance) {
+			this._chartInstance.destroy();
+		}
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		const labels = INTERACTIVE_CHART_DATA.map((d) => {
+			const date = new Date(d.date);
+			return `${date.getMonth() + 1}/${date.getDate()}`;
+		});
+		const data = INTERACTIVE_CHART_DATA.map((d) => (this._activeTab === 'desktop' ? d.desktop : d.mobile));
+		const color = this._activeTab === 'desktop' ? 'hsl(12, 76%, 61%)' : 'hsl(173, 58%, 39%)';
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels,
+				datasets: [
+					{
+						label: this._activeTab === 'desktop' ? 'Desktop' : 'Mobile',
+						data,
+						backgroundColor: color,
+						borderRadius: 2,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: {
+						grid: { display: false },
+						ticks: { maxRotation: 0, autoSkip: true, maxTicksLimit: 15, font: { size: 10 } },
+					},
+					y: { grid: { display: false }, border: { display: false } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-interactive/index.page.ts
@@ -1,7 +1,6 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
+import { Chart } from 'chart.js';
 import { INTERACTIVE_CHART_DATA } from '../shared/chart/chart-data';
-Chart.register(...registerables);
 
 @Component({
 	selector: 'spartan-chart-bar-interactive',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-interactive/index.page.ts
@@ -44,7 +44,7 @@ Chart.register(...registerables);
 })
 export default class ChartBarInteractiveComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 	protected _activeTab: 'desktop' | 'mobile' = 'desktop';
 
 	ngAfterViewInit(): void {

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-interactive/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 import { INTERACTIVE_CHART_DATA } from '../shared/chart/chart-data';
 
 @Component({
@@ -63,8 +63,8 @@ export default class ChartBarInteractiveComponent implements AfterViewInit, OnDe
 		if (!canvas) return;
 
 		const labels = INTERACTIVE_CHART_DATA.map((d) => {
-			const date = new Date(d.date);
-			return `${date.getMonth() + 1}/${date.getDate()}`;
+			const [, month, day] = d.date.split('-').map(Number);
+			return `${month}/${day}`;
 		});
 		const data = INTERACTIVE_CHART_DATA.map((d) => (this._activeTab === 'desktop' ? d.desktop : d.mobile));
 		const color = this._activeTab === 'desktop' ? 'hsl(12, 76%, 61%)' : 'hsl(173, 58%, 39%)';

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label-custom/index.page.ts
@@ -1,0 +1,93 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+const insideLabelsPlugin = {
+	id: 'insideLabels',
+	afterDatasetsDraw(chart: Chart) {
+		const { ctx } = chart;
+		chart.data.datasets.forEach((dataset, i) => {
+			const meta = chart.getDatasetMeta(i);
+			meta.data.forEach((element, index) => {
+				const value = dataset.data[index] as number;
+				const barWidth = (element as any).width;
+				const text = String(value);
+				ctx.save();
+				ctx.font = '12px sans-serif';
+				ctx.textAlign = 'center';
+				ctx.textBaseline = 'middle';
+				ctx.fillStyle = '#fff';
+				if (barWidth > 40) {
+					ctx.fillText(text, (element as any).x - barWidth / 2 + 16, (element as any).y);
+				}
+				ctx.restore();
+			});
+		});
+	},
+};
+
+@Component({
+	selector: 'spartan-chart-bar-label-custom',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Bar Chart - Custom Label</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartBarLabelCustomComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			plugins: [insideLabelsPlugin],
+			type: 'bar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						borderRadius: 4,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						backgroundColor: 'hsl(173, 58%, 39%)',
+						borderRadius: 4,
+					},
+				],
+			},
+			options: {
+				indexAxis: 'y',
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: true, position: 'bottom' } },
+				scales: {
+					x: { grid: { display: false }, border: { display: false } },
+					y: { grid: { display: false }, border: { display: false } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label-custom/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 const insideLabelsPlugin = {
 	id: 'insideLabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label-custom/index.page.ts
@@ -49,7 +49,7 @@ const insideLabelsPlugin = {
 })
 export default class ChartBarLabelCustomComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label-custom/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 const insideLabelsPlugin = {
 	id: 'insideLabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label/index.page.ts
@@ -1,0 +1,82 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+const datalabelsPlugin = {
+	id: 'datalabels',
+	afterDatasetsDraw(chart: Chart) {
+		const { ctx } = chart;
+		chart.data.datasets.forEach((dataset, i) => {
+			const meta = chart.getDatasetMeta(i);
+			meta.data.forEach((element, index) => {
+				const value = dataset.data[index];
+				ctx.save();
+				ctx.font = '12px sans-serif';
+				ctx.textAlign = 'center';
+				ctx.textBaseline = 'bottom';
+				ctx.fillStyle = 'hsl(12, 76%, 61%)';
+				ctx.fillText(String(value), (element as any).x, (element as any).y);
+				ctx.restore();
+			});
+		});
+	},
+};
+
+@Component({
+	selector: 'spartan-chart-bar-label',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Bar Chart - Label</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartBarLabelComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			plugins: [datalabelsPlugin],
+			type: 'bar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						borderRadius: 8,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, border: { display: false } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 const datalabelsPlugin = {
 	id: 'datalabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 const datalabelsPlugin = {
 	id: 'datalabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-label/index.page.ts
@@ -45,7 +45,7 @@ const datalabelsPlugin = {
 })
 export default class ChartBarLabelComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-mixed/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-mixed/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-bar-mixed',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-mixed/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-mixed/index.page.ts
@@ -1,0 +1,62 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-bar-mixed',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Bar Chart - Mixed Colors</h3>
+			<p class="text-muted-foreground text-sm">Showing visitors by browser</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartBarMixedComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						label: 'Visitors',
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderRadius: 5,
+					},
+				],
+			},
+			options: {
+				indexAxis: 'y',
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, border: { display: false } },
+					y: { grid: { display: false }, border: { display: false } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-mixed/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-mixed/index.page.ts
@@ -19,7 +19,7 @@ Chart.register(...registerables);
 })
 export default class ChartBarMixedComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-mixed/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-mixed/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-bar-mixed',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-multiple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-multiple/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-bar-multiple',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-multiple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-multiple/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartBarMultipleComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-multiple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-multiple/index.page.ts
@@ -1,0 +1,67 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-bar-multiple',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Bar Chart - Multiple</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartBarMultipleComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						borderRadius: 4,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						backgroundColor: 'hsl(173, 58%, 39%)',
+						borderRadius: 4,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: true, position: 'bottom' } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, border: { display: false } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-multiple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-multiple/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-bar-multiple',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-negative/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-negative/index.page.ts
@@ -1,0 +1,65 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-bar-negative',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Bar Chart - Negative</h3>
+			<p class="text-muted-foreground text-sm">Showing profit/loss for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Net positive this quarter</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartBarNegativeComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		const values = [186, 205, -207, 173, -209, 214];
+		const colors = values.map((v) => (v >= 0 ? 'hsl(173, 58%, 39%)' : 'hsl(12, 76%, 61%)'));
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Profit/Loss',
+						data: values,
+						backgroundColor: colors,
+						borderRadius: 4,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, border: { display: false } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-negative/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-negative/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartBarNegativeComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-negative/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-negative/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-bar-negative',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-negative/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-negative/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-bar-negative',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-stacked/index.page.ts
@@ -1,0 +1,69 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-bar-stacked',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Bar Chart - Stacked</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartBarStackedComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						borderRadius: 4,
+						stack: 'a',
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						backgroundColor: 'hsl(173, 58%, 39%)',
+						borderRadius: 4,
+						stack: 'a',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: true, position: 'bottom' } },
+				scales: {
+					x: { stacked: true, grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { stacked: true, grid: { display: false }, border: { display: false } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-stacked/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-bar-stacked',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-stacked/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-bar-stacked',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-bar-stacked/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartBarStackedComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-default/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-line-default',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-default/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-line-default',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-default/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartLineDefaultComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-default/index.page.ts
@@ -1,0 +1,63 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-line-default',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Line Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartLineDefaultComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						tension: 0.4,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, ticks: { maxRotation: 0 } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-colors/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-colors/index.page.ts
@@ -41,7 +41,7 @@ Chart.register(...registerables);
 })
 export default class ChartLineDotsColorsComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-colors/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-colors/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-line-dots-colors',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-colors/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-colors/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-line-dots-colors',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-colors/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-colors/index.page.ts
@@ -1,0 +1,89 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-line-dots-colors',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Line Chart with Colored Dots</h3>
+			<p class="text-muted-foreground text-sm">Browser usage by category</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex flex-wrap items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(12, 76%, 61%)"></span>
+				<span>Chrome</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(173, 58%, 39%)"></span>
+				<span>Safari</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(197, 37%, 24%)"></span>
+				<span>Firefox</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(43, 74%, 66%)"></span>
+				<span>Edge</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(27, 87%, 67%)"></span>
+				<span>Other</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartLineDotsColorsComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		const colors = [
+			'hsl(12, 76%, 61%)',
+			'hsl(173, 58%, 39%)',
+			'hsl(197, 37%, 24%)',
+			'hsl(43, 74%, 66%)',
+			'hsl(27, 87%, 67%)',
+		];
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						label: 'Visitors',
+						data: [275, 200, 187, 173, 90],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						pointBackgroundColor: colors,
+						pointBorderColor: colors,
+						pointRadius: 5,
+						pointHoverRadius: 7,
+						tension: 0.4,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, ticks: { maxRotation: 0 } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-custom/index.page.ts
@@ -1,0 +1,79 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-line-dots-custom',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Line Chart with Custom Dots</h3>
+			<p class="text-muted-foreground text-sm">Showing desktop and mobile visitors</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(12, 76%, 61%)"></span>
+				<span>Desktop</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(173, 58%, 39%)"></span>
+				<span>Mobile</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartLineDotsCustomComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						pointStyle: 'rect',
+						pointRadius: 6,
+						pointHoverRadius: 8,
+						tension: 0.4,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsl(173, 58%, 39%)',
+						pointStyle: 'triangle',
+						pointRadius: 6,
+						pointHoverRadius: 8,
+						tension: 0.4,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, ticks: { maxRotation: 0 } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-custom/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-line-dots-custom',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-custom/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-line-dots-custom',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots-custom/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartLineDotsCustomComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-line-dots',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-line-dots',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots/index.page.ts
@@ -1,0 +1,77 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-line-dots',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Line Chart with Dots</h3>
+			<p class="text-muted-foreground text-sm">Showing desktop and mobile visitors</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(12, 76%, 61%)"></span>
+				<span>Desktop</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(173, 58%, 39%)"></span>
+				<span>Mobile</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartLineDotsComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						pointRadius: 4,
+						pointHoverRadius: 6,
+						tension: 0.4,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsl(173, 58%, 39%)',
+						pointRadius: 4,
+						pointHoverRadius: 6,
+						tension: 0.4,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, ticks: { maxRotation: 0 } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-dots/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartLineDotsComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-interactive/index.page.ts
@@ -1,0 +1,156 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-line-interactive',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Interactive Line Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing desktop and mobile visitors for 90 days</p>
+		</div>
+		<div class="mt-4 flex gap-2">
+			<button
+				class="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors"
+				[class]="
+					_activeTab === 'desktop'
+						? 'bg-primary text-primary-foreground shadow'
+						: 'text-muted-foreground hover:bg-accent hover:text-accent-foreground bg-transparent'
+				"
+				(click)="switchTab('desktop')"
+			>
+				Desktop
+			</button>
+			<button
+				class="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors"
+				[class]="
+					_activeTab === 'mobile'
+						? 'bg-primary text-primary-foreground shadow'
+						: 'text-muted-foreground hover:bg-accent hover:text-accent-foreground bg-transparent'
+				"
+				(click)="switchTab('mobile')"
+			>
+				Mobile
+			</button>
+			<button
+				class="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors"
+				[class]="
+					_activeTab === 'all'
+						? 'bg-primary text-primary-foreground shadow'
+						: 'text-muted-foreground hover:bg-accent hover:text-accent-foreground bg-transparent'
+				"
+				(click)="switchTab('all')"
+			>
+				All
+			</button>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(12, 76%, 61%)"></span>
+				<span>Desktop</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(173, 58%, 39%)"></span>
+				<span>Mobile</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartLineInteractiveComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+	protected _activeTab: 'desktop' | 'mobile' | 'all' = 'all';
+
+	private readonly _dates = this.generateDates();
+	private readonly _desktopData = this.generateData(90, 50, 400);
+	private readonly _mobileData = this.generateData(90, 50, 400);
+
+	private generateDates(): string[] {
+		const dates: string[] = [];
+		const start = new Date(2024, 3, 1);
+		for (let i = 0; i < 90; i++) {
+			const d = new Date(start);
+			d.setDate(d.getDate() + i);
+			dates.push(d.toISOString().slice(0, 10));
+		}
+		return dates;
+	}
+
+	private generateData(count: number, min: number, max: number): number[] {
+		const data: number[] = [];
+		let prev = min + Math.random() * (max - min);
+		for (let i = 0; i < count; i++) {
+			prev = prev + (Math.random() - 0.5) * 60;
+			prev = Math.max(min, Math.min(max, prev));
+			data.push(Math.round(prev));
+		}
+		return data;
+	}
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: this.dates,
+				datasets: [
+					{
+						label: 'Desktop',
+						data: this.desktopData,
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						tension: 0.4,
+						pointRadius: 0,
+					},
+					{
+						label: 'Mobile',
+						data: this.mobileData,
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsl(173, 58%, 39%)',
+						tension: 0.4,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0, maxTicksLimit: 12 } },
+					y: { grid: { display: false }, ticks: { maxRotation: 0 } },
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	switchTab(tab: 'desktop' | 'mobile' | 'all'): void {
+		this._activeTab = tab;
+		if (!this._chartInstance) return;
+		const ds0 = this._chartInstance.data.datasets[0];
+		const ds1 = this._chartInstance.data.datasets[1];
+		if (tab === 'desktop') {
+			ds0.hidden = false;
+			ds1.hidden = true;
+		} else if (tab === 'mobile') {
+			ds0.hidden = true;
+			ds1.hidden = false;
+		} else {
+			ds0.hidden = false;
+			ds1.hidden = false;
+		}
+		this._chartInstance.update();
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-interactive/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-line-interactive',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-interactive/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-line-interactive',
@@ -72,10 +72,9 @@ export default class ChartLineInteractiveComponent implements AfterViewInit, OnD
 
 	private generateDates(): string[] {
 		const dates: string[] = [];
-		const start = new Date(2024, 3, 1);
+		const start = Date.UTC(2024, 3, 1);
 		for (let i = 0; i < 90; i++) {
-			const d = new Date(start);
-			d.setDate(d.getDate() + i);
+			const d = new Date(start + i * 86400000);
 			dates.push(d.toISOString().slice(0, 10));
 		}
 		return dates;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-interactive/index.page.ts
@@ -64,7 +64,7 @@ Chart.register(...registerables);
 })
 export default class ChartLineInteractiveComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 	protected _activeTab: 'desktop' | 'mobile' | 'all' = 'all';
 
 	private readonly _dates = this.generateDates();
@@ -99,11 +99,11 @@ export default class ChartLineInteractiveComponent implements AfterViewInit, OnD
 		this._chartInstance = new Chart(canvas, {
 			type: 'line',
 			data: {
-				labels: this.dates,
+				labels: this._dates,
 				datasets: [
 					{
 						label: 'Desktop',
-						data: this.desktopData,
+						data: this._desktopData,
 						borderColor: 'hsl(12, 76%, 61%)',
 						backgroundColor: 'hsl(12, 76%, 61%)',
 						tension: 0.4,
@@ -111,7 +111,7 @@ export default class ChartLineInteractiveComponent implements AfterViewInit, OnD
 					},
 					{
 						label: 'Mobile',
-						data: this.mobileData,
+						data: this._mobileData,
 						borderColor: 'hsl(173, 58%, 39%)',
 						backgroundColor: 'hsl(173, 58%, 39%)',
 						tension: 0.4,

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label-custom/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 const datalabelPlugin = {
 	id: 'datalabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label-custom/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 const datalabelPlugin = {
 	id: 'datalabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label-custom/index.page.ts
@@ -64,7 +64,7 @@ const datalabelPlugin = {
 })
 export default class ChartLineLabelCustomComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label-custom/index.page.ts
@@ -1,0 +1,113 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+const datalabelPlugin = {
+	id: 'datalabels',
+	afterDatasetsDraw(chart: Chart) {
+		const { ctx } = chart;
+		chart.data.datasets.forEach((dataset, datasetIndex) => {
+			const meta = chart.getDatasetMeta(datasetIndex);
+			if (meta.hidden) return;
+			meta.data.forEach((element, index) => {
+				const value = dataset.data[index];
+				const label = chart.data.labels?.[index] ?? '';
+				ctx.save();
+				ctx.font = '11px sans-serif';
+				ctx.fillStyle = 'hsl(0, 0%, 40%)';
+				ctx.textAlign = 'center';
+				ctx.textBaseline = 'bottom';
+				ctx.fillText(`${label}`, element.x, (element as any).y - 18);
+				ctx.fillText(String(value), element.x, (element as any).y - 6);
+				ctx.restore();
+			});
+		});
+	},
+};
+
+@Component({
+	selector: 'spartan-chart-line-label-custom',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Line Chart with Custom Labels</h3>
+			<p class="text-muted-foreground text-sm">Browser usage by category</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex flex-wrap items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(12, 76%, 61%)"></span>
+				<span>Chrome</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(173, 58%, 39%)"></span>
+				<span>Safari</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(197, 37%, 24%)"></span>
+				<span>Firefox</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(43, 74%, 66%)"></span>
+				<span>Edge</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(27, 87%, 67%)"></span>
+				<span>Other</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartLineLabelCustomComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		const colors = [
+			'hsl(12, 76%, 61%)',
+			'hsl(173, 58%, 39%)',
+			'hsl(197, 37%, 24%)',
+			'hsl(43, 74%, 66%)',
+			'hsl(27, 87%, 67%)',
+		];
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						label: 'Visitors',
+						data: [275, 200, 187, 173, 90],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						pointBackgroundColor: colors,
+						pointBorderColor: colors,
+						pointRadius: 5,
+						pointHoverRadius: 7,
+						tension: 0.4,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, ticks: { maxRotation: 0 } },
+				},
+			},
+			plugins: [datalabelPlugin],
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 const datalabelPlugin = {
 	id: 'datalabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 const datalabelPlugin = {
 	id: 'datalabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label/index.page.ts
@@ -1,0 +1,97 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+const datalabelPlugin = {
+	id: 'datalabels',
+	afterDatasetsDraw(chart: Chart) {
+		const { ctx } = chart;
+		chart.data.datasets.forEach((dataset, datasetIndex) => {
+			const meta = chart.getDatasetMeta(datasetIndex);
+			if (meta.hidden) return;
+			meta.data.forEach((element, index) => {
+				const value = dataset.data[index];
+				ctx.save();
+				ctx.font = '10px sans-serif';
+				ctx.fillStyle = 'hsl(0, 0%, 40%)';
+				ctx.textAlign = 'center';
+				ctx.textBaseline = 'bottom';
+				ctx.fillText(String(value), element.x, (element as any).y - 8);
+				ctx.restore();
+			});
+		});
+	},
+};
+
+@Component({
+	selector: 'spartan-chart-line-label',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Line Chart with Labels</h3>
+			<p class="text-muted-foreground text-sm">Showing desktop and mobile visitors</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(12, 76%, 61%)"></span>
+				<span>Desktop</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(173, 58%, 39%)"></span>
+				<span>Mobile</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartLineLabelComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						tension: 0.4,
+						pointRadius: 4,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsl(173, 58%, 39%)',
+						tension: 0.4,
+						pointRadius: 4,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, ticks: { maxRotation: 0 } },
+				},
+			},
+			plugins: [datalabelPlugin],
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-label/index.page.ts
@@ -50,7 +50,7 @@ const datalabelPlugin = {
 })
 export default class ChartLineLabelComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-linear/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-linear/index.page.ts
@@ -1,0 +1,63 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-line-linear',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Linear Line Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartLineLinearComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						tension: 0,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, ticks: { maxRotation: 0 } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-linear/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-linear/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-line-linear',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-linear/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-linear/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-line-linear',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-linear/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-linear/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartLineLinearComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-multiple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-multiple/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-line-multiple',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-multiple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-multiple/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-line-multiple',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-multiple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-multiple/index.page.ts
@@ -1,0 +1,75 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-line-multiple',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Multiple Line Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing desktop and mobile visitors</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(12, 76%, 61%)"></span>
+				<span>Desktop</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="h-3 w-3 rounded-full" style="background: hsl(173, 58%, 39%)"></span>
+				<span>Mobile</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartLineMultipleComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						tension: 0.4,
+						pointRadius: 0,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsl(173, 58%, 39%)',
+						tension: 0.4,
+						pointRadius: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, ticks: { maxRotation: 0 } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-multiple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-multiple/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartLineMultipleComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-step/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-step/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-line-step',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-step/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-step/index.page.ts
@@ -1,0 +1,63 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-line-step',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Stepped Line Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartLineStepComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'line',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsl(12, 76%, 61%)',
+						pointRadius: 0,
+						stepped: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					x: { grid: { display: false }, ticks: { maxRotation: 0 } },
+					y: { grid: { display: false }, ticks: { maxRotation: 0 } },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-step/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-step/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-line-step',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-step/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-line-step/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartLineStepComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-active/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-active/index.page.ts
@@ -1,0 +1,62 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-pie-donut-active',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Interactive Donut Chart</h3>
+			<p class="text-muted-foreground text-sm">Hover over segments to see details</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartPieDonutActiveComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'doughnut',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+						hoverOffset: 8,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				cutout: '60%',
+				plugins: {
+					legend: { display: false },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-active/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-active/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-pie-donut-active',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-active/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-active/index.page.ts
@@ -19,7 +19,7 @@ Chart.register(...registerables);
 })
 export default class ChartPieDonutActiveComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-active/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-active/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-pie-donut-active',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-text/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-text/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-pie-donut-text',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-text/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-text/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-pie-donut-text',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-text/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-text/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartPieDonutTextComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-text/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut-text/index.page.ts
@@ -1,0 +1,67 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-pie-donut-text',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Donut Chart with Text</h3>
+			<p class="text-muted-foreground text-sm">Browser market share</p>
+		</div>
+		<div class="relative mt-4">
+			<canvas #chart class="w-full"></canvas>
+			<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+				<div class="text-center">
+					<p class="text-3xl font-bold">925</p>
+					<p class="text-muted-foreground text-sm">Total</p>
+				</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartPieDonutTextComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'doughnut',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				cutout: '60%',
+				plugins: {
+					legend: { display: false },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-pie-donut',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-pie-donut',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut/index.page.ts
@@ -19,7 +19,7 @@ Chart.register(...registerables);
 })
 export default class ChartPieDonutComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-donut/index.page.ts
@@ -1,0 +1,61 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-pie-donut',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Donut Chart</h3>
+			<p class="text-muted-foreground text-sm">Browser market share</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartPieDonutComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'doughnut',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				cutout: '60%',
+				plugins: {
+					legend: { display: false },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-interactive/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-pie-interactive',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-interactive/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-pie-interactive',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-interactive/index.page.ts
@@ -1,0 +1,89 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-pie-interactive',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Interactive Donut Chart</h3>
+			<p class="text-muted-foreground text-sm">Click a segment to highlight it</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartPieInteractiveComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		const originalColors = [
+			'hsl(12, 76%, 61%)',
+			'hsl(173, 58%, 39%)',
+			'hsl(197, 37%, 24%)',
+			'hsl(43, 74%, 66%)',
+			'hsl(27, 87%, 67%)',
+		];
+		const fadedColors = [
+			'hsla(12, 76%, 61%, 0.3)',
+			'hsla(173, 58%, 39%, 0.3)',
+			'hsla(197, 37%, 24%, 0.3)',
+			'hsla(43, 74%, 66%, 0.3)',
+			'hsla(27, 87%, 67%, 0.3)',
+		];
+		let selectedIndex: number | null = null;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'doughnut',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [...originalColors],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				cutout: '60%',
+				plugins: {
+					legend: { display: false },
+				},
+				onClick: (_event, elements) => {
+					if (!this._chartInstance) return;
+					const dataset = this._chartInstance.data.datasets[0];
+					if (elements.length > 0) {
+						const index = elements[0].index;
+						if (selectedIndex === index) {
+							dataset.backgroundColor = [...originalColors];
+							selectedIndex = null;
+						} else {
+							dataset.backgroundColor = originalColors.map((c, i) => (i === index ? c : fadedColors[i]));
+							selectedIndex = index;
+						}
+					} else {
+						dataset.backgroundColor = [...originalColors];
+						selectedIndex = null;
+					}
+					this._chartInstance.update();
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-interactive/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-interactive/index.page.ts
@@ -19,7 +19,7 @@ Chart.register(...registerables);
 })
 export default class ChartPieInteractiveComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-custom/index.page.ts
@@ -1,0 +1,79 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { ArcElement, Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+const datalabelPlugin = {
+	id: 'datalabels',
+	afterDatasetsDraw(chart: Chart) {
+		const { ctx } = chart;
+		(chart.getDatasetMeta(0).data as ArcElement[]).forEach((arc, i) => {
+			const data = chart.data.datasets[0].data[i];
+			ctx.save();
+			ctx.fillStyle = '#fff';
+			ctx.font = 'bold 12px sans-serif';
+			ctx.textAlign = 'center';
+			ctx.textBaseline = 'middle';
+			const { x, y } = arc.tooltipPosition();
+			ctx.fillText(`${data}`, x, y);
+			ctx.restore();
+		});
+	},
+};
+
+@Component({
+	selector: 'spartan-chart-pie-label-custom',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Pie Chart with Custom Labels</h3>
+			<p class="text-muted-foreground text-sm">Browser market share with visitor counts</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartPieLabelCustomComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'pie',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+				},
+			},
+			plugins: [datalabelPlugin],
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-custom/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { ArcElement, Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { ArcElement, Chart } from 'chart.js';
 
 const datalabelPlugin = {
 	id: 'datalabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-custom/index.page.ts
@@ -13,7 +13,7 @@ const datalabelPlugin = {
 			ctx.font = 'bold 12px sans-serif';
 			ctx.textAlign = 'center';
 			ctx.textBaseline = 'middle';
-			const { x, y } = arc.tooltipPosition();
+			const { x, y } = arc.tooltipPosition(false);
 			ctx.fillText(`${data}`, x, y);
 			ctx.restore();
 		});
@@ -37,7 +37,7 @@ const datalabelPlugin = {
 })
 export default class ChartPieLabelCustomComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-custom/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { ArcElement, Chart } from 'chart.js';
+import { ArcElement, Chart } from 'chart.js/auto';
 
 const datalabelPlugin = {
 	id: 'datalabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-list/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-list/index.page.ts
@@ -15,7 +15,7 @@ const datalabelPlugin = {
 			ctx.font = 'bold 12px sans-serif';
 			ctx.textAlign = 'center';
 			ctx.textBaseline = 'middle';
-			const { x, y } = arc.tooltipPosition();
+			const { x, y } = arc.tooltipPosition(false);
 			ctx.fillText(`${pct}%`, x, y);
 			ctx.restore();
 		});
@@ -39,7 +39,7 @@ const datalabelPlugin = {
 })
 export default class ChartPieLabelListComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-list/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-list/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { ArcElement, Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { ArcElement, Chart } from 'chart.js';
 
 const datalabelPlugin = {
 	id: 'datalabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-list/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-list/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { ArcElement, Chart } from 'chart.js';
+import { ArcElement, Chart } from 'chart.js/auto';
 
 const datalabelPlugin = {
 	id: 'datalabels',
@@ -8,7 +8,7 @@ const datalabelPlugin = {
 		const data = chart.data.datasets[0].data as number[];
 		const total = data.reduce((a: number, b: number) => a + b, 0);
 		(chart.getDatasetMeta(0).data as ArcElement[]).forEach((arc, i) => {
-			const pct = Math.round((data[i] / total) * 100);
+			const pct = total > 0 ? Math.round((data[i] / total) * 100) : 0;
 			ctx.save();
 			ctx.fillStyle = '#fff';
 			ctx.font = 'bold 12px sans-serif';

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-list/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label-list/index.page.ts
@@ -1,0 +1,81 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { ArcElement, Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+const datalabelPlugin = {
+	id: 'datalabels',
+	afterDatasetsDraw(chart: Chart) {
+		const { ctx } = chart;
+		const data = chart.data.datasets[0].data as number[];
+		const total = data.reduce((a: number, b: number) => a + b, 0);
+		(chart.getDatasetMeta(0).data as ArcElement[]).forEach((arc, i) => {
+			const pct = Math.round((data[i] / total) * 100);
+			ctx.save();
+			ctx.fillStyle = '#fff';
+			ctx.font = 'bold 12px sans-serif';
+			ctx.textAlign = 'center';
+			ctx.textBaseline = 'middle';
+			const { x, y } = arc.tooltipPosition();
+			ctx.fillText(`${pct}%`, x, y);
+			ctx.restore();
+		});
+	},
+};
+
+@Component({
+	selector: 'spartan-chart-pie-label-list',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Pie Chart with Percentage Labels</h3>
+			<p class="text-muted-foreground text-sm">Browser market share with percentages</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartPieLabelListComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'pie',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+				},
+			},
+			plugins: [datalabelPlugin],
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label/index.page.ts
@@ -1,0 +1,79 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { ArcElement, Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+const datalabelPlugin = {
+	id: 'datalabels',
+	afterDatasetsDraw(chart: Chart) {
+		const { ctx } = chart;
+		(chart.getDatasetMeta(0).data as ArcElement[]).forEach((arc, i) => {
+			const label = chart.data.labels?.[i] || '';
+			ctx.save();
+			ctx.fillStyle = '#fff';
+			ctx.font = 'bold 12px sans-serif';
+			ctx.textAlign = 'center';
+			ctx.textBaseline = 'middle';
+			const { x, y } = arc.tooltipPosition();
+			ctx.fillText(label, x, y);
+			ctx.restore();
+		});
+	},
+};
+
+@Component({
+	selector: 'spartan-chart-pie-label',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Pie Chart with Labels</h3>
+			<p class="text-muted-foreground text-sm">Browser market share with names</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartPieLabelComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'pie',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+				},
+			},
+			plugins: [datalabelPlugin],
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { ArcElement, Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { ArcElement, Chart } from 'chart.js';
 
 const datalabelPlugin = {
 	id: 'datalabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label/index.page.ts
@@ -7,13 +7,13 @@ const datalabelPlugin = {
 	afterDatasetsDraw(chart: Chart) {
 		const { ctx } = chart;
 		(chart.getDatasetMeta(0).data as ArcElement[]).forEach((arc, i) => {
-			const label = chart.data.labels?.[i] || '';
+			const label = (chart.data.labels?.[i] || '') as string;
 			ctx.save();
 			ctx.fillStyle = '#fff';
 			ctx.font = 'bold 12px sans-serif';
 			ctx.textAlign = 'center';
 			ctx.textBaseline = 'middle';
-			const { x, y } = arc.tooltipPosition();
+			const { x, y } = arc.tooltipPosition(false);
 			ctx.fillText(label, x, y);
 			ctx.restore();
 		});
@@ -37,7 +37,7 @@ const datalabelPlugin = {
 })
 export default class ChartPieLabelComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-label/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { ArcElement, Chart } from 'chart.js';
+import { ArcElement, Chart } from 'chart.js/auto';
 
 const datalabelPlugin = {
 	id: 'datalabels',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-legend/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-legend/index.page.ts
@@ -41,7 +41,7 @@ Chart.register(...registerables);
 })
 export default class ChartPieLegendComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-legend/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-legend/index.page.ts
@@ -1,0 +1,82 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-pie-legend',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Pie Chart with Legend</h3>
+			<p class="text-muted-foreground text-sm">Browser market share</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex flex-wrap items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Chrome</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Safari</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(197, 37%, 24%)"></span>
+				<span class="text-muted-foreground">Firefox</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(43, 74%, 66%)"></span>
+				<span class="text-muted-foreground">Edge</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(27, 87%, 67%)"></span>
+				<span class="text-muted-foreground">Other</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartPieLegendComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'pie',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-legend/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-legend/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-pie-legend',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-legend/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-legend/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-pie-legend',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-separator-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-separator-none/index.page.ts
@@ -1,0 +1,59 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-pie-separator-none',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Pie Chart without Separators</h3>
+			<p class="text-muted-foreground text-sm">Browser market share with no borders</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartPieSeparatorNoneComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'pie',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 0,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-separator-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-separator-none/index.page.ts
@@ -19,7 +19,7 @@ Chart.register(...registerables);
 })
 export default class ChartPieSeparatorNoneComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-separator-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-separator-none/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-pie-separator-none',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-separator-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-separator-none/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-pie-separator-none',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-simple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-simple/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-pie-simple',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-simple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-simple/index.page.ts
@@ -1,0 +1,60 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-pie-simple',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Pie Chart</h3>
+			<p class="text-muted-foreground text-sm">Browser market share</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartPieSimpleComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'pie',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-simple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-simple/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-pie-simple',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-simple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-simple/index.page.ts
@@ -19,7 +19,7 @@ Chart.register(...registerables);
 })
 export default class ChartPieSimpleComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-stacked/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-pie-stacked',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-stacked/index.page.ts
@@ -1,0 +1,72 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-pie-stacked',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Stacked Donut Chart</h3>
+			<p class="text-muted-foreground text-sm">Two concentric rings showing nested data</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartPieStackedComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'doughnut',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+					{
+						data: [150, 120, 100, 80, 50],
+						backgroundColor: [
+							'hsla(12, 76%, 61%, 0.6)',
+							'hsla(173, 58%, 39%, 0.6)',
+							'hsla(197, 37%, 24%, 0.6)',
+							'hsla(43, 74%, 66%, 0.6)',
+							'hsla(27, 87%, 67%, 0.6)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-stacked/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-pie-stacked',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-pie-stacked/index.page.ts
@@ -19,7 +19,7 @@ Chart.register(...registerables);
 })
 export default class ChartPieStackedComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-default/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarDefaultComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-default/index.page.ts
@@ -1,0 +1,58 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-default',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarDefaultComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 273, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-default/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-default',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-default/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-default',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-dots/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-dots/index.page.ts
@@ -1,0 +1,60 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-dots',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarDotsComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 273, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+						pointRadius: 4,
+						pointBackgroundColor: 'hsl(12, 76%, 61%)',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-dots/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-dots/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-dots',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-dots/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-dots/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-dots',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-dots/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-dots/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarDotsComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-fill/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-fill/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarGridCircleFillComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-fill/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-fill/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-grid-circle-fill',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-fill/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-fill/index.page.ts
@@ -1,0 +1,66 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-grid-circle-fill',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarGridCircleFillComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 273, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					r: {
+						grid: { circular: true, color: 'hsla(12, 76%, 61%, 0.2)' },
+						angleLines: { color: 'hsla(12, 76%, 61%, 0.2)' },
+						pointLabels: { display: false },
+						ticks: { display: false },
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-fill/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-fill/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-grid-circle-fill',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-no-lines/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-no-lines/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-grid-circle-no-lines',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-no-lines/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-no-lines/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarGridCircleNoLinesComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-no-lines/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-no-lines/index.page.ts
@@ -1,0 +1,64 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-grid-circle-no-lines',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarGridCircleNoLinesComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 273, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					r: {
+						grid: { circular: true },
+						angleLines: { display: false },
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-no-lines/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle-no-lines/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-grid-circle-no-lines',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle/index.page.ts
@@ -1,0 +1,63 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-grid-circle',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarGridCircleComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 273, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					r: {
+						grid: { circular: true },
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-grid-circle',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-grid-circle',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-circle/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarGridCircleComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-custom/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-grid-custom',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-custom/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-grid-custom',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-custom/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarGridCustomComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-custom/index.page.ts
@@ -1,0 +1,65 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-grid-custom',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarGridCustomComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 273, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					r: {
+						ticks: {
+							stepSize: 50,
+						},
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-fill/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-fill/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarGridFillComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-fill/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-fill/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-grid-fill',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-fill/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-fill/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-grid-fill',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-fill/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-fill/index.page.ts
@@ -1,0 +1,63 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-grid-fill',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarGridFillComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 273, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					r: {
+						grid: { color: 'hsla(12, 76%, 61%, 0.15)' },
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-none/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarGridNoneComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-none/index.page.ts
@@ -1,0 +1,63 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-grid-none',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarGridNoneComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 273, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: { legend: { display: false } },
+				scales: {
+					r: {
+						grid: { display: false },
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-none/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-grid-none',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-grid-none/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-grid-none',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-icons/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-icons',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-icons/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarIconsComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-icons/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-icons',
@@ -61,15 +60,13 @@ export default class ChartRadarIconsComponent implements AfterViewInit, OnDestro
 						labels: {
 							generateLabels: (chart: Chart) => {
 								const datasets = chart.data.datasets;
-								return (
-									chart.data.labels?.map((label, i) => ({
-										text: i === 0 ? '🖥 Desktop' : '📱 Mobile',
-										fillStyle: datasets[i].borderColor as string,
-										strokeStyle: datasets[i].borderColor as string,
-										lineWidth: 0,
-										index: i,
-									})) || []
-								);
+								return datasets.map((ds, i) => ({
+									text: i === 0 ? '🖥 Desktop' : '📱 Mobile',
+									fillStyle: ds.borderColor as string,
+									strokeStyle: ds.borderColor as string,
+									lineWidth: 0,
+									index: i,
+								}));
 							},
 						},
 					},

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-icons/index.page.ts
@@ -1,0 +1,84 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-icons',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarIconsComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsla(173, 58%, 39%, 0.6)',
+						fill: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: {
+						display: true,
+						position: 'bottom',
+						labels: {
+							generateLabels: (chart: Chart) => {
+								const datasets = chart.data.datasets;
+								return (
+									chart.data.labels?.map((label, i) => ({
+										text: i === 0 ? '🖥 Desktop' : '📱 Mobile',
+										fillStyle: datasets[i].borderColor as string,
+										strokeStyle: datasets[i].borderColor as string,
+										lineWidth: 0,
+										index: i,
+									})) || []
+								);
+							},
+						},
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-label-custom/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-label-custom',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-label-custom/index.page.ts
@@ -1,0 +1,75 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-label-custom',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarLabelCustomComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsla(173, 58%, 39%, 0.6)',
+						fill: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+				},
+				scales: {
+					r: {
+						pointLabels: {
+							font: { size: 12, weight: 'bold' as const },
+							color: 'hsl(12, 76%, 61%)',
+						},
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-label-custom/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-label-custom',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-label-custom/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarLabelCustomComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-legend/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-legend/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarLegendComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-legend/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-legend/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-legend',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-legend/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-legend/index.page.ts
@@ -1,0 +1,70 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-legend',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarLegendComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsla(173, 58%, 39%, 0.6)',
+						fill: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: {
+						display: true,
+						position: 'bottom',
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-legend/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-legend/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-legend',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-lines-only/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-lines-only/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarLinesOnlyComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-lines-only/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-lines-only/index.page.ts
@@ -1,0 +1,70 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-lines-only',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarLinesOnlyComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'transparent',
+						fill: false,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'transparent',
+						fill: false,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: {
+						display: true,
+						position: 'bottom',
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-lines-only/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-lines-only/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-lines-only',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-lines-only/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-lines-only/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-lines-only',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-multiple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-multiple/index.page.ts
@@ -1,0 +1,70 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-multiple',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarMultipleComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsla(173, 58%, 39%, 0.6)',
+						fill: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: {
+						display: true,
+						position: 'bottom',
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-multiple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-multiple/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarMultipleComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-multiple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-multiple/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-multiple',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-multiple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-multiple/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-multiple',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-radius/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-radius/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radar-radius',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-radius/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-radius/index.page.ts
@@ -1,0 +1,76 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radar-radius',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radar Chart</h3>
+			<p class="text-muted-foreground text-sm">Showing total visitors for the last 6 months</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-start gap-2 pt-4 text-sm">
+			<div class="grid gap-2">
+				<div class="flex items-center gap-2 leading-none font-medium">Trending up by 5.2% this month</div>
+				<div class="text-muted-foreground text-xs">January - June 2024</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadarRadiusComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+		this._chartInstance = new Chart(canvas, {
+			type: 'radar',
+			data: {
+				labels: ['January', 'February', 'March', 'April', 'May', 'June'],
+				datasets: [
+					{
+						label: 'Desktop',
+						data: [186, 305, 237, 73, 209, 214],
+						borderColor: 'hsl(12, 76%, 61%)',
+						backgroundColor: 'hsla(12, 76%, 61%, 0.6)',
+						fill: true,
+					},
+					{
+						label: 'Mobile',
+						data: [80, 200, 120, 190, 130, 140],
+						borderColor: 'hsl(173, 58%, 39%)',
+						backgroundColor: 'hsla(173, 58%, 39%, 0.6)',
+						fill: true,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: {
+						display: true,
+						position: 'bottom',
+					},
+				},
+				scales: {
+					r: {
+						suggestedMin: 0,
+						suggestedMax: 350,
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-radius/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-radius/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadarRadiusComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-radius/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radar-radius/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radar-radius',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-grid/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-grid/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radial-grid',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-grid/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-grid/index.page.ts
@@ -1,0 +1,66 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radial-grid',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radial Chart with Grid</h3>
+			<p class="text-muted-foreground text-sm">Browser market share with grid lines</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartRadialGridComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'polarArea',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsla(12, 76%, 61%, 0.7)',
+							'hsla(173, 58%, 39%, 0.7)',
+							'hsla(197, 37%, 24%, 0.7)',
+							'hsla(43, 74%, 66%, 0.7)',
+							'hsla(27, 87%, 67%, 0.7)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+				},
+				scales: {
+					r: {
+						ticks: { display: false },
+						grid: { color: 'hsl(0, 0%, 85%)' },
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-grid/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-grid/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radial-grid',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-grid/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-grid/index.page.ts
@@ -19,7 +19,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadialGridComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-label/index.page.ts
@@ -19,7 +19,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadialLabelComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-label/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radial-label',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-label/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radial-label',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-label/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-label/index.page.ts
@@ -1,0 +1,72 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radial-label',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radial Chart with Labels</h3>
+			<p class="text-muted-foreground text-sm">Half-doughnut showing browser data</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartRadialLabelComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'doughnut',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				rotation: -90,
+				circumference: 180,
+				plugins: {
+					legend: { display: false },
+					tooltip: {
+						callbacks: {
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							label: (context: any) => {
+								const label = context.label ?? '';
+								const value = context.parsed;
+								return `${label}: ${value}`;
+							},
+						},
+					},
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-shape/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-shape/index.page.ts
@@ -1,0 +1,67 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radial-shape',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radial Chart with Total</h3>
+			<p class="text-muted-foreground text-sm">Custom arc style with centered total</p>
+		</div>
+		<div class="relative mt-4">
+			<canvas #chart class="w-full"></canvas>
+			<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+				<div class="text-center">
+					<p class="text-3xl font-bold">925</p>
+					<p class="text-muted-foreground text-sm">Total</p>
+				</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadialShapeComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'doughnut',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				cutout: '65%',
+				plugins: {
+					legend: { display: false },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-shape/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-shape/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radial-shape',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-shape/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-shape/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadialShapeComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-shape/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-shape/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radial-shape',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-simple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-simple/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radial-simple',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-simple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-simple/index.page.ts
@@ -1,0 +1,60 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radial-simple',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radial Chart</h3>
+			<p class="text-muted-foreground text-sm">Browser market share</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartRadialSimpleComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'polarArea',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsla(12, 76%, 61%, 0.7)',
+							'hsla(173, 58%, 39%, 0.7)',
+							'hsla(197, 37%, 24%, 0.7)',
+							'hsla(43, 74%, 66%, 0.7)',
+							'hsla(27, 87%, 67%, 0.7)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-simple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-simple/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radial-simple',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-simple/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-simple/index.page.ts
@@ -19,7 +19,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadialSimpleComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-stacked/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radial-stacked',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-stacked/index.page.ts
@@ -1,0 +1,74 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radial-stacked',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Stacked Radial Chart</h3>
+			<p class="text-muted-foreground text-sm">Two concentric rings with corner radius</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+	`,
+})
+export default class ChartRadialStackedComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'doughnut',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+						borderRadius: 4,
+					},
+					{
+						data: [150, 120, 100, 80, 50],
+						backgroundColor: [
+							'hsla(12, 76%, 61%, 0.5)',
+							'hsla(173, 58%, 39%, 0.5)',
+							'hsla(197, 37%, 24%, 0.5)',
+							'hsla(43, 74%, 66%, 0.5)',
+							'hsla(27, 87%, 67%, 0.5)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+						borderRadius: 4,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-stacked/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radial-stacked',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-stacked/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-stacked/index.page.ts
@@ -19,7 +19,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadialStackedComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-text/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-text/index.page.ts
@@ -25,7 +25,7 @@ Chart.register(...registerables);
 })
 export default class ChartRadialTextComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-text/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-text/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-radial-text',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-text/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-text/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-radial-text',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-text/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-radial-text/index.page.ts
@@ -1,0 +1,67 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-radial-text',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Radial Chart with Center Text</h3>
+			<p class="text-muted-foreground text-sm">Total visitors shown in center</p>
+		</div>
+		<div class="relative mt-4">
+			<canvas #chart class="w-full"></canvas>
+			<div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+				<div class="text-center">
+					<p class="text-3xl font-bold">925</p>
+					<p class="text-muted-foreground text-sm">Visitors</p>
+				</div>
+			</div>
+		</div>
+	`,
+})
+export default class ChartRadialTextComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'doughnut',
+			data: {
+				labels: ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'],
+				datasets: [
+					{
+						data: [275, 200, 187, 173, 90],
+						backgroundColor: [
+							'hsl(12, 76%, 61%)',
+							'hsl(173, 58%, 39%)',
+							'hsl(197, 37%, 24%)',
+							'hsl(43, 74%, 66%)',
+							'hsl(27, 87%, 67%)',
+						],
+						borderWidth: 1,
+						borderColor: '#fff',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				cutout: '80%',
+				plugins: {
+					legend: { display: false },
+				},
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-advanced/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-advanced/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-tooltip-advanced',
@@ -10,7 +9,7 @@ Chart.register(...registerables);
 	template: `
 		<div class="flex flex-col gap-1.5">
 			<h3 class="text-lg leading-none font-semibold tracking-tight">Advanced Tooltip</h3>
-			<p class="text-muted-foreground text-sm">Tooltip with title, body, and footer callbacks</p>
+			<p class="text-muted-foreground text-sm">Tooltip with title and label callbacks</p>
 		</div>
 		<div class="mt-4">
 			<canvas #chart class="w-full"></canvas>

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-advanced/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-advanced/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-tooltip-advanced',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-advanced/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-advanced/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartTooltipAdvancedComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-advanced/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-advanced/index.page.ts
@@ -1,0 +1,90 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-tooltip-advanced',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Advanced Tooltip</h3>
+			<p class="text-muted-foreground text-sm">Tooltip with title, body, and footer callbacks</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Running</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Swimming</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartTooltipAdvancedComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['2024-07-15', '2024-07-16', '2024-07-17', '2024-07-18', '2024-07-19', '2024-07-20'],
+				datasets: [
+					{
+						label: 'Running',
+						data: [450, 380, 520, 140, 600, 480],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+					},
+					{
+						label: 'Swimming',
+						data: [300, 420, 120, 550, 350, 400],
+						backgroundColor: 'hsl(173, 58%, 39%)',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+					tooltip: {
+						mode: 'index',
+						intersect: false,
+						callbacks: {
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							title: (items: any) => `Date: ${items[0].label}`,
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							label: (item: any) => `  ${item.dataset.label}: ${item.raw} mins`,
+						},
+					},
+				},
+				scales: {
+					x: {
+						stacked: true,
+						grid: { display: false },
+						ticks: { maxRotation: 0 },
+					},
+					y: {
+						stacked: true,
+						grid: { color: 'hsl(0, 0%, 90%)' },
+					},
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-default/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartTooltipDefaultComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-default/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-tooltip-default',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-default/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-tooltip-default',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-default/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-default/index.page.ts
@@ -1,0 +1,84 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-tooltip-default',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Activity Overview</h3>
+			<p class="text-muted-foreground text-sm">Running and swimming activity for the week</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Running</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Swimming</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartTooltipDefaultComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['2024-07-15', '2024-07-16', '2024-07-17', '2024-07-18', '2024-07-19', '2024-07-20'],
+				datasets: [
+					{
+						label: 'Running',
+						data: [450, 380, 520, 140, 600, 480],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+					},
+					{
+						label: 'Swimming',
+						data: [300, 420, 120, 550, 350, 400],
+						backgroundColor: 'hsl(173, 58%, 39%)',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+					tooltip: {
+						mode: 'index',
+						intersect: false,
+					},
+				},
+				scales: {
+					x: {
+						stacked: true,
+						grid: { display: false },
+						ticks: { maxRotation: 0 },
+					},
+					y: {
+						stacked: true,
+						grid: { color: 'hsl(0, 0%, 90%)' },
+					},
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-formatter/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-formatter/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-tooltip-formatter',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-formatter/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-formatter/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartTooltipFormatterComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-formatter/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-formatter/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-tooltip-formatter',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-formatter/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-formatter/index.page.ts
@@ -1,0 +1,92 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-tooltip-formatter',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Formatted Tooltip</h3>
+			<p class="text-muted-foreground text-sm">Tooltip with custom value formatting</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Running</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Swimming</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartTooltipFormatterComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['2024-07-15', '2024-07-16', '2024-07-17', '2024-07-18', '2024-07-19', '2024-07-20'],
+				datasets: [
+					{
+						label: 'Running',
+						data: [450, 380, 520, 140, 600, 480],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+					},
+					{
+						label: 'Swimming',
+						data: [300, 420, 120, 550, 350, 400],
+						backgroundColor: 'hsl(173, 58%, 39%)',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+					tooltip: {
+						mode: 'index',
+						intersect: false,
+						callbacks: {
+							label: (item) => {
+								const value = item.raw as number;
+								const hours = Math.floor(value / 60);
+								const mins = value % 60;
+								return ` ${item.dataset.label}: ${hours}h ${mins}m`;
+							},
+						},
+					},
+				},
+				scales: {
+					x: {
+						stacked: true,
+						grid: { display: false },
+						ticks: { maxRotation: 0 },
+					},
+					y: {
+						stacked: true,
+						grid: { color: 'hsl(0, 0%, 90%)' },
+					},
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-icons/index.page.ts
@@ -1,0 +1,135 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-tooltip-icons',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Tooltip with Icons</h3>
+			<p class="text-muted-foreground text-sm">Custom HTML tooltip showing colored icons</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Running</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Swimming</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartTooltipIconsComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		const getOrCreateTooltip = (chart: Chart) => {
+			let tooltipEl = chart.canvas.parentNode?.querySelector('div.chartjs-tooltip') as HTMLElement;
+			if (!tooltipEl) {
+				tooltipEl = document.createElement('div');
+				tooltipEl.className = 'chartjs-tooltip';
+				tooltipEl.style.position = 'absolute';
+				tooltipEl.style.pointerEvents = 'none';
+				tooltipEl.style.transition = 'all 0.15s ease';
+				tooltipEl.style.background = 'hsl(0, 0%, 100%)';
+				tooltipEl.style.border = '1px solid hsl(0, 0%, 90%)';
+				tooltipEl.style.borderRadius = '8px';
+				tooltipEl.style.padding = '10px 14px';
+				tooltipEl.style.fontSize = '12px';
+				tooltipEl.style.boxShadow = '0 4px 6px -1px rgb(0 0 0 / 0.1)';
+				chart.canvas.parentNode?.appendChild(tooltipEl);
+			}
+			return tooltipEl;
+		};
+
+		const iconColors: Record<string, string> = {
+			Running: 'hsl(12, 76%, 61%)',
+			Swimming: 'hsl(173, 58%, 39%)',
+		};
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['2024-07-15', '2024-07-16', '2024-07-17', '2024-07-18', '2024-07-19', '2024-07-20'],
+				datasets: [
+					{
+						label: 'Running',
+						data: [450, 380, 520, 140, 600, 480],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+					},
+					{
+						label: 'Swimming',
+						data: [300, 420, 120, 550, 350, 400],
+						backgroundColor: 'hsl(173, 58%, 39%)',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+					tooltip: {
+						enabled: false,
+						external: (context) => {
+							const tooltipModel = context.tooltip;
+							const tooltipEl = getOrCreateTooltip(context.chart);
+							if (tooltipModel.opacity === 0) {
+								tooltipEl.style.opacity = '0';
+								return;
+							}
+							if (tooltipModel.body) {
+								const titleLines = tooltipModel.title || [];
+								const bodyItems = tooltipModel.body.map((b) => b.lines);
+								let html = '';
+								if (titleLines.length > 0) {
+									html += `<div style="font-weight:600;margin-bottom:4px">${titleLines[0]}</div>`;
+								}
+								bodyItems.forEach((lines) => {
+									lines.forEach((line) => {
+										const label = line.split(':')[0].trim();
+										const color = iconColors[label] || '#888';
+										html += `<div style="display:flex;align-items:center;gap:6px;margin:2px 0"><span style="width:8px;height:8px;border-radius:50%;background:${color};display:inline-block"></span><span>${line}</span></div>`;
+									});
+								});
+								tooltipEl.innerHTML = html;
+							}
+							const position = context.chart.canvas.getBoundingClientRect();
+							tooltipEl.style.left = position.left + window.scrollX + tooltipModel.caretX + 'px';
+							tooltipEl.style.top = position.top + window.scrollY + tooltipModel.caretY - 10 + 'px';
+							tooltipEl.style.opacity = '1';
+						},
+					},
+				},
+				scales: {
+					x: {
+						stacked: true,
+						grid: { display: false },
+						ticks: { maxRotation: 0 },
+					},
+					y: {
+						stacked: true,
+						grid: { color: 'hsl(0, 0%, 90%)' },
+					},
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-icons/index.page.ts
@@ -90,20 +90,38 @@ export default class ChartTooltipIconsComponent implements AfterViewInit, OnDest
 								return;
 							}
 							if (tooltipModel.body) {
+								tooltipEl.textContent = '';
 								const titleLines = tooltipModel.title || [];
 								const bodyItems = tooltipModel.body.map((b) => b.lines);
-								let html = '';
 								if (titleLines.length > 0) {
-									html += `<div style="font-weight:600;margin-bottom:4px">${titleLines[0]}</div>`;
+									const titleDiv = document.createElement('div');
+									titleDiv.style.fontWeight = '600';
+									titleDiv.style.marginBottom = '4px';
+									titleDiv.textContent = titleLines[0];
+									tooltipEl.appendChild(titleDiv);
 								}
 								bodyItems.forEach((lines) => {
 									lines.forEach((line) => {
 										const label = line.split(':')[0].trim();
 										const color = iconColors[label] || '#888';
-										html += `<div style="display:flex;align-items:center;gap:6px;margin:2px 0"><span style="width:8px;height:8px;border-radius:50%;background:${color};display:inline-block"></span><span>${line}</span></div>`;
+										const rowDiv = document.createElement('div');
+										rowDiv.style.display = 'flex';
+										rowDiv.style.alignItems = 'center';
+										rowDiv.style.gap = '6px';
+										rowDiv.style.margin = '2px 0';
+										const dotSpan = document.createElement('span');
+										dotSpan.style.width = '8px';
+										dotSpan.style.height = '8px';
+										dotSpan.style.borderRadius = '50%';
+										dotSpan.style.background = color;
+										dotSpan.style.display = 'inline-block';
+										rowDiv.appendChild(dotSpan);
+										const textSpan = document.createElement('span');
+										textSpan.textContent = line;
+										rowDiv.appendChild(textSpan);
+										tooltipEl.appendChild(rowDiv);
 									});
 								});
-								tooltipEl.innerHTML = html;
 							}
 							tooltipEl.style.left = tooltipModel.caretX + 'px';
 							tooltipEl.style.top = tooltipModel.caretY - 10 + 'px';

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-icons/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-tooltip-icons',
@@ -106,9 +105,8 @@ export default class ChartTooltipIconsComponent implements AfterViewInit, OnDest
 								});
 								tooltipEl.innerHTML = html;
 							}
-							const position = context.chart.canvas.getBoundingClientRect();
-							tooltipEl.style.left = position.left + window.scrollX + tooltipModel.caretX + 'px';
-							tooltipEl.style.top = position.top + window.scrollY + tooltipModel.caretY - 10 + 'px';
+							tooltipEl.style.left = tooltipModel.caretX + 'px';
+							tooltipEl.style.top = tooltipModel.caretY - 10 + 'px';
 							tooltipEl.style.opacity = '1';
 						},
 					},

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-icons/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-tooltip-icons',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-icons/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-icons/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartTooltipIconsComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-line/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-line/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartTooltipIndicatorLineComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-line/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-line/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-tooltip-indicator-line',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-line/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-line/index.page.ts
@@ -1,0 +1,84 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-tooltip-indicator-line',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Tooltip with Line Indicator</h3>
+			<p class="text-muted-foreground text-sm">Stacked bar chart with vertical line indicator in tooltip</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Running</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Swimming</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartTooltipIndicatorLineComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['2024-07-15', '2024-07-16', '2024-07-17', '2024-07-18', '2024-07-19', '2024-07-20'],
+				datasets: [
+					{
+						label: 'Running',
+						data: [450, 380, 520, 140, 600, 480],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+					},
+					{
+						label: 'Swimming',
+						data: [300, 420, 120, 550, 350, 400],
+						backgroundColor: 'hsl(173, 58%, 39%)',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+					tooltip: {
+						mode: 'index',
+						intersect: false,
+					},
+				},
+				scales: {
+					x: {
+						stacked: true,
+						grid: { display: false },
+						ticks: { maxRotation: 0 },
+					},
+					y: {
+						stacked: true,
+						grid: { color: 'hsl(0, 0%, 90%)' },
+					},
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-line/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-line/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-tooltip-indicator-line',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-none/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-tooltip-indicator-none',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-none/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartTooltipIndicatorNoneComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-none/index.page.ts
@@ -1,0 +1,89 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-tooltip-indicator-none',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Tooltip without Indicator</h3>
+			<p class="text-muted-foreground text-sm">Stacked bar chart with no indicator in tooltip</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Running</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Swimming</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartTooltipIndicatorNoneComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['2024-07-15', '2024-07-16', '2024-07-17', '2024-07-18', '2024-07-19', '2024-07-20'],
+				datasets: [
+					{
+						label: 'Running',
+						data: [450, 380, 520, 140, 600, 480],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+					},
+					{
+						label: 'Swimming',
+						data: [300, 420, 120, 550, 350, 400],
+						backgroundColor: 'hsl(173, 58%, 39%)',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+					tooltip: {
+						mode: 'index',
+						intersect: false,
+						displayColors: false,
+						callbacks: {
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							label: (item: any) => item.formattedValue,
+						},
+					},
+				},
+				scales: {
+					x: {
+						stacked: true,
+						grid: { display: false },
+						ticks: { maxRotation: 0 },
+					},
+					y: {
+						stacked: true,
+						grid: { color: 'hsl(0, 0%, 90%)' },
+					},
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-indicator-none/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-tooltip-indicator-none',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-custom/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-tooltip-label-custom',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-custom/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-tooltip-label-custom',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-custom/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartTooltipLabelCustomComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-custom/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-custom/index.page.ts
@@ -1,0 +1,96 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-tooltip-label-custom',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Custom Label Tooltip</h3>
+			<p class="text-muted-foreground text-sm">Tooltip with custom label formatting</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Running</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Swimming</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartTooltipLabelCustomComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		const labelMap: Record<string, string> = {
+			Running: 'Run',
+			Swimming: 'Swim',
+		};
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['2024-07-15', '2024-07-16', '2024-07-17', '2024-07-18', '2024-07-19', '2024-07-20'],
+				datasets: [
+					{
+						label: 'Running',
+						data: [450, 380, 520, 140, 600, 480],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+					},
+					{
+						label: 'Swimming',
+						data: [300, 420, 120, 550, 350, 400],
+						backgroundColor: 'hsl(173, 58%, 39%)',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+					tooltip: {
+						mode: 'index',
+						intersect: false,
+						callbacks: {
+							label: (item) => {
+								const label = item.dataset.label || '';
+								const shortLabel = labelMap[label] || label;
+								return ` ${shortLabel}: ${item.raw} mins`;
+							},
+						},
+					},
+				},
+				scales: {
+					x: {
+						stacked: true,
+						grid: { display: false },
+						ticks: { maxRotation: 0 },
+					},
+					y: {
+						stacked: true,
+						grid: { color: 'hsl(0, 0%, 90%)' },
+					},
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-formatter/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-formatter/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartTooltipLabelFormatterComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-formatter/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-formatter/index.page.ts
@@ -1,0 +1,97 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-tooltip-label-formatter',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Formatted Date Label Tooltip</h3>
+			<p class="text-muted-foreground text-sm">Tooltip with formatted date labels</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Running</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Swimming</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartTooltipLabelFormatterComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+		const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['2024-07-15', '2024-07-16', '2024-07-17', '2024-07-18', '2024-07-19', '2024-07-20'],
+				datasets: [
+					{
+						label: 'Running',
+						data: [450, 380, 520, 140, 600, 480],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+					},
+					{
+						label: 'Swimming',
+						data: [300, 420, 120, 550, 350, 400],
+						backgroundColor: 'hsl(173, 58%, 39%)',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+					tooltip: {
+						mode: 'index',
+						intersect: false,
+						callbacks: {
+							title: (items) => {
+								const dateStr = items[0].label;
+								const date = new Date(dateStr + 'T00:00:00');
+								const dayName = dayNames[date.getDay()];
+								const monthName = monthNames[date.getMonth()];
+								const day = date.getDate();
+								return `${dayName}, ${monthName} ${day}`;
+							},
+						},
+					},
+				},
+				scales: {
+					x: {
+						stacked: true,
+						grid: { display: false },
+						ticks: { maxRotation: 0 },
+					},
+					y: {
+						stacked: true,
+						grid: { color: 'hsl(0, 0%, 90%)' },
+					},
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-formatter/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-formatter/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-tooltip-label-formatter',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-formatter/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-formatter/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-tooltip-label-formatter',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-none/index.page.ts
@@ -29,7 +29,7 @@ Chart.register(...registerables);
 })
 export default class ChartTooltipLabelNoneComponent implements AfterViewInit, OnDestroy {
 	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
-	private readonly _chartInstance: Chart | null = null;
+	private _chartInstance: Chart | null = null;
 
 	ngAfterViewInit(): void {
 		const canvas = this._chartRef()?.nativeElement;

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-none/index.page.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart } from 'chart.js';
+import { Chart } from 'chart.js/auto';
 
 @Component({
 	selector: 'spartan-chart-tooltip-label-none',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-none/index.page.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
+import { Chart } from 'chart.js';
 
 @Component({
 	selector: 'spartan-chart-tooltip-label-none',

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-none/index.page.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/chart-tooltip-label-none/index.page.ts
@@ -1,0 +1,88 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
+@Component({
+	selector: 'spartan-chart-tooltip-label-none',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'block p-6' },
+	styleUrl: '../../blocks-preview-default.css',
+	template: `
+		<div class="flex flex-col gap-1.5">
+			<h3 class="text-lg leading-none font-semibold tracking-tight">Tooltip without Label</h3>
+			<p class="text-muted-foreground text-sm">Stacked bar chart with no label in tooltip</p>
+		</div>
+		<div class="mt-4">
+			<canvas #chart class="w-full"></canvas>
+		</div>
+		<div class="flex items-center gap-4 pt-4 text-sm">
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(12, 76%, 61%)"></span>
+				<span class="text-muted-foreground">Running</span>
+			</div>
+			<div class="flex items-center gap-1.5">
+				<span class="h-3 w-3 shrink-0 rounded-sm" style="background: hsl(173, 58%, 39%)"></span>
+				<span class="text-muted-foreground">Swimming</span>
+			</div>
+		</div>
+	`,
+})
+export default class ChartTooltipLabelNoneComponent implements AfterViewInit, OnDestroy {
+	protected readonly _chartRef = viewChild<ElementRef<HTMLCanvasElement>>('chart');
+	private readonly _chartInstance: Chart | null = null;
+
+	ngAfterViewInit(): void {
+		const canvas = this._chartRef()?.nativeElement;
+		if (!canvas) return;
+
+		this._chartInstance = new Chart(canvas, {
+			type: 'bar',
+			data: {
+				labels: ['2024-07-15', '2024-07-16', '2024-07-17', '2024-07-18', '2024-07-19', '2024-07-20'],
+				datasets: [
+					{
+						label: 'Running',
+						data: [450, 380, 520, 140, 600, 480],
+						backgroundColor: 'hsl(12, 76%, 61%)',
+					},
+					{
+						label: 'Swimming',
+						data: [300, 420, 120, 550, 350, 400],
+						backgroundColor: 'hsl(173, 58%, 39%)',
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				maintainAspectRatio: true,
+				plugins: {
+					legend: { display: false },
+					tooltip: {
+						mode: 'index',
+						intersect: false,
+						callbacks: {
+							label: () => '',
+							title: (items) => items[0].label,
+						},
+					},
+				},
+				scales: {
+					x: {
+						stacked: true,
+						grid: { display: false },
+						ticks: { maxRotation: 0 },
+					},
+					y: {
+						stacked: true,
+						grid: { color: 'hsl(0, 0%, 90%)' },
+					},
+				},
+				interaction: { intersect: false, mode: 'index' },
+			},
+		});
+	}
+
+	ngOnDestroy(): void {
+		this._chartInstance?.destroy();
+	}
+}

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/chart/chart-data.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/chart/chart-data.ts
@@ -1,0 +1,155 @@
+export const AREA_CHART_DATA = [
+	{ month: 'January', desktop: 186, mobile: 80, other: 45 },
+	{ month: 'February', desktop: 305, mobile: 200, other: 100 },
+	{ month: 'March', desktop: 237, mobile: 120, other: 150 },
+	{ month: 'April', desktop: 73, mobile: 190, other: 50 },
+	{ month: 'May', desktop: 209, mobile: 130, other: 100 },
+	{ month: 'June', desktop: 214, mobile: 140, other: 160 },
+];
+
+export const BAR_CHART_DATA = [
+	{ month: 'January', desktop: 186 },
+	{ month: 'February', desktop: 305 },
+	{ month: 'March', desktop: 237 },
+	{ month: 'April', desktop: 73 },
+	{ month: 'May', desktop: 209 },
+	{ month: 'June', desktop: 214 },
+];
+
+export const LINE_CHART_DATA = [...BAR_CHART_DATA];
+
+export const PIE_CHART_DATA = [
+	{ browser: 'chrome', visitors: 275, fill: 'var(--color-chrome)' },
+	{ browser: 'safari', visitors: 200, fill: 'var(--color-safari)' },
+	{ browser: 'firefox', visitors: 187, fill: 'var(--color-firefox)' },
+	{ browser: 'edge', visitors: 173, fill: 'var(--color-edge)' },
+	{ browser: 'other', visitors: 90, fill: 'var(--color-other)' },
+];
+
+export const RADAR_CHART_DATA = [
+	{ month: 'January', desktop: 186, mobile: 80 },
+	{ month: 'February', desktop: 305, mobile: 200 },
+	{ month: 'March', desktop: 237, mobile: 120 },
+	{ month: 'April', desktop: 73, mobile: 190 },
+	{ month: 'May', desktop: 209, mobile: 130 },
+	{ month: 'June', desktop: 214, mobile: 140 },
+];
+
+export const RADIAL_CHART_DATA = [...PIE_CHART_DATA];
+
+export const INTERACTIVE_CHART_DATA = [
+	{ date: '2024-04-01', desktop: 222, mobile: 150 },
+	{ date: '2024-04-02', desktop: 97, mobile: 180 },
+	{ date: '2024-04-03', desktop: 167, mobile: 120 },
+	{ date: '2024-04-04', desktop: 242, mobile: 260 },
+	{ date: '2024-04-05', desktop: 373, mobile: 290 },
+	{ date: '2024-04-06', desktop: 301, mobile: 340 },
+	{ date: '2024-04-07', desktop: 245, mobile: 180 },
+	{ date: '2024-04-08', desktop: 409, mobile: 320 },
+	{ date: '2024-04-09', desktop: 59, mobile: 110 },
+	{ date: '2024-04-10', desktop: 261, mobile: 190 },
+	{ date: '2024-04-11', desktop: 324, mobile: 350 },
+	{ date: '2024-04-12', desktop: 152, mobile: 120 },
+	{ date: '2024-04-13', desktop: 119, mobile: 260 },
+	{ date: '2024-04-14', desktop: 346, mobile: 130 },
+	{ date: '2024-04-15', desktop: 193, mobile: 150 },
+	{ date: '2024-04-16', desktop: 271, mobile: 200 },
+	{ date: '2024-04-17', desktop: 332, mobile: 310 },
+	{ date: '2024-04-18', desktop: 406, mobile: 280 },
+	{ date: '2024-04-19', desktop: 334, mobile: 350 },
+	{ date: '2024-04-20', desktop: 185, mobile: 140 },
+	{ date: '2024-04-21', desktop: 124, mobile: 220 },
+	{ date: '2024-04-22', desktop: 268, mobile: 180 },
+	{ date: '2024-04-23', desktop: 137, mobile: 150 },
+	{ date: '2024-04-24', desktop: 342, mobile: 310 },
+	{ date: '2024-04-25', desktop: 72, mobile: 240 },
+	{ date: '2024-04-26', desktop: 213, mobile: 170 },
+	{ date: '2024-04-27', desktop: 381, mobile: 340 },
+	{ date: '2024-04-28', desktop: 112, mobile: 210 },
+	{ date: '2024-04-29', desktop: 209, mobile: 160 },
+	{ date: '2024-04-30', desktop: 256, mobile: 190 },
+	{ date: '2024-05-01', desktop: 145, mobile: 280 },
+	{ date: '2024-05-02', desktop: 313, mobile: 120 },
+	{ date: '2024-05-03', desktop: 225, mobile: 340 },
+	{ date: '2024-05-04', desktop: 369, mobile: 260 },
+	{ date: '2024-05-05', desktop: 178, mobile: 180 },
+	{ date: '2024-05-06', desktop: 242, mobile: 310 },
+	{ date: '2024-05-07', desktop: 127, mobile: 230 },
+	{ date: '2024-05-08', desktop: 356, mobile: 290 },
+	{ date: '2024-05-09', desktop: 214, mobile: 150 },
+	{ date: '2024-05-10', desktop: 98, mobile: 320 },
+	{ date: '2024-05-11', desktop: 275, mobile: 180 },
+	{ date: '2024-05-12', desktop: 341, mobile: 260 },
+	{ date: '2024-05-13', desktop: 163, mobile: 210 },
+	{ date: '2024-05-14', desktop: 289, mobile: 340 },
+	{ date: '2024-05-15', desktop: 402, mobile: 130 },
+	{ date: '2024-05-16', desktop: 118, mobile: 280 },
+	{ date: '2024-05-17', desktop: 337, mobile: 190 },
+	{ date: '2024-05-18', desktop: 251, mobile: 240 },
+	{ date: '2024-05-19', desktop: 186, mobile: 310 },
+	{ date: '2024-05-20', desktop: 405, mobile: 160 },
+	{ date: '2024-05-21', desktop: 142, mobile: 270 },
+	{ date: '2024-05-22', desktop: 368, mobile: 140 },
+	{ date: '2024-05-23', desktop: 94, mobile: 220 },
+	{ date: '2024-05-24', desktop: 217, mobile: 350 },
+	{ date: '2024-05-25', desktop: 283, mobile: 180 },
+	{ date: '2024-05-26', desktop: 154, mobile: 260 },
+	{ date: '2024-05-27', desktop: 326, mobile: 130 },
+	{ date: '2024-05-28', desktop: 398, mobile: 290 },
+	{ date: '2024-05-29', desktop: 171, mobile: 210 },
+	{ date: '2024-05-30', desktop: 245, mobile: 340 },
+	{ date: '2024-05-31', desktop: 108, mobile: 170 },
+	{ date: '2024-06-01', desktop: 287, mobile: 250 },
+	{ date: '2024-06-02', desktop: 156, mobile: 130 },
+	{ date: '2024-06-03', desktop: 331, mobile: 310 },
+	{ date: '2024-06-04', desktop: 409, mobile: 200 },
+	{ date: '2024-06-05', desktop: 124, mobile: 350 },
+	{ date: '2024-06-06', desktop: 278, mobile: 180 },
+	{ date: '2024-06-07', desktop: 352, mobile: 260 },
+	{ date: '2024-06-08', desktop: 193, mobile: 140 },
+	{ date: '2024-06-09', desktop: 216, mobile: 320 },
+	{ date: '2024-06-10', desktop: 168, mobile: 210 },
+	{ date: '2024-06-11', desktop: 345, mobile: 170 },
+	{ date: '2024-06-12', desktop: 281, mobile: 290 },
+	{ date: '2024-06-13', desktop: 109, mobile: 230 },
+	{ date: '2024-06-14', desktop: 367, mobile: 150 },
+	{ date: '2024-06-15', desktop: 243, mobile: 340 },
+	{ date: '2024-06-16', desktop: 175, mobile: 180 },
+	{ date: '2024-06-17', desktop: 312, mobile: 260 },
+	{ date: '2024-06-18', desktop: 394, mobile: 120 },
+	{ date: '2024-06-19', desktop: 138, mobile: 310 },
+	{ date: '2024-06-20', desktop: 256, mobile: 200 },
+	{ date: '2024-06-21', desktop: 329, mobile: 170 },
+	{ date: '2024-06-22', desktop: 182, mobile: 350 },
+	{ date: '2024-06-23', desktop: 207, mobile: 140 },
+	{ date: '2024-06-24', desktop: 358, mobile: 280 },
+	{ date: '2024-06-25', desktop: 141, mobile: 210 },
+	{ date: '2024-06-26', desktop: 296, mobile: 130 },
+	{ date: '2024-06-27', desktop: 223, mobile: 320 },
+	{ date: '2024-06-28', desktop: 174, mobile: 190 },
+	{ date: '2024-06-29', desktop: 385, mobile: 260 },
+	{ date: '2024-06-30', desktop: 254, mobile: 150 },
+];
+
+export const SINGLE_SERIES_CONFIG = {
+	desktop: { label: 'Desktop', color: 'var(--chart-1)' },
+};
+
+export const DUAL_SERIES_CONFIG = {
+	desktop: { label: 'Desktop', color: 'var(--chart-1)' },
+	mobile: { label: 'Mobile', color: 'var(--chart-2)' },
+};
+
+export const TRI_SERIES_CONFIG = {
+	...DUAL_SERIES_CONFIG,
+	other: { label: 'Other', color: 'var(--chart-3)' },
+};
+
+export const BROWSER_CONFIG = {
+	visitors: { label: 'Visitors' },
+	chrome: { label: 'Chrome', color: 'var(--chart-1)' },
+	safari: { label: 'Safari', color: 'var(--chart-2)' },
+	firefox: { label: 'Firefox', color: 'var(--chart-3)' },
+	edge: { label: 'Edge', color: 'var(--chart-4)' },
+	other: { label: 'Other', color: 'var(--chart-5)' },
+};

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/chart/chart-data.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/chart/chart-data.ts
@@ -1,6 +1,3 @@
-import { Chart, registerables } from 'chart.js';
-Chart.register(...registerables);
-
 export const AREA_CHART_DATA = [
 	{ month: 'January', desktop: 186, mobile: 80, other: 45 },
 	{ month: 'February', desktop: 305, mobile: 200, other: 100 },

--- a/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/chart/chart-data.ts
+++ b/apps/app/src/app/pages/(blocks-preview)/blocks-preview/shared/chart/chart-data.ts
@@ -1,3 +1,6 @@
+import { Chart, registerables } from 'chart.js';
+Chart.register(...registerables);
+
 export const AREA_CHART_DATA = [
 	{ month: 'January', desktop: 186, mobile: 80, other: 45 },
 	{ month: 'February', desktop: 305, mobile: 200, other: 100 },

--- a/apps/app/src/styles.css
+++ b/apps/app/src/styles.css
@@ -72,6 +72,11 @@
 	--sidebar-ring: oklch(0.708 0 0);
 	--surface: oklch(0.98 0 0);
 	--surface-foreground: var(--foreground);
+	--chart-1: oklch(0.646 0.222 41.116);
+	--chart-2: oklch(0.6 0.118 184.714);
+	--chart-3: oklch(0.398 0.07 227.392);
+	--chart-4: oklch(0.828 0.189 84.429);
+	--chart-5: oklch(0.769 0.188 70.08);
 }
 
 .dark {
@@ -104,6 +109,11 @@
 	--sidebar-ring: oklch(0.556 0 0);
 	--surface: oklch(0.2 0 0);
 	--surface-foreground: oklch(0.708 0 0);
+	--chart-1: oklch(0.488 0.243 264.376);
+	--chart-2: oklch(0.696 0.17 162.48);
+	--chart-3: oklch(0.769 0.188 70.08);
+	--chart-4: oklch(0.627 0.265 303.9);
+	--chart-5: oklch(0.645 0.246 16.439);
 }
 
 @layer base {

--- a/libs/helm/chart/README.md
+++ b/libs/helm/chart/README.md
@@ -1,0 +1,3 @@
+# @spartan-ng/helm/chart
+
+Secondary entry point of `@spartan-ng/helm`. It can be used by importing from `@spartan-ng/helm/chart`.

--- a/libs/helm/chart/ng-package.json
+++ b/libs/helm/chart/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/helm/chart/src/index.ts
+++ b/libs/helm/chart/src/index.ts
@@ -1,0 +1,23 @@
+import { HlmChartContainer } from './lib/hlm-chart-container';
+import { HlmChartLegend } from './lib/hlm-chart-legend';
+import { HlmChartLegendContent } from './lib/hlm-chart-legend-content';
+import { HlmChartStyle } from './lib/hlm-chart-style';
+import { HlmChartTooltip } from './lib/hlm-chart-tooltip';
+import { HlmChartTooltipContent } from './lib/hlm-chart-tooltip-content';
+
+export * from './lib/hlm-chart-container';
+export * from './lib/hlm-chart-legend';
+export * from './lib/hlm-chart-legend-content';
+export * from './lib/hlm-chart-style';
+export * from './lib/hlm-chart-tooltip';
+export * from './lib/hlm-chart-tooltip-content';
+export * from './lib/hlm-chart.types';
+
+export const HlmChartImports = [
+	HlmChartContainer,
+	HlmChartTooltip,
+	HlmChartTooltipContent,
+	HlmChartLegend,
+	HlmChartLegendContent,
+	HlmChartStyle,
+] as const;

--- a/libs/helm/chart/src/lib/hlm-chart-container.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-container.ts
@@ -1,0 +1,22 @@
+import { Component, computed, inject, InjectionToken, input } from '@angular/core';
+import { HlmChartStyle } from './hlm-chart-style';
+import type { ChartConfig } from './hlm-chart.types';
+
+export const HLM_CHART_CONFIG = new InjectionToken<ChartConfig>('HLM_CHART_CONFIG');
+
+@Component({
+	selector: 'hlm-chart-container, [hlmChartContainer]',
+	imports: [HlmChartStyle],
+	providers: [{ provide: HLM_CHART_CONFIG, useFactory: () => inject(HLM_CHART_CONFIG, { optional: true }) }],
+	template: `
+		<hlm-chart-style [id]="_chartId()" [config]="config()" />
+		<div [attr.data-chart]="_chartId()" data-slot="chart" class="flex aspect-video justify-center text-xs">
+			<ng-content />
+		</div>
+	`,
+})
+export class HlmChartContainer {
+	protected readonly _chartId = computed(() => `chart-${this.id() ?? Math.random().toString(36).slice(2, 9)}`);
+	public readonly id = input<string>();
+	public readonly config = input.required<ChartConfig>();
+}

--- a/libs/helm/chart/src/lib/hlm-chart-container.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-container.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, InjectionToken, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, InjectionToken, input } from '@angular/core';
 import { HlmChartStyle } from './hlm-chart-style';
 import type { ChartConfig } from './hlm-chart.types';
 
@@ -8,6 +8,7 @@ export const HLM_CHART_CONFIG = new InjectionToken<ChartConfig>('HLM_CHART_CONFI
 	selector: 'hlm-chart-container, [hlmChartContainer]',
 	imports: [HlmChartStyle],
 	providers: [{ provide: HLM_CHART_CONFIG, useFactory: () => inject(HLM_CHART_CONFIG, { optional: true }) }],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		<hlm-chart-style [id]="_chartId()" [config]="config()" />
 		<div [attr.data-chart]="_chartId()" data-slot="chart" class="flex aspect-video justify-center text-xs">

--- a/libs/helm/chart/src/lib/hlm-chart-container.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-container.ts
@@ -1,13 +1,17 @@
-import { ChangeDetectionStrategy, Component, computed, inject, InjectionToken, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, InjectionToken, input } from '@angular/core';
 import { HlmChartStyle } from './hlm-chart-style';
 import type { ChartConfig } from './hlm-chart.types';
 
-export const HLM_CHART_CONFIG = new InjectionToken<ChartConfig>('HLM_CHART_CONFIG');
+export interface ChartConfigRef {
+	value: ChartConfig | null;
+}
+
+export const HLM_CHART_CONFIG = new InjectionToken<ChartConfigRef>('HLM_CHART_CONFIG');
 
 @Component({
 	selector: 'hlm-chart-container, [hlmChartContainer]',
 	imports: [HlmChartStyle],
-	providers: [{ provide: HLM_CHART_CONFIG, useFactory: () => inject(HLM_CHART_CONFIG, { optional: true }) }],
+	providers: [{ provide: HLM_CHART_CONFIG, useFactory: () => ({ value: null }) }],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		<hlm-chart-style [id]="_chartId()" [config]="config()" />
@@ -17,7 +21,15 @@ export const HLM_CHART_CONFIG = new InjectionToken<ChartConfig>('HLM_CHART_CONFI
 	`,
 })
 export class HlmChartContainer {
+	private readonly _configRef = inject(HLM_CHART_CONFIG);
+
 	protected readonly _chartId = computed(() => `chart-${this.id() ?? Math.random().toString(36).slice(2, 9)}`);
 	public readonly id = input<string>();
 	public readonly config = input.required<ChartConfig>();
+
+	constructor() {
+		effect(() => {
+			this._configRef.value = this.config();
+		});
+	}
 }

--- a/libs/helm/chart/src/lib/hlm-chart-container.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-container.ts
@@ -1,9 +1,9 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject, InjectionToken, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, InjectionToken, input, signal } from '@angular/core';
 import { HlmChartStyle } from './hlm-chart-style';
 import type { ChartConfig } from './hlm-chart.types';
 
 export interface ChartConfigRef {
-	value: ChartConfig | null;
+	readonly value: ChartConfig | null;
 }
 
 export const HLM_CHART_CONFIG = new InjectionToken<ChartConfigRef>('HLM_CHART_CONFIG');
@@ -11,7 +11,13 @@ export const HLM_CHART_CONFIG = new InjectionToken<ChartConfigRef>('HLM_CHART_CO
 @Component({
 	selector: 'hlm-chart-container, [hlmChartContainer]',
 	imports: [HlmChartStyle],
-	providers: [{ provide: HLM_CHART_CONFIG, useFactory: () => ({ value: null }) }],
+	providers: [
+		{
+			provide: HLM_CHART_CONFIG,
+			useFactory: (c: HlmChartContainer) => c._configRef(),
+			deps: [HlmChartContainer],
+		},
+	],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		<hlm-chart-style [id]="_chartId()" [config]="config()" />
@@ -21,15 +27,15 @@ export const HLM_CHART_CONFIG = new InjectionToken<ChartConfigRef>('HLM_CHART_CO
 	`,
 })
 export class HlmChartContainer {
-	private readonly _configRef = inject(HLM_CHART_CONFIG);
-
 	protected readonly _chartId = computed(() => `chart-${this.id() ?? Math.random().toString(36).slice(2, 9)}`);
 	public readonly id = input<string>();
 	public readonly config = input.required<ChartConfig>();
 
+	protected readonly _configRef = signal<ChartConfigRef>({ value: null });
+
 	constructor() {
 		effect(() => {
-			this._configRef.value = this.config();
+			this._configRef.set({ value: this.config() });
 		});
 	}
 }

--- a/libs/helm/chart/src/lib/hlm-chart-legend-content.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-legend-content.ts
@@ -1,7 +1,8 @@
-import { Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 @Component({
 	selector: 'hlm-chart-legend-content, [hlmChartLegendContent]',
+	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		<div
 			class="flex items-center justify-center gap-4"

--- a/libs/helm/chart/src/lib/hlm-chart-legend-content.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-legend-content.ts
@@ -1,0 +1,26 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+	selector: 'hlm-chart-legend-content, [hlmChartLegendContent]',
+	template: `
+		<div
+			class="flex items-center justify-center gap-4"
+			[class.pb-3]="verticalAlign() === 'top'"
+			[class.pt-3]="verticalAlign() !== 'top'"
+		>
+			@for (item of items(); track $index) {
+				<div class="flex items-center gap-1.5">
+					@if (!hideIcon()) {
+						<div class="h-2 w-2 shrink-0 rounded-[2px]" [style.backgroundColor]="item.color"></div>
+					}
+					<span>{{ item.label }}</span>
+				</div>
+			}
+		</div>
+	`,
+})
+export class HlmChartLegendContent {
+	public readonly items = input<Array<{ label: string; color: string }>>([]);
+	public readonly verticalAlign = input<'top' | 'bottom'>('bottom');
+	public readonly hideIcon = input<boolean>(false);
+}

--- a/libs/helm/chart/src/lib/hlm-chart-legend.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-legend.ts
@@ -1,0 +1,4 @@
+import { Directive } from '@angular/core';
+
+@Directive({ selector: '[hlmChartLegend]', exportAs: 'hlmChartLegend' })
+export class HlmChartLegend {}

--- a/libs/helm/chart/src/lib/hlm-chart-style.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-style.ts
@@ -1,0 +1,36 @@
+import { Component, computed, input } from '@angular/core';
+import type { ChartConfig } from './hlm-chart.types';
+
+const THEMES: Record<string, string> = { light: '', dark: '.dark' };
+
+@Component({
+	selector: 'hlm-chart-style',
+	template: `
+		<span #span hidden></span>
+	`,
+})
+export class HlmChartStyle {
+	public readonly id = input.required<string>();
+	public readonly config = input.required<ChartConfig>();
+
+	protected readonly _styleContent = computed(() => {
+		const cfg = this.config();
+		const id = this.id();
+		const colorConfig = Object.entries(cfg).filter(([, v]) => v.theme ?? v.color);
+
+		if (!colorConfig.length) return '';
+
+		return Object.entries(THEMES)
+			.map(
+				([theme, prefix]) =>
+					`${prefix} [data-chart=${id}] {\n${colorConfig
+						.map(([key, itemConfig]) => {
+							const color = itemConfig.theme?.[theme] ?? itemConfig.color;
+							return color ? `  --color-${key}: ${color};` : null;
+						})
+						.filter(Boolean)
+						.join('\n')}\n}`,
+			)
+			.join('\n');
+	});
+}

--- a/libs/helm/chart/src/lib/hlm-chart-style.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-style.ts
@@ -20,7 +20,6 @@ const THEMES: Record<string, string> = { light: '', dark: '.dark' };
 export class HlmChartStyle {
 	private readonly _renderer = inject(Renderer2);
 	private readonly _host = inject(ElementRef).nativeElement as HTMLElement;
-	private readonly _styleElement: HTMLStyleElement | null = null;
 
 	public readonly id = input.required<string>();
 	public readonly config = input.required<ChartConfig>();
@@ -35,7 +34,7 @@ export class HlmChartStyle {
 		return Object.entries(THEMES)
 			.map(
 				([theme, prefix]) =>
-					`${prefix} [data-chart=${id}] {\n${colorConfig
+					`${prefix} [data-chart="${id}"] {\n${colorConfig
 						.map(([key, itemConfig]) => {
 							const color = itemConfig.theme?.[theme] ?? itemConfig.color;
 							return color ? `  --color-${key}: ${color};` : null;
@@ -49,7 +48,6 @@ export class HlmChartStyle {
 	constructor() {
 		const styleEl = this._renderer.createElement('style');
 		this._renderer.appendChild(this._host, styleEl);
-		this._styleElement = styleEl;
 
 		effect(() => {
 			const content = this._styleContent();

--- a/libs/helm/chart/src/lib/hlm-chart-style.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-style.ts
@@ -1,10 +1,11 @@
-import { Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import type { ChartConfig } from './hlm-chart.types';
 
 const THEMES: Record<string, string> = { light: '', dark: '.dark' };
 
 @Component({
 	selector: 'hlm-chart-style',
+	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		<span #span hidden></span>
 	`,

--- a/libs/helm/chart/src/lib/hlm-chart-style.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-style.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, input, Renderer2 } from '@angular/core';
+import {
+	ChangeDetectionStrategy,
+	Component,
+	computed,
+	effect,
+	ElementRef,
+	inject,
+	input,
+	Renderer2,
+} from '@angular/core';
 import type { ChartConfig } from './hlm-chart.types';
 
 const THEMES: Record<string, string> = { light: '', dark: '.dark' };
@@ -11,7 +20,7 @@ const THEMES: Record<string, string> = { light: '', dark: '.dark' };
 export class HlmChartStyle {
 	private readonly _renderer = inject(Renderer2);
 	private readonly _host = inject(ElementRef).nativeElement as HTMLElement;
-	private _styleElement: HTMLStyleElement | null = null;
+	private readonly _styleElement: HTMLStyleElement | null = null;
 
 	public readonly id = input.required<string>();
 	public readonly config = input.required<ChartConfig>();

--- a/libs/helm/chart/src/lib/hlm-chart-style.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-style.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, input, Renderer2 } from '@angular/core';
 import type { ChartConfig } from './hlm-chart.types';
 
 const THEMES: Record<string, string> = { light: '', dark: '.dark' };
@@ -6,11 +6,13 @@ const THEMES: Record<string, string> = { light: '', dark: '.dark' };
 @Component({
 	selector: 'hlm-chart-style',
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	template: `
-		<span #span hidden></span>
-	`,
+	template: ``,
 })
 export class HlmChartStyle {
+	private readonly _renderer = inject(Renderer2);
+	private readonly _host = inject(ElementRef).nativeElement as HTMLElement;
+	private _styleElement: HTMLStyleElement | null = null;
+
 	public readonly id = input.required<string>();
 	public readonly config = input.required<ChartConfig>();
 
@@ -34,4 +36,17 @@ export class HlmChartStyle {
 			)
 			.join('\n');
 	});
+
+	constructor() {
+		const styleEl = this._renderer.createElement('style');
+		this._renderer.appendChild(this._host, styleEl);
+		this._styleElement = styleEl;
+
+		effect(() => {
+			const content = this._styleContent();
+			if (styleEl.textContent !== content) {
+				styleEl.textContent = content;
+			}
+		});
+	}
 }

--- a/libs/helm/chart/src/lib/hlm-chart-tooltip-content.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-tooltip-content.ts
@@ -1,8 +1,9 @@
-import { Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import type { ChartTooltipIndicator } from './hlm-chart.types';
 
 @Component({
 	selector: 'hlm-chart-tooltip-content, [hlmChartTooltipContent]',
+	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		@if (active()) {
 			<div class="spartan-chart-tooltip grid min-w-[8rem] items-start gap-1.5">

--- a/libs/helm/chart/src/lib/hlm-chart-tooltip-content.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-tooltip-content.ts
@@ -1,0 +1,43 @@
+import { Component, input } from '@angular/core';
+import type { ChartTooltipIndicator } from './hlm-chart.types';
+
+@Component({
+	selector: 'hlm-chart-tooltip-content, [hlmChartTooltipContent]',
+	template: `
+		@if (active()) {
+			<div class="spartan-chart-tooltip grid min-w-[8rem] items-start gap-1.5">
+				@if (!hideLabel() && label()) {
+					<div class="font-medium">{{ label() }}</div>
+				}
+				<div class="grid gap-1.5">
+					@for (item of items(); track $index) {
+						<div class="flex w-full flex-wrap items-stretch gap-2" [class.items-center]="indicator() === 'dot'">
+							@if (!hideIndicator()) {
+								<div
+									class="shrink-0 rounded-[2px]"
+									[class]="_indicatorCssClass()"
+									[style.backgroundColor]="item.color"
+									[style.borderColor]="item.color"
+								></div>
+							}
+							<div class="flex flex-1 items-center justify-between leading-none">
+								<span class="text-muted-foreground">{{ item.label }}</span>
+								<span class="text-foreground font-mono font-medium tabular-nums">{{ item.value }}</span>
+							</div>
+						</div>
+					}
+				</div>
+			</div>
+		}
+	`,
+})
+export class HlmChartTooltipContent {
+	public readonly active = input<boolean>(false);
+	public readonly label = input<string>('');
+	public readonly items = input<Array<{ label: string; value: string | number; color: string }>>([]);
+	public readonly indicator = input<ChartTooltipIndicator>('dot');
+	public readonly hideLabel = input<boolean>(false);
+	public readonly hideIndicator = input<boolean>(false);
+
+	protected readonly _indicatorCssClass = input<string>('h-2.5 w-2.5', { alias: 'indicatorCssClass' });
+}

--- a/libs/helm/chart/src/lib/hlm-chart-tooltip.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-tooltip.ts
@@ -1,0 +1,4 @@
+import { Directive } from '@angular/core';
+
+@Directive({ selector: '[hlmChartTooltip]', exportAs: 'hlmChartTooltip' })
+export class HlmChartTooltip {}

--- a/libs/helm/chart/src/lib/hlm-chart.types.ts
+++ b/libs/helm/chart/src/lib/hlm-chart.types.ts
@@ -3,7 +3,9 @@ export type ChartConfig = Record<
 	{
 		label?: string;
 		icon?: string;
-	} & ({ color?: string; theme?: never } | { color?: never; theme?: Record<string, string> })
+		color?: string;
+		theme?: Record<string, string>;
+	}
 >;
 
 export type ChartTooltipIndicator = 'dot' | 'line' | 'dashed';

--- a/libs/helm/chart/src/lib/hlm-chart.types.ts
+++ b/libs/helm/chart/src/lib/hlm-chart.types.ts
@@ -1,0 +1,9 @@
+export type ChartConfig = Record<
+	string,
+	{
+		label?: string;
+		icon?: string;
+	} & ({ color?: string; theme?: never } | { color?: never; theme?: Record<string, string> })
+>;
+
+export type ChartTooltipIndicator = 'dot' | 'line' | 'dashed';

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -1352,6 +1352,122 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
       },
     },
   },
+  "chart": {
+    "helm": {
+      "HlmChartContainer": {
+        "inputs": [
+          {
+            "name": "id",
+            "required": false,
+            "type": "string",
+          },
+          {
+            "name": "config",
+            "required": true,
+            "type": "ChartConfig",
+          },
+        ],
+        "models": [],
+        "outputs": [],
+        "selector": "hlm-chart-container, [hlmChartContainer]",
+      },
+      "HlmChartLegend": {
+        "exportAs": "hlmChartLegend",
+        "inputs": [],
+        "models": [],
+        "outputs": [],
+        "selector": "[hlmChartLegend]",
+      },
+      "HlmChartLegendContent": {
+        "inputs": [
+          {
+            "name": "items",
+            "required": false,
+            "type": "Array<{ label: string; color: string }>",
+          },
+          {
+            "name": "verticalAlign",
+            "required": false,
+            "type": "'top' | 'bottom'",
+          },
+          {
+            "name": "hideIcon",
+            "required": false,
+            "type": "boolean",
+          },
+        ],
+        "models": [],
+        "outputs": [],
+        "selector": "hlm-chart-legend-content, [hlmChartLegendContent]",
+      },
+      "HlmChartStyle": {
+        "inputs": [
+          {
+            "name": "id",
+            "required": true,
+            "type": "string",
+          },
+          {
+            "name": "config",
+            "required": true,
+            "type": "ChartConfig",
+          },
+        ],
+        "models": [],
+        "outputs": [],
+        "selector": "hlm-chart-style",
+      },
+      "HlmChartTooltip": {
+        "exportAs": "hlmChartTooltip",
+        "inputs": [],
+        "models": [],
+        "outputs": [],
+        "selector": "[hlmChartTooltip]",
+      },
+      "HlmChartTooltipContent": {
+        "inputs": [
+          {
+            "name": "active",
+            "required": false,
+            "type": "boolean",
+          },
+          {
+            "name": "label",
+            "required": false,
+            "type": "string",
+          },
+          {
+            "name": "items",
+            "required": false,
+            "type": "Array<{ label: string; value: string | number; color: string }>",
+          },
+          {
+            "name": "indicator",
+            "required": false,
+            "type": "ChartTooltipIndicator",
+          },
+          {
+            "name": "hideLabel",
+            "required": false,
+            "type": "boolean",
+          },
+          {
+            "name": "hideIndicator",
+            "required": false,
+            "type": "boolean",
+          },
+          {
+            "name": "indicatorCssClass",
+            "required": false,
+            "type": "string",
+          },
+        ],
+        "models": [],
+        "outputs": [],
+        "selector": "hlm-chart-tooltip-content, [hlmChartTooltipContent]",
+      },
+    },
+  },
   "checkbox": {
     "brain": {
       "BrnCheckbox": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"@testing-library/cypress": "^10.0.2",
 		"@trpc/client": "10.45.2",
 		"@trpc/server": "10.45.2",
+		"chart.js": "^4.5.1",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"drizzle-orm": "^0.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@trpc/server':
         specifier: 10.45.2
         version: 10.45.2
+      chart.js:
+        specifier: ^4.5.1
+        version: 4.5.1
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3551,6 +3554,9 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
+
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -7124,6 +7130,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  chart.js@4.5.1:
+    resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
+    engines: {pnpm: '>=8'}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -17434,6 +17444,8 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  '@kurkle/color@0.3.4': {}
+
   '@leichtgewicht/ip-codec@2.0.5': {}
 
   '@listr2/prompt-adapter-inquirer@3.0.5(@inquirer/prompts@7.10.1(@types/node@22.6.2))(@types/node@22.6.2)(listr2@9.0.5)':
@@ -21773,6 +21785,10 @@ snapshots:
   char-regex@1.0.2: {}
 
   chardet@2.1.1: {}
+
+  chart.js@4.5.1:
+    dependencies:
+      '@kurkle/color': 0.3.4
 
   check-error@2.1.1: {}
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -87,6 +87,7 @@
 			"@spartan-ng/helm/button": ["libs/helm/button/src/index.ts"],
 			"@spartan-ng/helm/button-group": ["libs/helm/button-group/src/index.ts"],
 			"@spartan-ng/helm/calendar": ["libs/helm/calendar/src/index.ts"],
+			"@spartan-ng/helm/chart": ["libs/helm/chart/src/index.ts"],
 			"@spartan-ng/helm/card": ["libs/helm/card/src/index.ts"],
 			"@spartan-ng/helm/carousel": ["libs/helm/carousel/src/index.ts"],
 			"@spartan-ng/helm/checkbox": ["libs/helm/checkbox/src/index.ts"],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] sidebar

### Others

- [x] repo

## What is the current behavior?

The blocks page only has 2 sidebar blocks (sticky-header and inset). shadcn/ui ships 14 sidebar block variants that showcase different sidebar patterns — the blocks page is missing most of them.

## What is the new behavior?

Added 13 new sidebar block variants ported from shadcn's React implementations to Angular:

- **sidebar-01**: Simple sidebar with version switcher and search form
- **sidebar-02**: Collapsible sidebar groups with chevron toggle
- **sidebar-03**: Branded header with flat navigation and sub-items
- **sidebar-04**: Floating variant sidebar
- **sidebar-05**: Collapsible groups with Plus/Minus icons and search
- **sidebar-06**: Dropdown menu navigation with newsletter opt-in form
- **sidebar-07**: Icon collapse mode with TeamSwitcher, nav, projects, and user dropdown
- **sidebar-09**: Dual sidebar layout (mail client with icon nav + mail list)
- **sidebar-10**: Notion-like workspace sidebar with favorites and workspaces
- **sidebar-11**: File tree sidebar with collapsible folders
- **sidebar-12**: Calendar sidebar with inline date picker and checkbox groups
- **sidebar-14**: Right-side table of contents (`side="right"`)
- **sidebar-15**: Dual sidebar (Notion workspace left + calendar right)

New shared components: `team-switcher`, `search-form`, `version-switcher`, `nav-favorites`, `nav-workspaces`, `nav-actions`, `calendars`, `date-picker`, `nav-main-flat`

All blocks use existing spartan helm sidebar primitives (`hlm-sidebar`, `hlm-sidebar-menu-*`, `hlm-sidebar-group-*`, etc.) — no changes to the underlying component library.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- TypeScript typecheck passes clean
- Lint passes with 0 errors (12 pre-existing warnings in unrelated files)
- Branch: `feat/sidebar-blocks`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Charts tab that routes to a charts gallery page featuring 50+ chart preview blocks (area, bar, line, pie/donut, radar, radial, and tooltip variants).
  * Introduced reusable chart UI building blocks (container, legend, tooltip, and styling) with shared chart configuration and tooltip indicator support.

* **Chores**
  * Added the `chart.js` dependency.
  * Updated light/dark chart color theme variables for consistent styling.
  * Added a Helm chart secondary entry point (with documentation) and TypeScript path mapping for the chart package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->