### PR TITLE
fix(select): select option with a falsy value on enter keypress

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/select/select.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/select/select.cy.ts
@@ -378,4 +378,23 @@ describe('select', () => {
 			cy.get('hlm-select-scroll-down').should('exist');
 		});
 	});
+
+	describe('falsy value', () => {
+		beforeEach(() => {
+			cy.visit('/iframe.html?id=select--falsy-value');
+			cy.injectAxe();
+		});
+
+		it('should select an option with a falsy value on enter keypress', () => {
+			cy.get('[brnselecttrigger]').click();
+
+			cy.realPress('ArrowDown');
+			cy.realPress('Enter');
+
+			// the falsy value is committed and the panel closes
+			cy.get('hlm-select-content').should('not.exist');
+			cy.get('[brnselecttrigger]').should('have.attr', 'aria-expanded', 'false');
+			cy.get('[data-testid="value"]').should('contain.text', 'false');
+		});
+	});
 });

--- a/apps/ui-storybook/stories/select.stories.ts
+++ b/apps/ui-storybook/stories/select.stories.ts
@@ -775,3 +775,23 @@ class DynamicOptionsMultiSelectComponent implements OnInit {
 		]);
 	}
 }
+
+export const FalsyValue: Story = {
+	render: () => ({
+		props: { allowPayments: new FormControl<boolean | null>(null) },
+		template: /* HTML */ `
+			<div class="mb-3">
+				<pre data-testid="value">Form Control Value: {{ allowPayments.value | json }}</pre>
+			</div>
+			<hlm-select class="w-56" [formControl]="allowPayments">
+				<hlm-select-trigger>
+					<hlm-select-value placeholder="Select an option" />
+				</hlm-select-trigger>
+				<hlm-select-content *hlmSelectPortal>
+					<hlm-select-item [value]="true">Allowed</hlm-select-item>
+					<hlm-select-item [value]="false">Not allowed</hlm-select-item>
+				</hlm-select-content>
+			</hlm-select>
+		`,
+	}),
+};

--- a/libs/brain/select/src/lib/brn-select-multiple.ts
+++ b/libs/brain/select/src/lib/brn-select-multiple.ts
@@ -175,7 +175,7 @@ export class BrnSelectMultiple<T> implements BrnSelectBase<T>, ControlValueAcces
 
 		const value = this.keyManager.activeItem?.value();
 
-		if (value) {
+		if (value !== null && value !== undefined) {
 			this.select(value);
 		} else {
 			this.close();

--- a/libs/brain/select/src/lib/brn-select.ts
+++ b/libs/brain/select/src/lib/brn-select.ts
@@ -160,7 +160,7 @@ export class BrnSelect<T> implements BrnSelectBase<T>, ControlValueAccessor {
 
 		const value = this.keyManager.activeItem?.value();
 
-		if (value) {
+		if (value !== null && value !== undefined) {
 			this.select(value);
 		} else {
 			this.close();


### PR DESCRIPTION
`selectActiveItem()` guarded the commit with a truthiness check (`if (value)`), so an option whose value is falsy (`false`, `0`, `''`) was dropped: pressing Enter just closed the panel without selecting. It now checks `value !== null && value !== undefined`, so a defined falsy value is committed while a missing active item still closes. Applies to both `BrnSelect` and `BrnSelectMultiple`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] select

## What is the current behavior?

In a single or multiple `hlm-select` whose options carry a falsy value (e.g. a boolean `[value]="false"`, `0`, or an empty string), that option cannot be selected with the keyboard.

Steps to reproduce:
1. Open the select.
2. Arrow to the option whose value is falsy (e.g. `false`).
3. Press Enter.

Expected: the value is committed. Actual: the panel closes and the value is unchanged. Selecting the same option with the **mouse** works, and options with truthy values select fine with Enter — so it's specific to keyboard selection of falsy values.

Root cause: `BrnSelect.selectActiveItem()` (and `BrnSelectMultiple.selectActiveItem()`) guard the commit with `if (value)`, so a defined-but-falsy active value falls into the `else` branch and only closes the panel.

## What is the new behavior?

Options with a defined falsy value are now committed on Enter. The guard uses `value !== null && value !== undefined`, so `false` / `0` / `''` select correctly, while a genuinely missing active item still closes the panel. Added a `Select / Falsy Value` Storybook story and a Cypress e2e test covering the regression.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Reproduced and verified against the new `select--falsy-value` story.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed select component to properly handle and allow selection of falsy values (such as 0, false, or empty string).

* **Tests**
  * Added test coverage validating select functionality with falsy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->