### PR TITLE
ci: gate nightly release on commitlint and cli-smoke

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -136,8 +136,10 @@ jobs:
   release:
     needs:
       - check_date
+      - commitlint
       - build
       - format-and-lint
+      - cli-smoke
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Others

- [x] repo

## What is the current behavior?

I realized the nightly release smoke test fails. In the `nightly-release` workflow the `release` job runs
**in parallel** with `cli-smoke`. The `release` job publishes new `@spartan-ng` versions to npm while
`cli-smoke` is still running, so the smoke healthcheck sees the package `latest` version change underneath
it mid-run (you can see it drift, e.g. `0.0.1-alpha.716 → 0.0.1-alpha.717`, between cells) and the
angular-cli cells fail.

On top of that, `release` does not depend on `commitlint` or `cli-smoke` at all, so the nightly can publish
even when those checks are red.

## What is the new behavior?

Add `commitlint` and `cli-smoke` to the `release` job's `needs`:

- A red suite (commitlint, build, format-and-lint, or cli-smoke) now **blocks the publish** — we don't
  release if smoke fails.
- Because `release` now waits for `cli-smoke` to finish before it publishes, the two no longer overlap, so
  the concurrent-publish race that was making cli-smoke flaky should go away.

Tradeoff: the nightly is a bit slower, since `release` no longer runs in parallel with `cli-smoke`/`build`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly release workflow with additional prerequisite quality checks to ensure stricter validation before release deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->