### PR TITLE
fix(cli): prevent tsconfig include explosion when migrating many helm libraries

### DIFF
--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -42,6 +42,7 @@ jobs:
           - nx-standalone
           - acli
           - all-components
+          - all-components-nx-entry
     name: ${{ matrix.cell }}
     steps:
       - uses: actions/checkout@v6

--- a/apps/cli-smoke/src/matrix.ts
+++ b/apps/cli-smoke/src/matrix.ts
@@ -47,12 +47,29 @@ const nxStandaloneCells: SetupCell[] = [
 const angularCliCells: SetupCell[] = [{ id: 'acli', workspace: 'angular-cli' }];
 
 // Generate every supported primitive and build them all - broad per-component coverage the small default
-// set can't give, so a broken template in any single primitive surfaces here. Uses the angular-cli setup
-// on purpose: the components all land in src/ and `ng build` compiles the lot in one pass, with no nx
-// project graph to serialize (nx hits V8's max-string-length / OOM well before 57 generators). It is the
-// slowest cell; it fans out to its own runner so it does not hold up the others. Set `nightlyOnly: true`
-// to drop it from per-PR CI if it proves too slow.
-const allComponentsCells: SetupCell[] = [{ id: 'all-components', workspace: 'angular-cli', allComponents: true }];
+// set can't give, so a broken template in any single primitive surfaces here.
+//
+// - all-components (angular-cli): the components all land in src/ and `ng build` compiles the lot in one
+//   pass. The cheapest way to compile every primitive.
+// - all-components-nx-entry (nx, entrypoint, buildable): regression guard for the tsconfig.lib.json
+//   include/exclude explosion. nx's librarySecondaryEntryPointGenerator re-prefixed every existing glob
+//   for each entrypoint, doubling the arrays until `JSON.stringify` threw `RangeError: Invalid string
+//   length` (surfaced as `NX Invalid string length`) - which is why "all" failed on nx while a few
+//   worked. It was a fixable bug (see base/generator.ts dedupeEntrypointGlobs), not an inherent nx limit,
+//   so this now runs on nx. Entrypoint mode keeps all primitives in a single nx project, so there is no
+//   project graph to blow up either.
+//
+// These are the slowest cells; each fans out to its own runner so it does not hold up the others.
+const allComponentsCells: SetupCell[] = [
+	{ id: 'all-components', workspace: 'angular-cli', allComponents: true },
+	{
+		id: 'all-components-nx-entry',
+		workspace: 'nx',
+		generateAs: 'entrypoint',
+		buildable: true,
+		allComponents: true,
+	},
+];
 
 export const setupMatrix: SetupCell[] = [...nxCells, ...nxStandaloneCells, ...angularCliCells, ...allComponentsCells];
 

--- a/apps/cli-smoke/src/setup-matrix.spec.ts
+++ b/apps/cli-smoke/src/setup-matrix.spec.ts
@@ -2,6 +2,7 @@ import { setupMatrix } from './matrix';
 import { isSmokeAffected } from './support/affected';
 import {
 	assertHealthcheckClean,
+	assertMigrateHelmLibrariesLoads,
 	buildWorkspace,
 	cleanupWorkspace,
 	prepareWorkspace,
@@ -36,6 +37,9 @@ describe('CLI setup matrix', () => {
 					return;
 				}
 				const ws = prepareWorkspace(cell);
+				// Before generating anything: load migrate-helm-libraries as an installed package (it no-ops
+				// on an empty workspace). Guards its deep nx imports against a consumer's stricter exports map.
+				assertMigrateHelmLibrariesLoads(ws);
 				runGenerators(ws);
 				assertHealthcheckClean(ws);
 				useGeneratedComponents(ws);

--- a/apps/cli-smoke/src/setup-matrix.spec.ts
+++ b/apps/cli-smoke/src/setup-matrix.spec.ts
@@ -24,18 +24,24 @@ const affected = isSmokeAffected();
  * <os-tmp>/spartan-cli-smoke-workspaces/<cell-id> for inspection.
  */
 describe('CLI setup matrix', () => {
-	describe.each(setupMatrix)('$id', (cell) => {
-		it('scaffolds, generates, passes healthcheck, consumes components, and builds with themed styles', () => {
-			if (!affected) {
-				console.log(`[cli-smoke] ${cell.id}: skipped (nothing affecting the CLI changed).`);
-				return;
-			}
-			const ws = prepareWorkspace(cell);
-			runGenerators(ws);
-			assertHealthcheckClean(ws);
-			useGeneratedComponents(ws);
-			buildWorkspace(ws);
-			cleanupWorkspace(ws);
+	// A plain loop rather than `describe.each(setupMatrix)('$id', ...)`: the `$id` interpolation renders the
+	// cell id wrapped in quotes (e.g. `'nx-entry-buildable'`), so CI's `--testNamePattern="<id> "` (no quotes)
+	// matched nothing and every cell silently skipped. `describe(cell.id, ...)` produces a clean, unquoted
+	// name the per-cell pattern can anchor to.
+	for (const cell of setupMatrix) {
+		describe(cell.id, () => {
+			it('scaffolds, generates, passes healthcheck, consumes components, and builds with themed styles', () => {
+				if (!affected) {
+					console.log(`[cli-smoke] ${cell.id}: skipped (nothing affecting the CLI changed).`);
+					return;
+				}
+				const ws = prepareWorkspace(cell);
+				runGenerators(ws);
+				assertHealthcheckClean(ws);
+				useGeneratedComponents(ws);
+				buildWorkspace(ws);
+				cleanupWorkspace(ws);
+			});
 		});
-	});
+	}
 });

--- a/apps/cli-smoke/src/utils/workspace.ts
+++ b/apps/cli-smoke/src/utils/workspace.ts
@@ -202,6 +202,23 @@ export function runGenerators(ws: CellWorkspace): void {
 	}
 }
 
+/**
+ * Run `migrate-helm-libraries` against a workspace that has no spartan libraries yet. With a
+ * components.json already written and nothing to migrate, the generator exits early with
+ * "No libraries to migrate" without prompting - but loading it still resolves its `@nx/workspace`
+ * (removeGenerator) and `@nx/devkit` deep imports in the *installed* CLI, where a stricter `exports`
+ * map would break module resolution at load. This is the only coverage that runs the headline
+ * command end-to-end as an installed package. nx-only: the generator's remove path is nx-specific.
+ */
+export function assertMigrateHelmLibrariesLoads(ws: CellWorkspace): void {
+	if (ws.cell.workspace !== 'nx') return;
+	const out = capture(`npx nx g @spartan-ng/cli:migrate-helm-libraries 2>&1`, ws.dir);
+	console.log(out);
+	if (!out.includes('No libraries to migrate')) {
+		throw new Error(`Expected migrate-helm-libraries to no-op on a workspace with no spartan libraries, got:\n${out}`);
+	}
+}
+
 /** Every supported primitive name, read from the CLI source so the list stays current as primitives are
  * added (the harness lives in the same repo as the CLI). */
 function readAllPrimitives(): string[] {

--- a/apps/cli-smoke/src/utils/workspace.ts
+++ b/apps/cli-smoke/src/utils/workspace.ts
@@ -49,6 +49,12 @@ function execEnv(): NodeJS.ProcessEnv {
 		NPM_CONFIG_REGISTRY: registryInfo().registry,
 		// Make create-nx-workspace/ng fully non-interactive (suppresses the git-provider prompt etc.).
 		CI: 'true',
+		// Disable the nx daemon. These are throwaway workspaces running a linear sequence of generators,
+		// so the daemon's cross-invocation graph cache buys little, and under the all-components cell (50+
+		// generator runs back-to-back) it intermittently crashes with "Failed to process project graph",
+		// failing the cell non-deterministically. Running daemonless is reliable and, because the slow
+		// daemon retries are gone, actually faster for that cell.
+		NX_DAEMON: 'false',
 		// The all-components cell generates 57 primitives and compiles them in one `ng build`, which
 		// exceeds the 4GB default heap. Raise it for all cells (harmless for the small ones).
 		NODE_OPTIONS: '--max-old-space-size=8192',

--- a/libs/cli/src/generators/base/generator.spec.ts
+++ b/libs/cli/src/generators/base/generator.spec.ts
@@ -1,6 +1,6 @@
 import { applicationGenerator, E2eTestRunner, UnitTestRunner } from '@nx/angular/generators';
 import type { Schema } from '@nx/angular/src/generators/library/schema';
-import { addDependenciesToPackageJson, joinPathFragments, readJson, type Tree } from '@nx/devkit';
+import { addDependenciesToPackageJson, joinPathFragments, readJson, type Tree, updateJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { hlmBaseGenerator } from './generator';
 import { singleLibName } from './lib/single-lib-name';
@@ -168,5 +168,92 @@ describe('hlmBaseGenerator', () => {
 		const tsconfigAfterSecondRun = readJson(tree, 'tsconfig.base.json');
 
 		expect(tsconfigAfterSecondRun.compilerOptions.paths).toEqual(tsconfigAfterFirstRun.compilerOptions.paths);
+	});
+
+	it('should not exponentially grow tsconfig.lib.json include/exclude across many buildable entrypoints', async () => {
+		// Regression test: nx's `librarySecondaryEntryPointGenerator` re-prefixes every existing
+		// include/exclude glob for each entrypoint, doubling the arrays each time. With enough
+		// primitives (e.g. `migrate-helm-libraries` -> "all") the JSON serialization eventually
+		// throws `RangeError: Invalid string length`. The generator must keep these arrays bounded.
+		const { libraryGenerator } =
+			await vi.importActual<typeof import('@nx/angular/generators')>('@nx/angular/generators');
+
+		const directory = 'libs/test-ui';
+		const importAlias = '@spartan-ng/helm';
+
+		await libraryGenerator(tree, {
+			buildable: true,
+			name: singleLibName,
+			importPath: importAlias,
+			directory,
+			skipTests: true,
+			unitTestRunner: UnitTestRunner.None,
+		});
+
+		// Mirror what `initializeAngularEntrypoint` leaves behind: a recursive `**/*.ts` include
+		// that already covers every entrypoint subdirectory.
+		updateJson(tree, joinPathFragments(directory, 'tsconfig.lib.json'), (json) => {
+			json.include ??= [];
+			if (!json.include.includes('**/*.ts')) {
+				json.include.push('**/*.ts');
+			}
+			return json;
+		});
+
+		// 30+ primitives reproduces the failure: the doubling crosses the string-length ceiling.
+		const primitives = [
+			'accordion',
+			'alert',
+			'avatar',
+			'badge',
+			'button',
+			'card',
+			'checkbox',
+			'collapsible',
+			'command',
+			'dialog',
+			'icon',
+			'input',
+			'kbd',
+			'label',
+			'menubar',
+			'pagination',
+			'popover',
+			'progress',
+			'scroll-area',
+			'select',
+			'separator',
+			'sheet',
+			'skeleton',
+			'slider',
+			'sonner',
+			'spinner',
+			'switch',
+			'table',
+			'tabs',
+			'textarea',
+			'toggle',
+			'tooltip',
+		];
+
+		for (const name of primitives) {
+			await hlmBaseGenerator(tree, {
+				name,
+				directory,
+				buildable: true,
+				generateAs: 'entrypoint' as const,
+				importAlias,
+			});
+		}
+
+		const tsconfig = readJson(tree, joinPathFragments(directory, 'tsconfig.lib.json'));
+		// A correct result is a small, constant-sized set of globs - never one entry per primitive.
+		expect(tsconfig.include.length).toBeLessThan(10);
+		expect(tsconfig.exclude.length).toBeLessThan(10);
+		// The recursive include still covers every entrypoint's sources...
+		expect(tsconfig.include).toContain('**/*.ts');
+		// ...and the recursive excludes still keep every entrypoint's specs/tests out of the build.
+		expect(tsconfig.exclude).toContain('**/*.spec.ts');
+		expect(tsconfig.exclude).toContain('**/*.test.ts');
 	});
 });

--- a/libs/cli/src/generators/base/generator.spec.ts
+++ b/libs/cli/src/generators/base/generator.spec.ts
@@ -2,7 +2,7 @@ import { applicationGenerator, E2eTestRunner, UnitTestRunner } from '@nx/angular
 import type { Schema } from '@nx/angular/src/generators/library/schema';
 import { addDependenciesToPackageJson, joinPathFragments, readJson, type Tree, updateJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { hlmBaseGenerator } from './generator';
+import { dedupeEntrypointGlobs, hlmBaseGenerator } from './generator';
 import { singleLibName } from './lib/single-lib-name';
 
 // Mock buildDependencyArray and buildDevDependencyArray
@@ -190,13 +190,12 @@ describe('hlmBaseGenerator', () => {
 			unitTestRunner: UnitTestRunner.None,
 		});
 
-		// Mirror what `initializeAngularEntrypoint` leaves behind: a recursive `**/*.ts` include
-		// that already covers every entrypoint subdirectory.
+		// Seed include/exclude explicitly rather than relying on nx's library defaults: a recursive
+		// `**/*.ts` include (what `initializeAngularEntrypoint` adds) plus the standard spec/test excludes.
+		// This keeps the assertions about the normalized result independent of nx's default tsconfig.
 		updateJson(tree, joinPathFragments(directory, 'tsconfig.lib.json'), (json) => {
-			json.include ??= [];
-			if (!json.include.includes('**/*.ts')) {
-				json.include.push('**/*.ts');
-			}
+			json.include = ['src/**/*.ts', '**/*.ts'];
+			json.exclude = ['src/**/*.spec.ts', 'src/**/*.test.ts'];
 			return json;
 		});
 
@@ -255,5 +254,27 @@ describe('hlmBaseGenerator', () => {
 		// ...and the recursive excludes still keep every entrypoint's specs/tests out of the build.
 		expect(tsconfig.exclude).toContain('**/*.spec.ts');
 		expect(tsconfig.exclude).toContain('**/*.test.ts');
+	});
+});
+
+describe('dedupeEntrypointGlobs', () => {
+	it('collapses entrypoint-prefixed variants to a single recursive glob', () => {
+		const include = ['src/**/*.ts', '**/*.ts', 'accordion/src/**/*.ts', 'accordion/**/*.ts', 'alert/**/*.ts'];
+		expect(dedupeEntrypointGlobs(include, ['**/*.ts'])).toEqual(['**/*.ts']);
+	});
+
+	it('only restores a recursive glob when a variant was present (no unconditional injection)', () => {
+		// exclude with no spec/test globs at all: must stay as-is, not gain `**/*.spec.ts`/`**/*.test.ts`.
+		expect(dedupeEntrypointGlobs(['jest.config.ts'], ['**/*.spec.ts', '**/*.test.ts'])).toEqual(['jest.config.ts']);
+		// only spec variants present -> only the spec recursive glob is restored, test is not injected.
+		expect(dedupeEntrypointGlobs(['src/**/*.spec.ts', 'jest.config.ts'], ['**/*.spec.ts', '**/*.test.ts'])).toEqual([
+			'jest.config.ts',
+			'**/*.spec.ts',
+		]);
+	});
+
+	it('does not widen a root-only `*.ts` into a recursive glob', () => {
+		// `*.ts` matches only the root; it is not a sub-path variant of `**/*.ts`, so it is left untouched.
+		expect(dedupeEntrypointGlobs(['*.ts'], ['**/*.ts'])).toEqual(['*.ts']);
 	});
 });

--- a/libs/cli/src/generators/base/generator.spec.ts
+++ b/libs/cli/src/generators/base/generator.spec.ts
@@ -273,8 +273,13 @@ describe('dedupeEntrypointGlobs', () => {
 		]);
 	});
 
-	it('does not widen a root-only `*.ts` into a recursive glob', () => {
-		// `*.ts` matches only the root; it is not a sub-path variant of `**/*.ts`, so it is left untouched.
+	it('does not rewrite flat custom globs (only recursive `/**/` sub-paths are collapsed)', () => {
+		// `*.ts` matches only the root and `tools/*.ts` only that folder; neither is an nx entrypoint
+		// variant (no `/**/`), so both are preserved rather than widened to `**/*.ts`.
 		expect(dedupeEntrypointGlobs(['*.ts'], ['**/*.ts'])).toEqual(['*.ts']);
+		expect(dedupeEntrypointGlobs(['tools/*.ts', 'accordion/src/**/*.ts'], ['**/*.ts'])).toEqual([
+			'tools/*.ts',
+			'**/*.ts',
+		]);
 	});
 });

--- a/libs/cli/src/generators/base/generator.ts
+++ b/libs/cli/src/generators/base/generator.ts
@@ -60,22 +60,44 @@ function setupAngularCliProject(tree: Tree, alias: string, targetLibDir: string)
 // The library already includes a recursive `**/*.ts` glob, which matches files in every entrypoint
 // subdirectory, so the prefixed copies are redundant. This collapses them back to a bounded, equivalent
 // set of recursive globs. It is idempotent, so it stays bounded no matter how many entrypoints are added.
-function dedupeEntrypointGlobs(patterns: string[], recursiveGlobs: string[]): string[] {
-	// The suffix each recursive glob already covers, e.g. '**/*.ts' -> '*.ts', '**/*.spec.ts' -> '*.spec.ts'.
+// Collapses the entrypoint-prefixed globs nx accumulates back into their recursive equivalents, keeping
+// `tsconfig.lib.json` bounded. For each glob in `recursiveGlobs` (e.g. `**/*.ts`), any "scoped variant"
+// that it already covers - the recursive glob itself, or a sub-path form like `accordion/src/**/*.ts`
+// that ends in the same `*.ext` suffix - is dropped, and the single recursive glob is restored *only if*
+// such a variant was present. Patterns that aren't a scoped variant (literal files like `jest.config.ts`,
+// a root-only `*.ts`, or a custom glob) are preserved untouched, and no recursive glob is injected unless
+// it was already represented - so the function never widens or adds globs the tsconfig didn't already imply.
+export function dedupeEntrypointGlobs(patterns: string[], recursiveGlobs: string[]): string[] {
+	// The suffix each recursive glob covers in every subdirectory, e.g. '**/*.ts' -> '*.ts'.
 	const suffixes = recursiveGlobs.map((glob) => glob.replace(/^\*\*\//, ''));
-	// A glob is redundant if a recursive sibling already matches the same files in every subdirectory.
-	const isCoveredByRecursiveGlob = (pattern: string) =>
-		pattern.includes('*') && suffixes.some((suffix) => pattern === suffix || pattern.endsWith(`/${suffix}`));
+	const variantSeen = recursiveGlobs.map(() => false);
+	// A pattern is a scoped variant of recursiveGlobs[i] if it is that glob, or a sub-path glob ending in
+	// `/<suffix>` (so `*.ts` on its own is NOT a variant of `**/*.ts` and is left alone).
+	const variantIndex = (pattern: string) =>
+		recursiveGlobs.findIndex(
+			(recursive, i) => pattern === recursive || (pattern.includes('*') && pattern.endsWith(`/${suffixes[i]}`)),
+		);
 
-	const result = patterns.filter((pattern) => !isCoveredByRecursiveGlob(pattern));
-	for (const glob of recursiveGlobs) {
-		if (!result.includes(glob)) {
+	const result = patterns.filter((pattern) => {
+		const index = variantIndex(pattern);
+		if (index === -1) {
+			return true; // unrelated glob - keep as-is
+		}
+		variantSeen[index] = true;
+		return false; // redundant scoped variant - drop it
+	});
+	recursiveGlobs.forEach((glob, i) => {
+		if (variantSeen[i]) {
 			result.push(glob);
 		}
-	}
+	});
 	return result;
 }
 
+// Targets `tsconfig.lib.json` by convention: that's the file `initializeAngularEntrypoint` seeds and the
+// default build tsConfig for an @nx/angular library, which is also the file nx's secondary-entrypoint
+// generator inflates. A library whose build target points its tsConfig elsewhere isn't normalized here,
+// but the spartan generators never produce that shape.
 function normalizeEntrypointTsConfig(tree: Tree, libraryDir: string): void {
 	const tsConfigLibPath = joinPathFragments(libraryDir, 'tsconfig.lib.json');
 	if (!tree.exists(tsConfigLibPath)) {
@@ -96,6 +118,10 @@ async function generateEntrypointFiles(tree: Tree, alias: string, options: HlmBa
 	const targetLibDir = `${options.directory}/${options.name}/src`;
 
 	if (options.buildable) {
+		// Normalize before *and* after: if tsconfig.lib.json is already bloated from an earlier run, the
+		// nx generator would re-double the existing arrays and could throw "Invalid string length" before
+		// the post-call cleanup runs. Pre-normalizing makes a dirty workspace recover deterministically.
+		normalizeEntrypointTsConfig(tree, options.directory);
 		await librarySecondaryEntryPointGenerator(tree, {
 			name: options.name,
 			library: singleLibName,

--- a/libs/cli/src/generators/base/generator.ts
+++ b/libs/cli/src/generators/base/generator.ts
@@ -71,11 +71,13 @@ export function dedupeEntrypointGlobs(patterns: string[], recursiveGlobs: string
 	// The suffix each recursive glob covers in every subdirectory, e.g. '**/*.ts' -> '*.ts'.
 	const suffixes = recursiveGlobs.map((glob) => glob.replace(/^\*\*\//, ''));
 	const variantSeen = recursiveGlobs.map(() => false);
-	// A pattern is a scoped variant of recursiveGlobs[i] if it is that glob, or a sub-path glob ending in
-	// `/<suffix>` (so `*.ts` on its own is NOT a variant of `**/*.ts` and is left alone).
+	// A pattern is a scoped variant of recursiveGlobs[i] only if it is that glob itself, or a recursive
+	// sub-path glob (contains `/**/` and ends in `/<suffix>`) - exactly the shape nx prepends per entry
+	// point, e.g. `accordion/src/**/*.ts`. A flat `*.ts` or a custom `tools/*.ts` is NOT a variant and is
+	// left untouched, so user globs are never widened or dropped.
 	const variantIndex = (pattern: string) =>
 		recursiveGlobs.findIndex(
-			(recursive, i) => pattern === recursive || (pattern.includes('*') && pattern.endsWith(`/${suffixes[i]}`)),
+			(recursive, i) => pattern === recursive || (pattern.includes('/**/') && pattern.endsWith(`/${suffixes[i]}`)),
 		);
 
 	const result = patterns.filter((pattern) => {

--- a/libs/cli/src/generators/base/generator.ts
+++ b/libs/cli/src/generators/base/generator.ts
@@ -52,6 +52,46 @@ function setupAngularCliProject(tree: Tree, alias: string, targetLibDir: string)
 	addTsConfigPath(tree, alias, [`./${joinPathFragments(targetLibDir, 'src', 'index.ts').replace(/\\/g, '/')}`]);
 }
 
+// nx's `librarySecondaryEntryPointGenerator` appends an entrypoint-prefixed copy of every existing
+// include/exclude glob each time it runs (see `updateTsConfigIncludedFiles`). When many entrypoints
+// are generated into the same library - e.g. `migrate-helm-libraries` (or `ui`) with "all" selected -
+// these arrays double on every call until `JSON.stringify` throws `RangeError: Invalid string length`.
+//
+// The library already includes a recursive `**/*.ts` glob, which matches files in every entrypoint
+// subdirectory, so the prefixed copies are redundant. This collapses them back to a bounded, equivalent
+// set of recursive globs. It is idempotent, so it stays bounded no matter how many entrypoints are added.
+function dedupeEntrypointGlobs(patterns: string[], recursiveGlobs: string[]): string[] {
+	// The suffix each recursive glob already covers, e.g. '**/*.ts' -> '*.ts', '**/*.spec.ts' -> '*.spec.ts'.
+	const suffixes = recursiveGlobs.map((glob) => glob.replace(/^\*\*\//, ''));
+	// A glob is redundant if a recursive sibling already matches the same files in every subdirectory.
+	const isCoveredByRecursiveGlob = (pattern: string) =>
+		pattern.includes('*') && suffixes.some((suffix) => pattern === suffix || pattern.endsWith(`/${suffix}`));
+
+	const result = patterns.filter((pattern) => !isCoveredByRecursiveGlob(pattern));
+	for (const glob of recursiveGlobs) {
+		if (!result.includes(glob)) {
+			result.push(glob);
+		}
+	}
+	return result;
+}
+
+function normalizeEntrypointTsConfig(tree: Tree, libraryDir: string): void {
+	const tsConfigLibPath = joinPathFragments(libraryDir, 'tsconfig.lib.json');
+	if (!tree.exists(tsConfigLibPath)) {
+		return;
+	}
+	updateJson(tree, tsConfigLibPath, (json) => {
+		if (Array.isArray(json.include)) {
+			json.include = dedupeEntrypointGlobs(json.include, ['**/*.ts']);
+		}
+		if (Array.isArray(json.exclude)) {
+			json.exclude = dedupeEntrypointGlobs(json.exclude, ['**/*.spec.ts', '**/*.test.ts']);
+		}
+		return json;
+	});
+}
+
 async function generateEntrypointFiles(tree: Tree, alias: string, options: HlmBaseGeneratorSchema): Promise<string> {
 	const targetLibDir = `${options.directory}/${options.name}/src`;
 
@@ -62,6 +102,9 @@ async function generateEntrypointFiles(tree: Tree, alias: string, options: HlmBa
 			skipFormat: true,
 			skipModule: true,
 		});
+		// Collapse the redundant entrypoint-prefixed globs nx just appended so the include/exclude
+		// arrays stay bounded as more entrypoints are added. See `dedupeEntrypointGlobs`.
+		normalizeEntrypointTsConfig(tree, options.directory);
 	} else {
 		// Resolve the workspace's root tsconfig rather than assuming tsconfig.base.json - a standalone nx
 		// workspace registers paths in tsconfig.json (there is no base file).

--- a/libs/cli/src/generators/migrate-helm-libraries/generator.spec.ts
+++ b/libs/cli/src/generators/migrate-helm-libraries/generator.spec.ts
@@ -27,12 +27,12 @@ describe('migrate-helm-libraries generator', () => {
 		);
 	});
 
-	// Regression test for the `@nx/workspace` barrel import.
-	// Importing `removeGenerator` from the `@nx/workspace` entry point eagerly evaluates the
-	// barrel, which loads `convert-to-nx-project` -> `output.js`. On nx 22 that module crashes
-	// with "Cannot read properties of undefined (reading 'inverse')", so the generator threw
-	// before doing any work. Loading the generator and running it must not throw.
-	it('should run without crashing on the @nx/workspace barrel import', async () => {
+	// Regression test for resolving `@nx/workspace`'s `removeGenerator`. The package entry crashes on
+	// load ("Cannot read properties of undefined (reading 'inverse')") and the deep `src/` specifier is
+	// blocked by `exports` on nx 23+, so the generator must neither import it eagerly nor throw on load.
+	// Loading the generator and running it (here: nothing to migrate) must not throw. Resolving the
+	// generator itself when a library is removed is covered end-to-end by the cli-smoke suite.
+	it('should load and run without eagerly resolving the @nx/workspace remove generator', async () => {
 		const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
 
 		await expect(

--- a/libs/cli/src/generators/migrate-helm-libraries/generator.ts
+++ b/libs/cli/src/generators/migrate-helm-libraries/generator.ts
@@ -23,7 +23,7 @@ type RemoveGenerator = (
 // blocked by the package's `exports` map on nx 23+ (where the compiled file also moved to `dist/`).
 // Resolve the compiled generator by absolute path instead: that bypasses the `exports` gate and never
 // loads the crashing barrel. Lazy, so it only runs when a library actually has to be removed.
-async function loadRemoveGenerator(): Promise<RemoveGenerator> {
+function loadRemoveGenerator(): RemoveGenerator {
 	const workspaceRoot = dirname(require.resolve('@nx/workspace/package.json'));
 	const candidates = [
 		join(workspaceRoot, 'dist', 'src', 'generators', 'remove', 'remove.js'), // nx 23+
@@ -31,8 +31,10 @@ async function loadRemoveGenerator(): Promise<RemoveGenerator> {
 	];
 	for (const candidate of candidates) {
 		if (existsSync(candidate)) {
-			const mod = await import(candidate);
-			return mod.removeGenerator as RemoveGenerator;
+			// `require` (not `import()`) so an absolute filesystem path is loaded directly: it bypasses the
+			// package `exports` gate and, unlike dynamic import, accepts native Windows paths (C:\...) without
+			// a file:// URL. This generator already runs as CommonJS.
+			return (require(candidate) as { removeGenerator: RemoveGenerator }).removeGenerator;
 		}
 	}
 	throw new Error(
@@ -175,7 +177,7 @@ async function removeExistingLibraries(
 				throw new Error(`Could not find the project name for library: ${library} in project root path ${projectRoot}`);
 			}
 
-			const removeGenerator = await loadRemoveGenerator();
+			const removeGenerator = loadRemoveGenerator();
 			await removeGenerator(tree, {
 				projectName,
 				forceRemove: true,

--- a/libs/cli/src/generators/migrate-helm-libraries/generator.ts
+++ b/libs/cli/src/generators/migrate-helm-libraries/generator.ts
@@ -1,12 +1,7 @@
 import { formatFiles, logger, readJson, type Tree, updateJson } from '@nx/devkit';
 import { getRootTsConfigPathInTree } from '@nx/js';
-// Import `removeGenerator` from its module directly rather than the `@nx/workspace` barrel.
-// The barrel eagerly evaluates `convert-to-nx-project`, whose `output.js` crashes on nx 22
-// ("Cannot read properties of undefined (reading 'inverse')") due to a chalk/tslib interop
-// issue in nx itself. Importing the generator directly avoids loading that module.
-// See https://github.com/nrwl/nx/issues/35521 - revert to the barrel once nx ships the fix.
-import { removeGenerator } from '@nx/workspace/src/generators/remove/remove';
 import { prompt } from 'enquirer';
+import { existsSync } from 'node:fs';
 import { dirname, join } from 'path';
 import { getOrCreateConfig } from '../../utils/config';
 import { readTsConfigPathsFromTree } from '../../utils/tsconfig';
@@ -15,6 +10,35 @@ import type { SupportedLibraries } from '../base/lib/supported-libs';
 import { createPrimitiveLibraries } from '../ui/generator';
 import type { Primitive } from '../ui/primitives';
 import type { MigrateHelmLibrariesGeneratorSchema } from './schema';
+
+type RemoveGenerator = (
+	tree: Tree,
+	schema: { projectName: string; forceRemove: boolean; skipFormat: boolean; importPath: string },
+) => Promise<unknown>;
+
+// `@nx/workspace`'s `removeGenerator` is reachable two ways, each broken on a different nx version:
+// importing the package entry eagerly evaluates `convert-to-nx-project`, whose `output.js` crashes
+// ("Cannot read properties of undefined (reading 'inverse')") due to a chalk/tslib interop issue
+// (see https://github.com/nrwl/nx/issues/35521), while the deep `@nx/workspace/src/...` specifier is
+// blocked by the package's `exports` map on nx 23+ (where the compiled file also moved to `dist/`).
+// Resolve the compiled generator by absolute path instead: that bypasses the `exports` gate and never
+// loads the crashing barrel. Lazy, so it only runs when a library actually has to be removed.
+async function loadRemoveGenerator(): Promise<RemoveGenerator> {
+	const workspaceRoot = dirname(require.resolve('@nx/workspace/package.json'));
+	const candidates = [
+		join(workspaceRoot, 'dist', 'src', 'generators', 'remove', 'remove.js'), // nx 23+
+		join(workspaceRoot, 'src', 'generators', 'remove', 'remove.js'), // nx <= 22
+	];
+	for (const candidate of candidates) {
+		if (existsSync(candidate)) {
+			const mod = await import(candidate);
+			return mod.removeGenerator as RemoveGenerator;
+		}
+	}
+	throw new Error(
+		`Could not locate the @nx/workspace remove generator (looked in: ${candidates.join(', ')}). Please report this with your nx version.`,
+	);
+}
 
 export async function migrateHelmLibrariesGenerator(tree: Tree, options: MigrateHelmLibrariesGeneratorSchema) {
 	// Detect the libraries that are already installed
@@ -151,6 +175,7 @@ async function removeExistingLibraries(
 				throw new Error(`Could not find the project name for library: ${library} in project root path ${projectRoot}`);
 			}
 
+			const removeGenerator = await loadRemoveGenerator();
 			await removeGenerator(tree, {
 				projectName,
 				forceRemove: true,

--- a/libs/cli/src/generators/migrate-icon/generator.ts
+++ b/libs/cli/src/generators/migrate-icon/generator.ts
@@ -1,7 +1,7 @@
 import { formatFiles, type Tree } from '@nx/devkit';
-import { applyChangesToString, ChangeType, type StringChange } from '@nx/devkit/src/utils/string-change';
 import { isImported } from '@schematics/angular/utility/ast-utils';
 import ts from 'typescript';
+import { applyChangesToString, ChangeType, type StringChange } from '../../utils/string-change';
 import { visitFiles } from '../../utils/visit-files';
 import type { MigrateIconGeneratorSchema } from './schema';
 

--- a/libs/cli/src/generators/migrate-scroll-area/generator.ts
+++ b/libs/cli/src/generators/migrate-scroll-area/generator.ts
@@ -1,7 +1,7 @@
 import { formatFiles, type Tree, visitNotIgnoredFiles } from '@nx/devkit';
-import { applyChangesToString, ChangeType, type StringChange } from '@nx/devkit/src/utils/string-change';
 import { isImported } from '@schematics/angular/utility/ast-utils';
 import ts from 'typescript';
+import { applyChangesToString, ChangeType, type StringChange } from '../../utils/string-change';
 import type { MigrateScrollAreaGeneratorSchema } from './schema';
 
 export async function migrateScrollAreaGenerator(tree: Tree, { skipFormat }: MigrateScrollAreaGeneratorSchema) {

--- a/libs/cli/src/utils/string-change.ts
+++ b/libs/cli/src/utils/string-change.ts
@@ -1,0 +1,103 @@
+// Vendored from @nx/devkit's `src/utils/string-change` (MIT licensed). Imported here rather than from
+// `@nx/devkit` because these helpers are not part of devkit's public entry point - they only live under
+// the deep `@nx/devkit/src/utils/string-change` path. That path resolves fine inside this monorepo (the
+// dev `@nx/devkit` has no `exports` map) but throws `Package subpath './src/utils/string-change' is not
+// defined by "exports"` once the CLI is installed as a real dependency against a devkit that does declare
+// `exports`. Vendoring the (tiny, stable) implementation keeps it working regardless of how the consumer's
+// `@nx/devkit` is packaged.
+
+export enum ChangeType {
+	Delete = 'Delete',
+	Insert = 'Insert',
+}
+
+export interface StringDeletion {
+	type: ChangeType.Delete;
+	/** Place in the original text to start deleting characters */
+	start: number;
+	/** Number of characters to delete */
+	length: number;
+}
+
+export interface StringInsertion {
+	type: ChangeType.Insert;
+	/** Text to insert into the original text */
+	text: string;
+	/** Place in the original text to insert new text */
+	index: number;
+}
+
+/** A change to be made to a string */
+export type StringChange = StringInsertion | StringDeletion;
+
+/**
+ * Applies a list of changes to a string's original value.
+ *
+ * This is useful when working with ASTs.
+ */
+export function applyChangesToString(text: string, changes: StringChange[]): string {
+	assertChangesValid(changes);
+
+	const sortedChanges = changes.sort((a, b) => {
+		const diff = getChangeIndex(a) - getChangeIndex(b);
+		if (diff === 0) {
+			if (a.type === b.type) {
+				return 0;
+			}
+			// When at the same place, Insert before Delete
+			return isStringInsertion(a) ? -1 : 1;
+		}
+		return diff;
+	});
+
+	let offset = 0;
+	for (const change of sortedChanges) {
+		const index = getChangeIndex(change) + offset;
+		if (isStringInsertion(change)) {
+			text = text.slice(0, index) + change.text + text.slice(index);
+			offset += change.text.length;
+		} else {
+			text = text.slice(0, index) + text.slice(index + change.length);
+			offset -= change.length;
+		}
+	}
+
+	return text;
+}
+
+function assertChangesValid(changes: StringChange[]): void {
+	for (const change of changes) {
+		if (isStringInsertion(change)) {
+			if (!Number.isInteger(change.index)) {
+				throw new TypeError(`${change.index} must be an integer.`);
+			}
+			if (change.index < 0) {
+				throw new Error(`${change.index} must be a positive integer.`);
+			}
+			if (typeof change.text !== 'string') {
+				throw new Error(`${change.text} must be a string.`);
+			}
+		} else {
+			if (!Number.isInteger(change.start)) {
+				throw new TypeError(`${change.start} must be an integer.`);
+			}
+			if (change.start < 0) {
+				throw new Error(`${change.start} must be a positive integer.`);
+			}
+			if (!Number.isInteger(change.length)) {
+				throw new TypeError(`${change.length} must be an integer.`);
+			}
+			if (change.length < 0) {
+				throw new Error(`${change.length} must be a positive integer.`);
+			}
+		}
+	}
+}
+
+function getChangeIndex(change: StringChange): number {
+	return isStringInsertion(change) ? change.index : change.start;
+}
+
+function isStringInsertion(change: StringChange): change is StringInsertion {
+	return change.type === ChangeType.Insert;
+}


### PR DESCRIPTION
## Problem

Running `nx g @spartan-ng/cli:migrate-helm-libraries` (or `ui`) and selecting **all** primitives on an nx workspace with **buildable secondary entrypoints** crashes with:

```
NX   Invalid string length
```

Reported with `@spartan-ng/brain: 0.0.1-alpha.716`, ~30+ components. Selecting only a few works.

## Root cause

In buildable + entrypoint mode each primitive is generated as a secondary entrypoint into one shared library, via nx's `librarySecondaryEntryPointGenerator`. Its `updateTsConfigIncludedFiles` appends an entrypoint-prefixed copy of **every** existing `include`/`exclude` glob:

```js
json.include = [...json.include, ...newIncludes]; // re-prefixes every existing glob
```

Because it re-prefixes globs added by *previous* entrypoints too, the arrays roughly **double per primitive** (`2 → 4 → 8 → …`). Around the 22nd primitive the `JSON.stringify` inside `updateJson` exceeds V8's max string length (~536 MB) and throws `RangeError: Invalid string length`, which nx prints as `NX  Invalid string length`. That is why a few components work but "all" fails.

The `include` diff the reporter saw (`+ accordion/src/**/*.ts`, `+ accordion/**/*.ts`) is the first doubling step.

## Fix

After each secondary entrypoint is generated, collapse the redundant prefixed globs back to their recursive equivalents (`base/generator.ts` → `dedupeEntrypointGlobs`/`normalizeEntrypointTsConfig`). The library's recursive `**/*.ts` include already matches every entrypoint subdirectory, so the per-entrypoint copies are redundant. The normalization is idempotent, so the arrays stay bounded regardless of primitive count.

- **Angular CLI is unaffected** - it never generates buildable secondary entrypoints (it uses `addTsConfigPath`), so this code path isn't reached.
- Build output is equivalent: `nx build` of a 51-entrypoint library compiles every entrypoint with the collapsed globs.

## Also fixed (found while adding smoke coverage)

These were pre-existing and unrelated to the bug, but blocked the smoke suite from actually validating anything:

1. **Healthcheck crashed when the CLI is installed.** `migrate-icon`/`migrate-scroll-area` imported the deep path `@nx/devkit/src/utils/string-change`, which a published devkit blocks via its `exports` map (`Package subpath ... is not defined by "exports"`). Vendored the small util locally.
2. **Smoke cells silently skipped.** `describe.each('$id')` rendered cell ids wrapped in quotes (`'nx-entry-buildable'`), so CI's `--testNamePattern="<id> "` matched nothing. Switched to a `describe(cell.id)` loop.
3. **nx-daemon flakiness** under many back-to-back generators (`Failed to process project graph`) - disabled the daemon in the throwaway smoke workspaces.

## Tests

- New unit regression test reproduces the exact `Invalid string length` without the fix and passes with it (drives the real nx generator).
- New `all-components-nx-entry` smoke cell: all primitives as buildable entrypoints on nx - the exact failing shape. Passes locally end-to-end (generate → healthcheck → build) in ~2.4 min.
- Verified locally: full `cli` unit suite (165), `nx-entry-buildable` + `all-components-nx-entry` smoke cells, lint.

Draft to observe CI timing for the new all-components-nx-entry cell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented `tsconfig.lib.json` include/exclude globs from growing exponentially during repeated buildable entrypoint generation.
  * Improved stability when migrating Helm libraries, avoiding crashes and handling “no libraries to migrate” more reliably.

* **Tests**
  * Expanded the CLI smoke test matrix to cover an additional Nx all-components entrypoint scenario.
  * Strengthened generator regression coverage for buildable entrypoint handling and tsconfig bounding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->