### PR TITLE
fix(radio-group): restore native tab behavior

### DIFF
--- a/libs/brain/radio-group/src/lib/brn-radio.spec.ts
+++ b/libs/brain/radio-group/src/lib/brn-radio.spec.ts
@@ -1,8 +1,77 @@
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { render } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 import { BrnRadioGroupImports } from '../index';
 
 describe('BrnRadioComponent', () => {
+	it('should focus the first radio when tabbing into a group reset to no selected value', async () => {
+		const user = userEvent.setup();
+		const { getAllByRole, getByText, rerender } = await render(
+			`
+			<button type="button">before</button>
+			<div brnRadioGroup [value]="value">
+				<brn-radio value="16.1.4">16.1.4</brn-radio>
+				<brn-radio value="16.0.0">16.0.0</brn-radio>
+				<brn-radio value="15.3.0">15.3.0</brn-radio>
+			</div>
+			<button type="button">after</button>
+			`,
+			{
+				imports: [BrnRadioGroupImports],
+				componentProperties: {
+					value: '16.0.0',
+				},
+			},
+		);
+
+		const radioButtons = getAllByRole('radio') as HTMLInputElement[];
+		getByText('before').focus();
+		await user.tab();
+		expect(radioButtons[1]).toHaveFocus();
+
+		await rerender({
+			componentProperties: {
+				value: null,
+			},
+		});
+
+		getByText('before').focus();
+		await user.tab();
+		expect(radioButtons[0]).toHaveFocus();
+
+		await user.tab();
+		expect(getByText('after')).toHaveFocus();
+	});
+
+	it('should focus the first enabled radio when tabbing into a group with no selected enabled radio', async () => {
+		const user = userEvent.setup();
+		const { getAllByRole, getByText } = await render(
+			`
+			<button type="button">before</button>
+			<div brnRadioGroup [value]="value">
+				<brn-radio disabled value="16.1.4">16.1.4</brn-radio>
+				<brn-radio value="16.0.0">16.0.0</brn-radio>
+				<brn-radio value="15.3.0">15.3.0</brn-radio>
+			</div>
+			<button type="button">after</button>
+			`,
+			{
+				imports: [BrnRadioGroupImports],
+				componentProperties: {
+					value: '',
+				},
+			},
+		);
+
+		const radioButtons = getAllByRole('radio') as HTMLInputElement[];
+		getByText('before').focus();
+		await user.tab();
+		expect(radioButtons[1]).toHaveFocus();
+
+		await user.tab();
+		expect(getByText('after')).toHaveFocus();
+	});
+
 	it('should disable the radio button when disabled is true (reactive forms)', async () => {
 		const form = new FormGroup({
 			radioGroup: new FormControl('16.1.4'),

--- a/libs/brain/radio-group/src/lib/brn-radio.spec.ts
+++ b/libs/brain/radio-group/src/lib/brn-radio.spec.ts
@@ -43,9 +43,9 @@ describe('BrnRadioComponent', () => {
 		expect(getByText('after')).toHaveFocus();
 	});
 
-	it('should focus the first enabled radio when tabbing into a group with no selected enabled radio', async () => {
+	it('should focus the first enabled radio when tabbing into a reset group with a disabled first radio', async () => {
 		const user = userEvent.setup();
-		const { getAllByRole, getByText } = await render(
+		const { getAllByRole, getByText, rerender } = await render(
 			`
 			<button type="button">before</button>
 			<div brnRadioGroup [value]="value">
@@ -58,12 +58,22 @@ describe('BrnRadioComponent', () => {
 			{
 				imports: [BrnRadioGroupImports],
 				componentProperties: {
-					value: '',
+					value: '15.3.0',
 				},
 			},
 		);
 
 		const radioButtons = getAllByRole('radio') as HTMLInputElement[];
+		getByText('before').focus();
+		await user.tab();
+		expect(radioButtons[2]).toHaveFocus();
+
+		await rerender({
+			componentProperties: {
+				value: null,
+			},
+		});
+
 		getByText('before').focus();
 		await user.tab();
 		expect(radioButtons[1]).toHaveFocus();

--- a/libs/brain/radio-group/src/lib/brn-radio.ts
+++ b/libs/brain/radio-group/src/lib/brn-radio.ts
@@ -58,7 +58,6 @@ const INPUT_POST_FIX = '-input';
 			[attr.id]="_inputId()"
 			[checked]="_checked()"
 			[disabled]="_disabledState()"
-			[tabIndex]="_tabIndex()"
 			[attr.name]="_radioGroup.name()"
 			[attr.value]="value()"
 			[required]="required()"
@@ -93,18 +92,6 @@ export class BrnRadio<T = unknown> implements OnDestroy {
 	 * Whether the radio button is checked.
 	 */
 	protected readonly _checked = computed(() => this._radioGroup.value() === this.value());
-
-	protected readonly _tabIndex = computed(() => {
-		const disabled = this._disabledState();
-		const checked = this._checked();
-		const hasSelectedRadio = this._radioGroup.value() !== undefined;
-		const isFirstRadio = this._radioGroup.radioButtons()[0] === this;
-
-		if (disabled || (!checked && (hasSelectedRadio || !isFirstRadio))) {
-			return -1;
-		}
-		return 0;
-	});
 
 	/**
 	 * The unique ID for the radio button input. If none is supplied, it will be auto-generated.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [x] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

Closes #1491

When a radio group is cleared to no selected value, such as the default Storybook example after clicking `Reset`, every radio input receives `tabindex="-1"`. That leaves the group with no tabbable radio, so keyboard users cannot tab back into the group to choose a new option.

The root cause is the component's custom `_tabIndex` computation. It treats any group value other than `undefined` as meaning there is a selected radio. Resetting the example sets the value to `null`, which means no radio is checked, but the logic still considers the group selected and assigns `-1` to every unchecked radio.

## What is the new behavior?

`BrnRadio` no longer overrides the native radio input's tab order with a custom `[tabIndex]` binding.

Because Spartan radio groups render real same-name `<input type="radio">` controls, the browser already provides the native radio-group tab behavior: tabbing into a group focuses the checked radio, and when none is checked the group still has an enabled radio in the tab order. Removing the custom roving-tabindex logic restores that native behavior and avoids duplicating it incorrectly in Angular state.

The regression tests now verify the keyboard behavior directly with `userEvent.tab()`:

- a selected group can be reset to no selected value and still receive focus on the first radio
- a group whose first option is disabled focuses the first enabled radio when no enabled radio is selected
- tabbing again leaves the group instead of trapping focus

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

No docs were updated because this fixes the implementation to match the expected native keyboard behavior for the existing component API.

Validation performed:

- `pnpm vitest run libs/brain/radio-group/src/lib/brn-radio.spec.ts --config libs/brain/vite.config.mts`
- `pnpm nx lint brain` passes with existing unrelated warnings
- `pnpm nx build brain`
- `git diff --check`

Manual verification:

- Confirmed `main` reproduces the bug in Storybook: after `Reset`, all radios have `tabindex="-1"`
- Confirmed the fix branch removes explicit `tabindex` attributes and restores keyboard access after reset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added keyboard-navigation focus tests for the radio group component, including cases where the selected value is cleared and where the first option is disabled.
* **Refactor**
  * Adjusted radio tab focus behavior by changing how focusability/tab order is determined within the radio component, aligning tabbing with the expected keyboard navigation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->