### PR TITLE
docs: add tailwind configuration guide for Jetbrains-based IDEs

### DIFF
--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation-snippets.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation-snippets.ts
@@ -71,7 +71,7 @@ export const cssVariables = `
 }
 `;
 
-export const tailwindIntellisense = `
+export const tailwindAutocompletion = `
 {
   "tailwindCSS.classFunctions": ["hlm", "cva", "classes"]
 }

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/installation.page.ts
@@ -21,8 +21,8 @@ import { metaWith } from '../../../../shared/meta/meta.util';
 import {
 	cssVariables,
 	spartanPresetImport,
+	tailwindAutocompletion,
 	tailwindImports,
-	tailwindIntellisense,
 	tailwindPrettierSorting,
 } from './installation-snippets';
 
@@ -196,7 +196,7 @@ export const routeMeta: RouteMeta = {
 
 			<spartan-section-sub-heading id="editor-setup">Editor Setup (Optional)</spartan-section-sub-heading>
 
-			<h3 spartanH4 id="intellisense">IntelliSense</h3>
+			<h3 spartanH4 id="tailwind-autocompletion">Tailwind autocompletion</h3>
 			<p class="${hlmP}">
 				Enable Tailwind autocompletion in
 				<code class="${hlmCode}">hlm</code>
@@ -206,6 +206,8 @@ export const routeMeta: RouteMeta = {
 				<code class="${hlmCode}">classes</code>
 				functions:
 			</p>
+
+			<h4 spartanH4>Intellisense (VSCode)</h4>
 
 			<ol class="my-6 ml-6 list-decimal [&>li]:mt-2">
 				<li>
@@ -227,7 +229,20 @@ export const routeMeta: RouteMeta = {
 				</li>
 			</ol>
 
-			<spartan-code class="mt-4" [code]="_tailwindIntellisense" />
+			<spartan-code class="mt-4" [code]="_tailwindAutocompletion" />
+
+			<h4 spartanH4>Tailwind CSS plugin (Jetbrains)</h4>
+
+			<ol class="my-6 ml-6 list-decimal [&>li]:mt-2">
+				<li>
+					Open Tailwind configuration (
+					<code>Settings > Language & Frameworks > Style sheets > Tailwind CSS</code>
+					)
+				</li>
+				<li>Add this to the configuration:</li>
+			</ol>
+
+			<spartan-code class="mt-4" [code]="_tailwindAutocompletion" />
 
 			<h3 spartanH4 id="sorting-classes" class="mt-8">Class Sorting</h3>
 			<p class="${hlmP}">Automatically sort Tailwind classes with Prettier:</p>
@@ -243,6 +258,13 @@ export const routeMeta: RouteMeta = {
 					>
 						prettier-plugin-tailwindcss
 					</a>
+				</li>
+				<li>
+					(Optional) For Jetbrains-based IDEs: configure Prettier. Go to
+					<code>Settings > Language & Frameworks > JavaScript > Prettier</code>
+					, check "Automatic Prettier configuration" and add
+					<code>html</code>
+					in the "Run for files" pattern.
 				</li>
 				<li>
 					Add this to your
@@ -266,6 +288,6 @@ export default class InstallationPage {
 	protected readonly _tailwindImports = tailwindImports;
 	protected readonly _spartanPresetImport = spartanPresetImport;
 	protected readonly _cssVariables = cssVariables;
-	protected readonly _tailwindIntellisense = tailwindIntellisense;
+	protected readonly _tailwindAutocompletion = tailwindAutocompletion;
 	protected readonly _tailwindPrettierSorting = tailwindPrettierSorting;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

Currently, only VSCode configuration of Tailwind is explained.

Closes #1481 

## What is the new behavior?

This PR adds a guide to setup Tailwind CSS on Jetbrains-based IDEs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the installation page wording from “IntelliSense” to “Tailwind autocompletion.”
  * Restructured the editor setup section to add clearer, dedicated guidance for VS Code and Jetbrains-based IDEs.
  * Updated the Tailwind configuration snippet shown in the page to match the new autocompletion terminology.
  * Expanded the class sorting guidance with additional Prettier configuration details for Jetbrains IDEs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->