### PR TITLE
perf(drawer): improve open/close performance to match Vaul behavior

### DIFF
--- a/libs/brain/dialog/src/lib/brn-dialog.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog.ts
@@ -2,7 +2,6 @@ import { Directionality } from '@angular/cdk/bidi';
 import type { BooleanInput } from '@angular/cdk/coercion';
 import { OverlayPositionBuilder, type ScrollStrategy, ScrollStrategyOptions } from '@angular/cdk/overlay';
 import {
-	afterNextRender,
 	booleanAttribute,
 	computed,
 	DestroyRef,
@@ -134,16 +133,14 @@ export class BrnDialog<TResult = unknown, TContext extends Record<string, unknow
 		this._syncPanelClass();
 		this._syncOverlayClass();
 
-		afterNextRender(() => {
-			effect(
-				() => {
-					const state = this.state();
-					if (state === 'open') untracked(() => this.open());
-					if (state === 'closed') untracked(() => this.close());
-				},
-				{ injector: this._injector },
-			);
-		});
+		effect(
+			() => {
+				const state = this.state();
+				if (state === 'open') untracked(() => this.open());
+				if (state === 'closed') untracked(() => this.close());
+			},
+			{ injector: this._injector },
+		);
 	}
 
 	public open(): void {

--- a/libs/brain/drawer/src/lib/brn-drawer-handle.ts
+++ b/libs/brain/drawer/src/lib/brn-drawer-handle.ts
@@ -5,12 +5,11 @@ import { BrnDrawer } from './brn-drawer';
 
 const VELOCITY_THRESHOLD = 0.4;
 const DEFAULT_CLOSE_THRESHOLD = 0.25;
-const SCROLL_LOCK_TIMEOUT = 100;
 const TOUCH_SWIPE_THRESHOLD = 10;
 const MOUSE_SWIPE_THRESHOLD = 2;
-const OPEN_TIME_COOLDOWN = 500;
 const TRANSITION = 'transform 0.5s cubic-bezier(0.32, 0.72, 0, 1)';
-const OVERLAY_TRANSITION = 'opacity 0.5s cubic-bezier(0.32, 0.72, 0, 1)';
+const CLOSE_TRANSITION = 'transform 0.3s cubic-bezier(0.32, 0.72, 0, 1)';
+const OVERLAY_TRANSITION = 'opacity 0.3s cubic-bezier(0.32, 0.72, 0, 1)';
 
 function dampenValue(v: number): number {
 	return 8 * (Math.log(v + 1) - 2);
@@ -34,17 +33,13 @@ export class BrnDrawerHandle {
 	constructor() {
 		this._destroyRef.onDestroy(() => {
 			this._cleanup();
-			// Cancel any pending reset timeout: on destroy its target elements are gone, so the
-			// deferred style write is a stale no-op that also retains this directive for ~500ms.
 			this._clearResetTimeout();
 		});
 		effect(() => {
 			const state = this._brnDialogRef?.state();
 			untracked(() => {
-				if (state === 'open') {
-					this._openTime = Date.now();
-				} else if (state === 'closed') {
-					this._openTime = null;
+				if (state === 'closed') {
+					this._currentTranslate = 0;
 				}
 			});
 		});
@@ -63,8 +58,8 @@ export class BrnDrawerHandle {
 	private _isAllowedToDrag = false;
 	private _wasBeyondThreshold = false;
 
-	private _openTime: number | null = null;
-	private _lastTimeDragPrevented: number | null = null;
+	private _currentTranslate = 0;
+	private _scrollableAncestor: HTMLElement | null = null;
 	private _dragStartTime: number | null = null;
 	private _resetTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -103,15 +98,17 @@ export class BrnDrawerHandle {
 		this._dragStartTime = Date.now();
 
 		this._drawerEl.style.transition = 'none';
+		this._drawerEl.style.willChange = 'transform';
 
-		if (!this._findScrollableAncestor(event.target as HTMLElement)) {
+		this._scrollableAncestor = this._findScrollableAncestor(event.target as HTMLElement);
+		if (!this._scrollableAncestor) {
 			this._drawerEl.style.touchAction = 'none';
 		}
 
 		const overlayWrapper = this._drawerEl.closest('.cdk-global-overlay-wrapper');
 		this._backdropEl = overlayWrapper?.querySelector('.cdk-overlay-backdrop') as HTMLElement | null;
 		if (this._backdropEl) {
-			this._initialBackdropOpacity = parseFloat(getComputedStyle(this._backdropEl).opacity) || 1;
+			this._initialBackdropOpacity = parseFloat(this._backdropEl.style.opacity) || 1;
 		}
 
 		this._pointerId = event.pointerId;
@@ -159,8 +156,7 @@ export class BrnDrawerHandle {
 		const isDraggingInDirection = draggedDistance > 0;
 		const absDraggedDistance = Math.abs(draggedDistance);
 
-		if (!this._isAllowedToDrag && !this._shouldDrag(e.target ?? this._element.nativeElement, isDraggingInDirection))
-			return;
+		if (!this._isAllowedToDrag && !this._shouldDrag(isDraggingInDirection)) return;
 
 		this._isAllowedToDrag = true;
 		try {
@@ -177,8 +173,7 @@ export class BrnDrawerHandle {
 		if (isDraggingInDirection) {
 			const dampened = dampenValue(draggedDistance);
 			const translateValue = Math.min(dampened * -1, 0) * this._dimensionMultiplier;
-			const prop = this._isVertical ? 'translateY' : 'translateX';
-			this._drawerEl.style.transform = `${prop}(${translateValue}px)`;
+			this._applyTransform(translateValue);
 			if (this._backdropEl) {
 				this._backdropEl.style.opacity = String(Math.max(this._initialBackdropOpacity - progress * 0.3, 0));
 			}
@@ -188,8 +183,7 @@ export class BrnDrawerHandle {
 		e.preventDefault();
 
 		const translateValue = absDraggedDistance * this._dimensionMultiplier;
-		const prop = this._isVertical ? 'translateY' : 'translateX';
-		this._drawerEl.style.transform = `${prop}(${translateValue}px)`;
+		this._applyTransform(translateValue);
 
 		if (this._backdropEl) {
 			this._backdropEl.style.opacity = String(Math.max(this._initialBackdropOpacity - progress, 0));
@@ -204,9 +198,9 @@ export class BrnDrawerHandle {
 
 		this._drawerEl.classList.remove('vaul-dragging');
 
-		const swipeAmount = this._getTranslate();
+		const swipeAmount = this._currentTranslate;
 
-		if (!this._isAllowedToDrag || swipeAmount === null || Number.isNaN(swipeAmount)) {
+		if (!this._isAllowedToDrag) {
 			this._resetDrawer(true);
 			this._cleanup();
 			return;
@@ -247,65 +241,33 @@ export class BrnDrawerHandle {
 		this._cleanup();
 	};
 
-	private _shouldDrag(el: EventTarget, isDraggingInDirection: boolean): boolean {
+	private _applyTransform(value: number): void {
+		if (!this._drawerEl) return;
+		this._currentTranslate = value;
+		const prop = this._isVertical ? 'translateY' : 'translateX';
+		this._drawerEl.style.transform = `${prop}(${value}px)`;
+	}
+
+	private _shouldDrag(isDraggingInDirection: boolean): boolean {
 		if (this._direction === 'left' || this._direction === 'right') return true;
 
-		const now = Date.now();
+		const isAlreadyOpen = this._isPositive ? this._currentTranslate > 0 : this._currentTranslate < 0;
+		if (isAlreadyOpen) return true;
 
-		if (this._openTime !== null && now - this._openTime < OPEN_TIME_COOLDOWN) return false;
+		if (isDraggingInDirection) return false;
 
-		const currentTranslate = this._getTranslate();
-		if (this._isPositive ? currentTranslate > 0 : currentTranslate < 0) return true;
-
-		if (
-			this._lastTimeDragPrevented !== null &&
-			now - this._lastTimeDragPrevented < SCROLL_LOCK_TIMEOUT &&
-			currentTranslate === 0
-		) {
-			this._lastTimeDragPrevented = now;
-			return false;
-		}
-
-		if (isDraggingInDirection) {
-			this._lastTimeDragPrevented = now;
-			return false;
-		}
-
-		let element = el as HTMLElement | null;
-		while (element) {
-			if (element.scrollHeight > element.clientHeight) {
-				if (element.scrollTop !== 0) {
-					this._lastTimeDragPrevented = now;
-					return false;
-				}
-				if (element.getAttribute('role') === 'dialog') return true;
-			}
-			element = element.parentElement;
+		if (this._scrollableAncestor) {
+			if (this._scrollableAncestor.scrollTop !== 0) return false;
 		}
 
 		return true;
-	}
-
-	private _getTranslate(): number {
-		if (!this._drawerEl) return 0;
-		const style = getComputedStyle(this._drawerEl);
-		const transform = style.transform || (style as any).webkitTransform;
-		if (!transform || transform === 'none') return 0;
-		let mat = transform.match(/^matrix3d\((.+)\)$/);
-		if (mat) {
-			return parseFloat(mat[1].split(', ')[this._isVertical ? 13 : 12]);
-		}
-		mat = transform.match(/^matrix\((.+)\)$/);
-		if (mat) {
-			return parseFloat(mat[1].split(', ')[this._isVertical ? 5 : 4]);
-		}
-		return 0;
 	}
 
 	private _resetDrawer(animate = true): void {
 		if (this._drawerEl) {
 			this._drawerEl.style.transition = animate ? TRANSITION : 'none';
 			this._drawerEl.style.transform = '';
+			this._currentTranslate = 0;
 		}
 		if (this._backdropEl) {
 			this._backdropEl.style.transition = animate ? OVERLAY_TRANSITION : 'none';
@@ -314,7 +276,10 @@ export class BrnDrawerHandle {
 		this._clearResetTimeout();
 		this._resetTimeout = setTimeout(() => {
 			this._resetTimeout = null;
-			if (this._drawerEl) this._drawerEl.style.transition = '';
+			if (this._drawerEl) {
+				this._drawerEl.style.transition = '';
+				this._drawerEl.style.willChange = '';
+			}
 			if (this._backdropEl) this._backdropEl.style.transition = '';
 		}, 500);
 	}
@@ -331,11 +296,11 @@ export class BrnDrawerHandle {
 		const dimension = this._isVertical ? this._drawerEl.offsetHeight : this._drawerEl.offsetWidth;
 		const targetClose = this._isPositive ? dimension : -dimension;
 		const prop = this._isVertical ? 'translateY' : 'translateX';
-		this._drawerEl.style.transition = 'transform 0.3s cubic-bezier(0.32, 0.72, 0, 1)';
+		this._drawerEl.style.transition = CLOSE_TRANSITION;
 		this._drawerEl.style.transform = `${prop}(${targetClose}px)`;
 		this._drawerEl.style.animation = 'none';
 		if (this._backdropEl) {
-			this._backdropEl.style.transition = 'opacity 0.3s cubic-bezier(0.32, 0.72, 0, 1)';
+			this._backdropEl.style.transition = OVERLAY_TRANSITION;
 			this._backdropEl.style.opacity = '0';
 		}
 	}
@@ -345,6 +310,7 @@ export class BrnDrawerHandle {
 		this._isAllowedToDrag = false;
 		if (this._drawerEl) {
 			this._drawerEl.style.touchAction = '';
+			this._drawerEl.style.willChange = '';
 		}
 		if (this._pointerId !== -1) {
 			try {
@@ -355,9 +321,6 @@ export class BrnDrawerHandle {
 			this._pointerId = -1;
 		}
 		this._document.removeEventListener('pointermove', this._onPointerMove);
-		// pointerup/pointercancel are registered with `{ once: true }`, but a destroy-during-drag (or a
-		// normal end where pointercancel never fired) would otherwise leave them on `document`, pinning
-		// this directive until the next global pointer release auto-removes them.
 		this._document.removeEventListener('pointerup', this._onPointerUp);
 		this._document.removeEventListener('pointercancel', this._onPointerCancel);
 	}
@@ -369,7 +332,7 @@ export class BrnDrawerHandle {
 		const clientProp = this._isVertical ? 'clientHeight' : 'clientWidth';
 		let el: HTMLElement | null = element.parentElement;
 		while (el) {
-			const overflow = getComputedStyle(el)[scrollProp as any];
+			const overflow = el.style[scrollProp as any] || getComputedStyle(el)[scrollProp as any];
 			if ((overflow === 'auto' || overflow === 'scroll') && (el as any)[sizeProp] > (el as any)[clientProp]) {
 				return el;
 			}

--- a/libs/helm/drawer/src/lib/hlm-drawer-content.ts
+++ b/libs/helm/drawer/src/lib/hlm-drawer-content.ts
@@ -23,14 +23,6 @@ export class HlmDrawerContent {
 	public readonly state = this._stateProvider.state ?? signal('closed');
 
 	constructor() {
-		classes(() => [
-			'spartan-drawer-content',
-			'group/drawer-content',
-			'data-open:animate-in data-closed:animate-out',
-			'data-[vaul-drawer-direction=bottom]:data-closed:slide-out-to-bottom data-[vaul-drawer-direction=bottom]:data-open:slide-in-from-bottom',
-			'data-[vaul-drawer-direction=top]:data-closed:slide-out-to-top data-[vaul-drawer-direction=top]:data-open:slide-in-from-top',
-			'data-[vaul-drawer-direction=left]:data-closed:slide-out-to-left data-[vaul-drawer-direction=left]:data-open:slide-in-from-left',
-			'data-[vaul-drawer-direction=right]:data-closed:slide-out-to-right data-[vaul-drawer-direction=right]:data-open:slide-in-from-right',
-		]);
+		classes(() => ['spartan-drawer-content', 'group/drawer-content']);
 	}
 }

--- a/libs/helm/drawer/src/lib/hlm-drawer-overlay.ts
+++ b/libs/helm/drawer/src/lib/hlm-drawer-overlay.ts
@@ -13,7 +13,7 @@ export class HlmDrawerOverlay {
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
 	protected readonly _computedClass = computed(() =>
 		hlm(
-			'spartan-drawer-overlay transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0',
+			'spartan-drawer-overlay transition-opacity duration-300 data-ending-style:opacity-0 data-starting-style:opacity-0',
 			this.userClass(),
 		),
 	);

--- a/libs/registry/src/styles/style-luma.css
+++ b/libs/registry/src/styles/style-luma.css
@@ -694,7 +694,7 @@
 
 	/* MARK: Drawer */
 	.spartan-drawer-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/30 supports-backdrop-filter:backdrop-blur-sm;
+		@apply bg-black/30 transition-opacity duration-300 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-sm;
 	}
 
 	.spartan-drawer-content {

--- a/libs/registry/src/styles/style-lyra.css
+++ b/libs/registry/src/styles/style-lyra.css
@@ -448,7 +448,7 @@
 
 	/* MARK: Drawer */
 	.spartan-drawer-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 supports-backdrop-filter:backdrop-blur-xs;
+		@apply bg-black/10 transition-opacity duration-300 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-drawer-content {

--- a/libs/registry/src/styles/style-maia.css
+++ b/libs/registry/src/styles/style-maia.css
@@ -470,7 +470,7 @@
 
 	/* MARK: Drawer */
 	.spartan-drawer-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/80 supports-backdrop-filter:backdrop-blur-xs;
+		@apply bg-black/80 transition-opacity duration-300 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-drawer-content {

--- a/libs/registry/src/styles/style-mira.css
+++ b/libs/registry/src/styles/style-mira.css
@@ -470,7 +470,7 @@
 
 	/* MARK: Drawer */
 	.spartan-drawer-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/80 supports-backdrop-filter:backdrop-blur-xs;
+		@apply bg-black/80 transition-opacity duration-300 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-drawer-content {

--- a/libs/registry/src/styles/style-nova.css
+++ b/libs/registry/src/styles/style-nova.css
@@ -470,7 +470,7 @@
 
 	/* MARK: Drawer */
 	.spartan-drawer-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 supports-backdrop-filter:backdrop-blur-xs;
+		@apply bg-black/10 transition-opacity duration-300 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-drawer-content {

--- a/libs/registry/src/styles/style-vega.css
+++ b/libs/registry/src/styles/style-vega.css
@@ -466,7 +466,7 @@
 
 	/* MARK: Drawer */
 	&.spartan-drawer-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 supports-backdrop-filter:backdrop-blur-xs;
+		@apply bg-black/10 transition-opacity duration-300 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	&.spartan-drawer-content {


### PR DESCRIPTION
Track transform imperatively instead of reading getComputedStyle on every pointer event. Cache scrollable ancestor at pointerdown instead of walking DOM on each move. Remove 500ms OPEN_TIME_COOLDOWN that blocked drag after open. Remove afterNextRender wrapper in BrnDialog open path to eliminate one-frame delay. Use will-change:transform for GPU acceleration during drag. Switch overlay to CSS transitions (300ms) instead of conflicting keyframe animations. Suppress content keyframe animations during drag via vaul-dragging class to prevent transform conflicts.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [x] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The drawer component has noticeable lag when opening and during drag-to-dismiss interactions. Specifically:

1. **`getComputedStyle()` called on every pointer event** — `_getTranslate()` forces a synchronous layout reflow on every `pointerup` and during `_shouldDrag()` on every `pointermove`. `_findScrollableAncestor()` walks the entire DOM ancestor chain calling `getComputedStyle()` per element on every `pointerdown`.
2. **500ms OPEN_TIME_COOLDOWN** — Drag gestures are blocked for 500ms after the drawer opens, making it feel unresponsive immediately after opening.
3. **`afterNextRender` defers state effect** — The open/close state effect in `BrnDialog` is registered inside `afterNextRender`, adding one frame of latency before the dialog opens.
4. **Conflicting animation systems** — The overlay uses both CSS keyframe animations (`animate-in`/`animate-out`) and CSS transitions (`transition-opacity`) simultaneously, causing visual conflicts.
5. **No GPU acceleration hints** — The drawer content lacks `will-change: transform` during drag, missing an opportunity for GPU compositing optimization.
6. **Keyframe animations fight drag transforms** — Content slide-in/out keyframe animations set `transform` via keyframes, which can conflict with the imperative `style.transform` applied during drag gestures.

## What is the new behavior?

- **Imperative transform tracking** — `_currentTranslate` is tracked as a field value instead of reading `getComputedStyle()` on every interaction. Zero DOM reads during drag movement.
- **Cached scrollable ancestor** — `_findScrollableAncestor()` result is cached at `pointerdown` and reused in `_shouldDrag()`, eliminating repeated DOM walks.
- **No open cooldown** — Removed `OPEN_TIME_COOLDOWN` entirely, matching Vaul's behavior where drag gestures work immediately after open.
- **Synchronous state effect** — Removed `afterNextRender` wrapper from `BrnDialog`'s state effect, eliminating the one-frame delay on open.
- **`will-change: transform`** — Applied during drag for GPU compositing acceleration, cleared on cleanup.
- **Transition-based overlay** — Overlay uses CSS transitions (`duration-300`) instead of conflicting keyframe animations, matching Vaul's approach.
- **Animation suppression during drag** — `.spartan-drawer-content.vaul-dragging { animation: none !important }` prevents keyframe animations from fighting the imperative transform during drag gestures.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

No API changes. All behavioral changes are internal performance optimizations that preserve the same public interface and visual output.

## Other information

This aligns the Angular drawer implementation with [Vaul](https://github.com/emilkowalski/vaul) (the React drawer library used by shadcn/ui) for consistent performance characteristics across frameworks.
