### PR TITLE
fix(cli): respect configured npm registry in version healthcheck

### DIFF
--- a/libs/cli/src/generators/healthcheck/healthchecks/version.ts
+++ b/libs/cli/src/generators/healthcheck/healthchecks/version.ts
@@ -79,7 +79,11 @@ export const versionHealthcheck: Healthcheck = {
 
 async function fetchLatestMetadata(dep: string): Promise<PackageJson | null> {
 	try {
-		const request = await fetch(`https://registry.npmjs.org/${dep}/latest`);
+		// Respect the project's configured npm registry rather than hardcoding npmjs. This keeps the check
+		// correct against private registries, and lets the cli-smoke local registry (which publishes the
+		// freshly built packages as "latest") match the installed version instead of flagging a false drift.
+		const registry = (process.env.npm_config_registry || 'https://registry.npmjs.org').replace(/\/$/, '');
+		const request = await fetch(`${registry}/${dep}/latest`);
 
 		if (!request.ok) {
 			return null;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Others

- [x] cli

## What is the current behavior?

The `Spartan - Dependency Check` healthcheck hardcodes `registry.npmjs.org` when
resolving the latest `@spartan-ng/brain` and `@spartan-ng/cli` versions. Under the
`cli-smoke` nightly job this flags the locally published packages as outdated, and
because the smoke harness runs the healthcheck with `--auto-fix`, the fix rewrites
`package.json` to a version that does not exist in the local registry. The Angular
CLI then runs its post-generate install against that version, which fails, so the
`acli` and `all-components` smoke cells error out. (The nx cells pass because `nx g`
does not auto-run an install on `package.json` changes.)

Closes #

## What is the new behavior?

`fetchLatestMetadata` now resolves the latest version against `npm_config_registry`
(falling back to `https://registry.npmjs.org`). During smoke the harness already sets
that env var to the local registry, where the freshly built packages are `latest`, so
the installed version matches and no false drift is reported. This is also more correct
for real users installing from a private registry.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version checking to respect custom npm registry configurations, allowing users with private or custom npm registries to receive accurate "latest version" information for dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->