### PR TITLE
feat(utils): add provideSpartanHlm utility to fix CDK overlay z-index…

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(sonner)/sonner-template.ts
+++ b/apps/app/src/app/pages/(components)/components/(sonner)/sonner-template.ts
@@ -15,3 +15,16 @@ import { HlmToasterImports } from '@spartan-ng/helm/sonner';
 })
 export class App {}
 `;
+
+export const appConfigCode = `
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { provideSpartanHlm } from '@spartan-ng/helm/utils';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideSpartanHlm(),
+    // ... other providers
+  ],
+};
+`;

--- a/apps/app/src/app/pages/(components)/components/(sonner)/sonner.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(sonner)/sonner.page.ts
@@ -18,7 +18,7 @@ import { metaWith } from '../../../../shared/meta/meta.util';
 import { SonnerDescriptionExample } from './sonner--description.example';
 import { SonnerPositionExample } from './sonner--position.example';
 import { SonnerTypesExample } from './sonner--types.example';
-import { defaultTemplate } from './sonner-template';
+import { appConfigCode, defaultTemplate } from './sonner-template';
 import { SonnerPreview, defaultImports, defaultSkeleton } from './sonner.preview';
 
 export const routeMeta: RouteMeta = {
@@ -68,6 +68,19 @@ export const routeMeta: RouteMeta = {
 			</p>
 
 			<spartan-code class="mt-6" fileName="src/app/app.ts" [code]="_defaultTemplate" />
+
+			<spartan-section-sub-heading id="angular-21-compatibility">Angular 21 Compatibility</spartan-section-sub-heading>
+			<p class="${hlmP}">
+				If you are using Angular 21+, the CDK overlay now defaults to using the
+				<code class="${hlmCode}">popover</code>
+				attribute, which causes overlay-based components (sheets, dialogs, etc.) to always render above
+				<code class="${hlmCode}">&lt;hlm-toaster&gt;</code>
+				. To fix this, add
+				<code class="${hlmCode}">provideSpartanHlm()</code>
+				to your application config:
+			</p>
+
+			<spartan-code class="mt-6" fileName="src/app/app.config.ts" [code]="_appConfigCode" />
 
 			<spartan-section-sub-heading id="usage">Usage</spartan-section-sub-heading>
 			<div class="mt-6 space-y-4">
@@ -122,4 +135,5 @@ export default class SonnerPage {
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 	protected readonly _defaultTemplate = defaultTemplate;
+	protected readonly _appConfigCode = appConfigCode;
 }

--- a/libs/helm/utils/src/index.ts
+++ b/libs/helm/utils/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/hlm';
+export * from './lib/provide-spartan-hlm';

--- a/libs/helm/utils/src/lib/provide-spartan-hlm.spec.ts
+++ b/libs/helm/utils/src/lib/provide-spartan-hlm.spec.ts
@@ -1,0 +1,32 @@
+import { OVERLAY_DEFAULT_CONFIG } from '@angular/cdk/overlay';
+import { TestBed } from '@angular/core/testing';
+import { provideSpartanHlm } from './provide-spartan-hlm';
+
+describe('provideSpartanHlm', () => {
+	it('should provide OVERLAY_DEFAULT_CONFIG with usePopover set to false', () => {
+		TestBed.configureTestingModule({
+			providers: [provideSpartanHlm()],
+		});
+
+		const config = TestBed.inject(OVERLAY_DEFAULT_CONFIG);
+		expect(config).toBeDefined();
+		expect(config.usePopover).toBe(false);
+	});
+
+	it('should return EnvironmentProviders', () => {
+		const providers = provideSpartanHlm();
+		expect(providers).toBeDefined();
+	});
+
+	it('should be compatible with other providers', () => {
+		TestBed.configureTestingModule({
+			providers: [provideSpartanHlm(), { provide: 'custom-token', useValue: 'custom-value' }],
+		});
+
+		const config = TestBed.inject(OVERLAY_DEFAULT_CONFIG);
+		const customToken = TestBed.inject('custom-token' as never);
+
+		expect(config.usePopover).toBe(false);
+		expect(customToken).toBe('custom-value');
+	});
+});

--- a/libs/helm/utils/src/lib/provide-spartan-hlm.ts
+++ b/libs/helm/utils/src/lib/provide-spartan-hlm.ts
@@ -1,0 +1,34 @@
+import { OVERLAY_DEFAULT_CONFIG } from '@angular/cdk/overlay';
+import { type EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
+
+/**
+ * Provides default configuration for Spartan Helm components.
+ *
+ * This utility configures the Angular CDK overlay to disable the `usePopover`
+ * behavior introduced in Angular 21, which causes CDK overlay-based components
+ * (sheets, dialogs, tooltips, etc.) to render above `position: fixed` elements
+ * like `<hlm-toaster>`.
+ *
+ * @returns {EnvironmentProviders} Environment providers to be added to the application config.
+ *
+ * @example
+ * ```ts
+ * // app.config.ts
+ * import { provideSpartanHlm } from '@spartan-ng/helm/utils';
+ *
+ * export const appConfig: ApplicationConfig = {
+ *   providers: [
+ *     provideSpartanHlm(),
+ *     // ... other providers
+ *   ],
+ * };
+ * ```
+ */
+export function provideSpartanHlm(): EnvironmentProviders {
+	return makeEnvironmentProviders([
+		{
+			provide: OVERLAY_DEFAULT_CONFIG,
+			useValue: { usePopover: false },
+		},
+	]);
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [x] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In Angular 21, the CDK overlay defaults to using the `popover` attribute, which causes overlay-based components (sheets, dialogs, tooltips) to always render above `position: fixed` elements like `<hlm-toaster>`. This means toasts are hidden behind CDK overlay-based components with no built-in workaround.

Closes #1280

## What is the new behavior?

Adds `provideSpartanHlm()` utility to `@spartan-ng/helm/utils` that configures `OVERLAY_DEFAULT_CONFIG` with `usePopover: false`. Users can add this provider to their `app.config.ts` to fix the z-index conflict between the toaster and CDK overlay-based components.

Also updates the sonner documentation with an "Angular 21 Compatibility" section explaining the issue and the fix.

```ts
// app.config.ts
import { provideSpartanHlm } from '@spartan-ng/helm/utils';

export const appConfig: ApplicationConfig = {
  providers: [
    provideSpartanHlm(),
    // ... other providers
  ],
};
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is a non-breaking additive change. Existing applications are not affected unless they encounter the z-index conflict with Angular 21+ CDK overlay. The utility is opt-in and exported from `@spartan-ng/helm/utils`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Angular environment provider that updates overlay defaults to keep popovers disabled for improved Angular 21 compatibility.
  * Added an application configuration snippet and surfaced it on the Sonner component page.
  * Re-exported the provider through the Helm utilities package for simpler integration.
* **Documentation**
  * Updated the Angular 21 compatibility section with the new application configuration snippet.
* **Tests**
  * Added unit tests covering overlay default overrides and correct merging behavior with existing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->