### PR TITLE
fix(cli): angular-cli component generation (embla peer range + tsconfig include)

### DIFF
--- a/libs/cli/src/generators/base/generator.spec.ts
+++ b/libs/cli/src/generators/base/generator.spec.ts
@@ -180,6 +180,26 @@ describe('hlmBaseGenerator', () => {
 		expect(tsconfigApp.include).toContain('src/**/*.ts');
 	});
 
+	it('preserves implicit src coverage when tsconfig.app.json has no include key', async () => {
+		// A tsconfig.app.json with no `include` implicitly compiles every `.ts` under the config dir. Seeding
+		// the array with only the lib glob would drop the app's own `src` from the editor program, so the
+		// helper must restore the implicit `src` coverage alongside the generated libs.
+		writeJson(tree, 'tsconfig.app.json', { extends: './tsconfig.json', files: ['src/main.ts'] });
+
+		await hlmBaseGenerator(tree, {
+			name: 'button',
+			directory: 'libs/test-ui',
+			buildable: false,
+			generateAs: 'library' as const,
+			importAlias: '@spartan-ng/helm',
+			angularCli: true,
+		});
+
+		const tsconfigApp = readJson(tree, 'tsconfig.app.json');
+		expect(tsconfigApp.include).toContain('libs/test-ui/**/src/**/*.ts');
+		expect(tsconfigApp.include).toContain('src/**/*.ts');
+	});
+
 	it('does not duplicate the components include across multiple angular-cli generations', async () => {
 		writeJson(tree, 'tsconfig.app.json', { include: ['src/**/*.ts'] });
 		const base = {

--- a/libs/cli/src/generators/base/generator.spec.ts
+++ b/libs/cli/src/generators/base/generator.spec.ts
@@ -158,7 +158,7 @@ describe('hlmBaseGenerator', () => {
 		);
 	});
 
-	it('adds the components dir to tsconfig.app.json include for angular-cli projects', async () => {
+	it('adds the generated components source dirs to tsconfig.app.json include for angular-cli projects', async () => {
 		// Simulate an Angular CLI app layout: a root tsconfig.app.json that only includes `src`. The generated
 		// libs live under libs/test-ui (outside src), so without this they'd be orphaned in the editor.
 		writeJson(tree, 'tsconfig.app.json', { extends: './tsconfig.json', include: ['src/**/*.ts'] });
@@ -173,7 +173,9 @@ describe('hlmBaseGenerator', () => {
 		});
 
 		const tsconfigApp = readJson(tree, 'tsconfig.app.json');
-		expect(tsconfigApp.include).toContain('libs/test-ui/**/*.ts');
+		expect(tsconfigApp.include).toContain('libs/test-ui/**/src/**/*.ts');
+		// keep the generated source files in the app project without pulling in specs/stories/helpers under libs/test-ui
+		expect(tsconfigApp.include).not.toContain('libs/test-ui/**/*.ts');
 		// the app's own src glob is preserved
 		expect(tsconfigApp.include).toContain('src/**/*.ts');
 	});
@@ -192,7 +194,7 @@ describe('hlmBaseGenerator', () => {
 		await hlmBaseGenerator(tree, { ...base, name: 'card' });
 
 		const tsconfigApp = readJson(tree, 'tsconfig.app.json');
-		const globCount = tsconfigApp.include.filter((glob: string) => glob === 'libs/test-ui/**/*.ts').length;
+		const globCount = tsconfigApp.include.filter((glob: string) => glob === 'libs/test-ui/**/src/**/*.ts').length;
 		expect(globCount).toBe(1);
 	});
 

--- a/libs/cli/src/generators/base/generator.spec.ts
+++ b/libs/cli/src/generators/base/generator.spec.ts
@@ -1,6 +1,13 @@
 import { applicationGenerator, E2eTestRunner, UnitTestRunner } from '@nx/angular/generators';
 import type { Schema } from '@nx/angular/src/generators/library/schema';
-import { addDependenciesToPackageJson, joinPathFragments, readJson, type Tree, updateJson } from '@nx/devkit';
+import {
+	addDependenciesToPackageJson,
+	joinPathFragments,
+	readJson,
+	type Tree,
+	updateJson,
+	writeJson,
+} from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { dedupeEntrypointGlobs, hlmBaseGenerator } from './generator';
 import { singleLibName } from './lib/single-lib-name';
@@ -149,6 +156,57 @@ describe('hlmBaseGenerator', () => {
 			{ '@angular/core': '^17.0.0' },
 			{ '@types/node': '^20.0.0' },
 		);
+	});
+
+	it('adds the components dir to tsconfig.app.json include for angular-cli projects', async () => {
+		// Simulate an Angular CLI app layout: a root tsconfig.app.json that only includes `src`. The generated
+		// libs live under libs/test-ui (outside src), so without this they'd be orphaned in the editor.
+		writeJson(tree, 'tsconfig.app.json', { extends: './tsconfig.json', include: ['src/**/*.ts'] });
+
+		await hlmBaseGenerator(tree, {
+			name: 'button',
+			directory: 'libs/test-ui',
+			buildable: false,
+			generateAs: 'library' as const,
+			importAlias: '@spartan-ng/helm',
+			angularCli: true,
+		});
+
+		const tsconfigApp = readJson(tree, 'tsconfig.app.json');
+		expect(tsconfigApp.include).toContain('libs/test-ui/**/*.ts');
+		// the app's own src glob is preserved
+		expect(tsconfigApp.include).toContain('src/**/*.ts');
+	});
+
+	it('does not duplicate the components include across multiple angular-cli generations', async () => {
+		writeJson(tree, 'tsconfig.app.json', { include: ['src/**/*.ts'] });
+		const base = {
+			directory: 'libs/test-ui',
+			buildable: false,
+			generateAs: 'library' as const,
+			importAlias: '@spartan-ng/helm',
+			angularCli: true,
+		};
+
+		await hlmBaseGenerator(tree, { ...base, name: 'button' });
+		await hlmBaseGenerator(tree, { ...base, name: 'card' });
+
+		const tsconfigApp = readJson(tree, 'tsconfig.app.json');
+		const globCount = tsconfigApp.include.filter((glob: string) => glob === 'libs/test-ui/**/*.ts').length;
+		expect(globCount).toBe(1);
+	});
+
+	it('leaves the workspace untouched when there is no tsconfig.app.json', async () => {
+		await hlmBaseGenerator(tree, {
+			name: 'button',
+			directory: 'libs/test-ui',
+			buildable: false,
+			generateAs: 'library' as const,
+			importAlias: '@spartan-ng/helm',
+			angularCli: true,
+		});
+
+		expect(tree.exists('tsconfig.app.json')).toBe(false);
 	});
 
 	it('should not duplicate paths in tsconfig.base.json on second run (idempotent)', async () => {

--- a/libs/cli/src/generators/base/generator.ts
+++ b/libs/cli/src/generators/base/generator.ts
@@ -50,6 +50,32 @@ function isAlreadyInstalled(tree: Tree, alias: string): boolean {
 
 function setupAngularCliProject(tree: Tree, alias: string, targetLibDir: string) {
 	addTsConfigPath(tree, alias, [`./${joinPathFragments(targetLibDir, 'src', 'index.ts').replace(/\\/g, '/')}`]);
+
+	// The generated libraries live outside the app's `src`, so they aren't covered by tsconfig.app.json's
+	// default `src/**/*.ts` include. The app still *builds* (the Angular builder follows the path-mapped
+	// imports into the libs), but the TS language server treats the generated files as orphans compiled
+	// without the root `paths`, so cross-lib imports (`@spartan-ng/helm/utils`, ...) show as "cannot find
+	// module" in the editor. Add the components base dir to the include so the files belong to the app
+	// project and resolve in-editor.
+	const componentsBaseDir = path.posix.dirname(targetLibDir.replace(/\\/g, '/'));
+	ensureAppTsConfigIncludes(tree, `${componentsBaseDir}/**/*.ts`);
+}
+
+// Adds `glob` to the Angular CLI app's tsconfig.app.json `include` (idempotent). Targets tsconfig.app.json
+// by convention - the default build/typecheck tsconfig for an `ng new` app; a non-standard app tsconfig is
+// left untouched (the spartan angular-cli flow assumes the default layout).
+function ensureAppTsConfigIncludes(tree: Tree, glob: string) {
+	const tsConfigAppPath = 'tsconfig.app.json';
+	if (!tree.exists(tsConfigAppPath)) {
+		return;
+	}
+	updateJson(tree, tsConfigAppPath, (json) => {
+		json.include = Array.isArray(json.include) ? json.include : [];
+		if (!json.include.includes(glob)) {
+			json.include.push(glob);
+		}
+		return json;
+	});
 }
 
 // nx's `librarySecondaryEntryPointGenerator` appends an entrypoint-prefixed copy of every existing

--- a/libs/cli/src/generators/base/generator.ts
+++ b/libs/cli/src/generators/base/generator.ts
@@ -71,7 +71,12 @@ function ensureAppTsConfigIncludes(tree: Tree, glob: string) {
 		return;
 	}
 	updateJson(tree, tsConfigAppPath, (json) => {
-		json.include = Array.isArray(json.include) ? json.include : [];
+		if (!Array.isArray(json.include)) {
+			// With no `include`, TypeScript implicitly compiles every `.ts` under the config dir. Seeding the
+			// array with just our glob would silently replace that with "only the generated libs", dropping the
+			// app's own `src` from the editor program. Preserve the implicit `src` coverage before appending.
+			json.include = ['src/**/*.ts'];
+		}
 		if (!json.include.includes(glob)) {
 			json.include.push(glob);
 		}

--- a/libs/cli/src/generators/base/generator.ts
+++ b/libs/cli/src/generators/base/generator.ts
@@ -55,10 +55,11 @@ function setupAngularCliProject(tree: Tree, alias: string, targetLibDir: string)
 	// default `src/**/*.ts` include. The app still *builds* (the Angular builder follows the path-mapped
 	// imports into the libs), but the TS language server treats the generated files as orphans compiled
 	// without the root `paths`, so cross-lib imports (`@spartan-ng/helm/utils`, ...) show as "cannot find
-	// module" in the editor. Add the components base dir to the include so the files belong to the app
-	// project and resolve in-editor.
+	// module" in the editor. Add the generated component source dirs to the include so the files belong to
+	// the app project and resolve in-editor, without pulling specs/stories/helpers under the components dir
+	// into the app program.
 	const componentsBaseDir = path.posix.dirname(targetLibDir.replace(/\\/g, '/'));
-	ensureAppTsConfigIncludes(tree, `${componentsBaseDir}/**/*.ts`);
+	ensureAppTsConfigIncludes(tree, `${componentsBaseDir}/**/src/**/*.ts`);
 }
 
 // Adds `glob` to the Angular CLI app's tsconfig.app.json `include` (idempotent). Targets tsconfig.app.json

--- a/libs/cli/src/generators/base/lib/build-dependency-array.spec.ts
+++ b/libs/cli/src/generators/base/lib/build-dependency-array.spec.ts
@@ -1,0 +1,70 @@
+import { type Tree, updateJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import type { HlmBaseGeneratorSchema } from '../schema';
+import { buildDependencyArray } from './build-dependency-array';
+
+describe('buildDependencyArray', () => {
+	let tree: Tree;
+
+	const carouselOptions: HlmBaseGeneratorSchema = {
+		name: 'carousel',
+		directory: 'libs/ui',
+		buildable: false,
+		generateAs: 'library',
+		importAlias: '@spartan-ng/helm',
+		peerDependencies: {
+			'embla-carousel': '>=8.0.0 <9.0.0',
+			'embla-carousel-angular': '>=21.0.0 <23.0.0',
+		},
+	};
+
+	beforeEach(() => {
+		tree = createTreeWithEmptyWorkspace();
+	});
+
+	function setAngularVersion(version: string | null) {
+		updateJson(tree, 'package.json', (json) => {
+			json.dependencies ??= {};
+			if (version === null) {
+				delete json.dependencies['@angular/core'];
+			} else {
+				json.dependencies['@angular/core'] = version;
+			}
+			return json;
+		});
+	}
+
+	it('pins embla-carousel-angular to the installed Angular major', () => {
+		setAngularVersion('^21.2.9');
+
+		const deps = buildDependencyArray(tree, carouselOptions, '^21.0.0');
+
+		expect(deps['embla-carousel-angular']).toBe('^21.0.0');
+		// other peer deps are passed through untouched
+		expect(deps['embla-carousel']).toBe('>=8.0.0 <9.0.0');
+	});
+
+	it('tracks whatever Angular major is installed', () => {
+		setAngularVersion('^22.0.1');
+
+		const deps = buildDependencyArray(tree, carouselOptions, '^22.0.0');
+
+		expect(deps['embla-carousel-angular']).toBe('^22.0.0');
+	});
+
+	it('falls back to the declared range when Angular cannot be resolved', () => {
+		setAngularVersion(null);
+
+		const deps = buildDependencyArray(tree, carouselOptions, '^21.0.0');
+
+		expect(deps['embla-carousel-angular']).toBe('>=21.0.0 <23.0.0');
+	});
+
+	it('does not introduce embla for primitives that do not declare it', () => {
+		setAngularVersion('^21.2.9');
+
+		const deps = buildDependencyArray(tree, { ...carouselOptions, name: 'button', peerDependencies: {} }, '^21.0.0');
+
+		expect(deps).not.toHaveProperty('embla-carousel-angular');
+	});
+});

--- a/libs/cli/src/generators/base/lib/build-dependency-array.ts
+++ b/libs/cli/src/generators/base/lib/build-dependency-array.ts
@@ -22,7 +22,7 @@ export function buildDependencyArray(tree: Tree, options: HlmBaseGeneratorSchema
 	if (dependencies['embla-carousel-angular']) {
 		const angularVersion = getInstalledPackageVersion(tree, '@angular/core', undefined, false);
 		const angularMajor = angularVersion ? major(angularVersion) : null;
-		if (angularMajor) {
+		if (angularMajor !== null) {
 			dependencies['embla-carousel-angular'] = `^${angularMajor}.0.0`;
 		}
 	}

--- a/libs/cli/src/generators/base/lib/build-dependency-array.ts
+++ b/libs/cli/src/generators/base/lib/build-dependency-array.ts
@@ -1,4 +1,5 @@
 import { type Tree } from '@nx/devkit';
+import { major } from 'semver';
 import { getInstalledPackageVersion } from '../../../utils/version-utils';
 import type { HlmBaseGeneratorSchema } from '../schema';
 import { NG_ICONS_VERSION, TAILWIND_MERGE_VERSION, TW_ANIMATE_CSS } from '../versions';
@@ -12,6 +13,18 @@ export function buildDependencyArray(tree: Tree, options: HlmBaseGeneratorSchema
 
 	if (options.peerDependencies) {
 		dependencies = { ...dependencies, ...options.peerDependencies };
+	}
+
+	// embla-carousel-angular majors track the Angular major (v21 -> Angular 21, v22 -> Angular 22). A static
+	// range in supported-ui-libraries.json can't know the consumer's Angular version, so npm resolves the
+	// highest match and pulls a major whose peer range excludes an older Angular (ERESOLVE). Pin it to the
+	// installed Angular major instead. Falls back to the declared range when Angular can't be resolved.
+	if (dependencies['embla-carousel-angular']) {
+		const angularVersion = getInstalledPackageVersion(tree, '@angular/core', undefined, false);
+		const angularMajor = angularVersion ? major(angularVersion) : null;
+		if (angularMajor) {
+			dependencies['embla-carousel-angular'] = `^${angularMajor}.0.0`;
+		}
 	}
 
 	if (options.name === 'icon' || options.name === 'spinner') {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Others

- [x] cli

## What is the current behavior?

Two issues surface when generating spartan components into an **Angular CLI** app
(`ng g @spartan-ng/cli:ui`):

1. **Carousel install fails with ERESOLVE.** The carousel primitive declares
   `embla-carousel-angular: ">=21.0.0 <23.0.0"`. That package's major tracks the
   Angular major (v21 → Angular 21, v22 → Angular 22), so on an Angular 21 workspace
   npm resolves the highest match (`22.x`), whose peer is `@angular/common >=22.0.0`,
   and the install fails.
2. **Generated libs are unresolved in the editor.** The generator writes libraries
   under the configured directory (e.g. `libs/ui`), outside the app's `src`. The app
   still *builds* (the Angular builder follows the path-mapped imports into the libs),
   but the TS language server treats the generated files as orphans compiled without
   the root `paths` mapping, so cross-lib imports (`@spartan-ng/helm/utils`, ...) show
   as "cannot find module".

Closes #

## What is the new behavior?

1. Pin `embla-carousel-angular` to the installed Angular major at generate time
   instead of a static range. Falls back to the declared range when Angular can't be
   resolved.
2. Add the components base dir to `tsconfig.app.json`'s `include` so the generated
   files belong to the app project and resolve in-editor. Idempotent, and a no-op when
   there is no `tsconfig.app.json`.

Both paths are covered by unit tests.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The `include` fix targets `tsconfig.app.json` by convention (the default `ng new`
build/typecheck tsconfig); a non-standard app tsconfig is left untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced support for Angular CLI projects with automatic TypeScript configuration updates for generated libraries
  * Improved dependency version resolution that intelligently pins library versions to installed framework majors

* **Tests**
  * Added comprehensive test coverage for dependency resolution and project configuration handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->