### PR TITLE
fix(accordion): use natural height for dynamic content

### DIFF
--- a/apps/ui-storybook/stories/accordion.stories.ts
+++ b/apps/ui-storybook/stories/accordion.stories.ts
@@ -298,6 +298,75 @@ export const TestAriaValidWithIcon: Story = {
 	},
 };
 
+export const DynamicContent: Story = {
+	render: () => ({
+		moduleMetadata: {
+			imports: [AccordionDynamicContentStory],
+		},
+		template: `<accordion-dynamic-content />`,
+	}),
+};
+
+@Component({
+	selector: 'accordion-dynamic-content',
+	imports: [HlmAccordionImports, HlmButtonImports],
+	host: {
+		class: 'block w-[420px]',
+	},
+	template: `
+		<div class="mb-4 flex flex-wrap gap-2">
+			<button hlmBtn size="sm" (click)="addContent()">Add content</button>
+			<button hlmBtn size="sm" variant="secondary" (click)="toggle()">Toggle</button>
+			<button hlmBtn size="sm" variant="outline" (click)="resetContent()">Reset</button>
+		</div>
+
+		<hlm-accordion type="multiple">
+			<hlm-accordion-item [isOpened]="_isOpen()" (openedChange)="_isOpen.set($event)">
+				<hlm-accordion-trigger>Dynamic content</hlm-accordion-trigger>
+				<hlm-accordion-content>
+					<div class="space-y-3">
+						@for (item of _items(); track item.id) {
+							<p class="rounded-md border p-3 text-sm">
+								{{ item.text }}
+							</p>
+						}
+					</div>
+				</hlm-accordion-content>
+			</hlm-accordion-item>
+
+			<hlm-accordion-item>
+				<hlm-accordion-trigger>Stable sibling</hlm-accordion-trigger>
+				<hlm-accordion-content>
+					This panel gives you a second trigger to test toggling and focus behavior while the first panel changes.
+				</hlm-accordion-content>
+			</hlm-accordion-item>
+		</hlm-accordion>
+	`,
+})
+export class AccordionDynamicContentStory {
+	private _nextId = 2;
+	protected readonly _isOpen = signal(true);
+	protected readonly _items = signal([{ id: 1, text: 'Initial accordion content.' }]);
+
+	protected addContent(): void {
+		const id = this._nextId++;
+		this._items.update((items) => [
+			...items,
+			{ id, text: `Dynamically added content row ${id}. Toggle the panel and add more rows to test height updates.` },
+		]);
+	}
+
+	protected toggle(): void {
+		this._isOpen.update((isOpen) => !isOpen);
+	}
+
+	protected resetContent(): void {
+		this._nextId = 2;
+		this._isOpen.set(true);
+		this._items.set([{ id: 1, text: 'Initial accordion content.' }]);
+	}
+}
+
 // Button State Sync
 export const ButtonStateSync: Story = {
 	render: () => ({

--- a/libs/brain/accordion/src/lib/brn-accordion-content.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-content.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, afterEveryRender, afterNextRender, computed, inject, input, signal } from '@angular/core';
+import { DestroyRef, Directive, ElementRef, NgZone, afterNextRender, computed, inject, input, signal } from '@angular/core';
 import { measureDimensions } from '@spartan-ng/brain/core';
 import { injectBrnAccordionConfig, injectBrnAccordionItem } from './brn-accordion-token';
 
@@ -19,6 +19,12 @@ export class BrnAccordionContent {
 	private readonly _config = injectBrnAccordionConfig();
 	private readonly _item = injectBrnAccordionItem();
 	private readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+	private readonly _destroyRef = inject(DestroyRef);
+	private readonly _ngZone = inject(NgZone);
+	private _resizeObserver: ResizeObserver | null = null;
+	private _mutationObserver: MutationObserver | null = null;
+	private readonly _observedElements = new Set<Element>();
+	private _measurementFrame = 0;
 
 	protected readonly _width = signal<number | null>(null);
 	protected readonly _height = signal<number | null>(null);
@@ -37,12 +43,11 @@ export class BrnAccordionContent {
 		if (!this._item) {
 			throw Error('Accordion Content can only be used inside an AccordionItem. Add brnAccordionItem to parent.');
 		}
-		// The fallback mutates display styles to measure hidden content, so keep it out of the recurring read phase.
 		afterNextRender({
-			mixedReadWrite: () => this._measureAndSetDimensions({ allowDisplayFallback: true }),
-		});
-		afterEveryRender({
-			read: () => this._measureAndSetDimensions(),
+			mixedReadWrite: () => {
+				this._measureAndSetDimensions({ allowDisplayFallback: true });
+				this._setupResizeObserver();
+			},
 		});
 	}
 
@@ -66,5 +71,60 @@ export class BrnAccordionContent {
 		if (height !== this._height()) {
 			this._height.set(height);
 		}
+	}
+
+	private _setupResizeObserver(): void {
+		if (typeof ResizeObserver === 'undefined') return;
+
+		const element = this._elementRef.nativeElement;
+
+		this._ngZone.runOutsideAngular(() => {
+			this._resizeObserver = new ResizeObserver(() => this._queueMeasurement());
+			this._observeContentElements();
+
+			if (typeof MutationObserver !== 'undefined') {
+				this._mutationObserver = new MutationObserver((records) => {
+					if (records.some((record) => record.target === element && record.type === 'childList')) {
+						this._observeContentElements();
+					}
+					this._queueMeasurement();
+				});
+				this._mutationObserver.observe(element, { childList: true, characterData: true, subtree: true });
+			}
+
+			this._destroyRef.onDestroy(() => {
+				this._resizeObserver?.disconnect();
+				this._mutationObserver?.disconnect();
+				if (this._measurementFrame) {
+					cancelAnimationFrame(this._measurementFrame);
+				}
+			});
+		});
+	}
+
+	private _observeContentElements(): void {
+		if (!this._resizeObserver) return;
+
+		for (const observedElement of this._observedElements) {
+			this._resizeObserver.unobserve(observedElement);
+		}
+		this._observedElements.clear();
+
+		const element = this._elementRef.nativeElement;
+		const elementsToObserve = element.children.length > 0 ? Array.from(element.children) : [element];
+
+		for (const elementToObserve of elementsToObserve) {
+			this._resizeObserver.observe(elementToObserve);
+			this._observedElements.add(elementToObserve);
+		}
+	}
+
+	private _queueMeasurement(): void {
+		if (this._measurementFrame) return;
+
+		this._measurementFrame = requestAnimationFrame(() => {
+			this._measurementFrame = 0;
+			this._ngZone.run(() => this._measureAndSetDimensions());
+		});
 	}
 }

--- a/libs/brain/accordion/src/lib/brn-accordion-content.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-content.ts
@@ -1,16 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
-import {
-	DestroyRef,
-	Directive,
-	ElementRef,
-	NgZone,
-	PLATFORM_ID,
-	afterNextRender,
-	computed,
-	inject,
-	input,
-	signal,
-} from '@angular/core';
+import { Directive, ElementRef, afterEveryRender, computed, inject, input, signal } from '@angular/core';
 import { measureDimensions } from '@spartan-ng/brain/core';
 import { injectBrnAccordionConfig, injectBrnAccordionItem } from './brn-accordion-token';
 
@@ -30,10 +18,7 @@ import { injectBrnAccordionConfig, injectBrnAccordionItem } from './brn-accordio
 export class BrnAccordionContent {
 	private readonly _config = injectBrnAccordionConfig();
 	private readonly _item = injectBrnAccordionItem();
-	private readonly _elementRef = inject(ElementRef);
-	private readonly _destroyRef = inject(DestroyRef);
-	private readonly _ngZone = inject(NgZone);
-	private readonly _platformId = inject(PLATFORM_ID);
+	private readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
 	protected readonly _width = signal<number | null>(null);
 	protected readonly _height = signal<number | null>(null);
@@ -52,45 +37,26 @@ export class BrnAccordionContent {
 		if (!this._item) {
 			throw Error('Accordion Content can only be used inside an AccordionItem. Add brnAccordionItem to parent.');
 		}
-		afterNextRender(() => {
-			const hasValidDimensions = this._measureAndSetDimensions();
-			if (!hasValidDimensions) {
-				this._setupVisibilityObserver();
-			}
+		afterEveryRender({
+			read: () => this._measureAndSetDimensions(),
 		});
 	}
 
-	private _measureAndSetDimensions(): boolean {
-		const content = this._elementRef.nativeElement.firstChild as HTMLElement | null;
-		if (!content) return false;
+	private _measureAndSetDimensions(): void {
+		const element = this._elementRef.nativeElement;
+		let width = element.scrollWidth;
+		let height = element.scrollHeight;
 
-		const { width, height } = measureDimensions(content, this._config.measurementDisplay);
-		this._width.set(width);
-		this._height.set(height);
+		if (width === 0 && height === 0) {
+			const elementToMeasure = (element.firstElementChild as HTMLElement | null) ?? element;
+			({ width, height } = measureDimensions(elementToMeasure, this._config.measurementDisplay));
+		}
 
-		return width > 0 && height > 0;
-	}
-
-	private _setupVisibilityObserver(): void {
-		if (!isPlatformBrowser(this._platformId)) return;
-		if (typeof IntersectionObserver === 'undefined') return;
-
-		this._ngZone.runOutsideAngular(() => {
-			const observer = new IntersectionObserver(
-				(entries) => {
-					if (entries[0].isIntersecting) {
-						this._ngZone.run(() => {
-							if (this._measureAndSetDimensions()) {
-								observer.disconnect();
-							}
-						});
-					}
-				},
-				{ root: null, threshold: 0 },
-			);
-
-			observer.observe(this._elementRef.nativeElement);
-			this._destroyRef.onDestroy(() => observer.disconnect());
-		});
+		if (width !== this._width()) {
+			this._width.set(width);
+		}
+		if (height !== this._height()) {
+			this._height.set(height);
+		}
 	}
 }

--- a/libs/brain/accordion/src/lib/brn-accordion-content.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-content.ts
@@ -1,6 +1,5 @@
-import { DestroyRef, Directive, ElementRef, NgZone, afterNextRender, computed, inject, input, signal } from '@angular/core';
-import { measureDimensions } from '@spartan-ng/brain/core';
-import { injectBrnAccordionConfig, injectBrnAccordionItem } from './brn-accordion-token';
+import { Directive, computed } from '@angular/core';
+import { injectBrnAccordionItem } from './brn-accordion-token';
 
 @Directive({
 	selector: 'brn-accordion-content,[brnAccordionContent]',
@@ -9,122 +8,21 @@ import { injectBrnAccordionConfig, injectBrnAccordionItem } from './brn-accordio
 		'[attr.aria-labelledby]': 'ariaLabeledBy',
 		role: 'region',
 		'[id]': 'id',
-		'[style.--brn-accordion-content-width.px]': '_width()',
-		'[style.--brn-accordion-content-height.px]': '_height()',
 		'[attr.inert]': '_inert()',
-		'[attr.style]': 'style()',
 	},
 })
 export class BrnAccordionContent {
-	private readonly _config = injectBrnAccordionConfig();
 	private readonly _item = injectBrnAccordionItem();
-	private readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
-	private readonly _destroyRef = inject(DestroyRef);
-	private readonly _ngZone = inject(NgZone);
-	private _resizeObserver: ResizeObserver | null = null;
-	private _mutationObserver: MutationObserver | null = null;
-	private readonly _observedElements = new Set<Element>();
-	private _measurementFrame = 0;
 
-	protected readonly _width = signal<number | null>(null);
-	protected readonly _height = signal<number | null>(null);
 	protected readonly _inert = computed(() => (this.state?.() === 'closed' ? true : undefined));
 
 	public readonly state = this._item?.state;
 	public readonly id = `brn-accordion-content-${this._item?.id}`;
 	public readonly ariaLabeledBy = `brn-accordion-trigger-${this._item?.id}`;
-	/**
-	 * The style to be applied to the host element after the dimensions are calculated.
-	 * @default 'overflow: hidden'
-	 */
-	public readonly style = input<string>('overflow: hidden');
 
 	constructor() {
 		if (!this._item) {
 			throw Error('Accordion Content can only be used inside an AccordionItem. Add brnAccordionItem to parent.');
 		}
-		afterNextRender({
-			mixedReadWrite: () => {
-				this._measureAndSetDimensions({ allowDisplayFallback: true });
-				this._setupResizeObserver();
-			},
-		});
-	}
-
-	private _measureAndSetDimensions(options: { allowDisplayFallback?: boolean } = {}): void {
-		const element = this._elementRef.nativeElement;
-		let width = element.scrollWidth;
-		let height = element.scrollHeight;
-
-		if (width === 0 && height === 0) {
-			if (options.allowDisplayFallback) {
-				const elementToMeasure = (element.firstElementChild as HTMLElement | null) ?? element;
-				({ width, height } = measureDimensions(elementToMeasure, this._config.measurementDisplay));
-			} else if (element.getClientRects().length === 0) {
-				return;
-			}
-		}
-
-		if (width !== this._width()) {
-			this._width.set(width);
-		}
-		if (height !== this._height()) {
-			this._height.set(height);
-		}
-	}
-
-	private _setupResizeObserver(): void {
-		if (typeof ResizeObserver === 'undefined') return;
-
-		const element = this._elementRef.nativeElement;
-
-		this._ngZone.runOutsideAngular(() => {
-			this._resizeObserver = new ResizeObserver(() => this._queueMeasurement());
-			this._observeContentElements();
-
-			if (typeof MutationObserver !== 'undefined') {
-				this._mutationObserver = new MutationObserver((records) => {
-					if (records.some((record) => record.target === element && record.type === 'childList')) {
-						this._observeContentElements();
-					}
-					this._queueMeasurement();
-				});
-				this._mutationObserver.observe(element, { childList: true, characterData: true, subtree: true });
-			}
-
-			this._destroyRef.onDestroy(() => {
-				this._resizeObserver?.disconnect();
-				this._mutationObserver?.disconnect();
-				if (this._measurementFrame) {
-					cancelAnimationFrame(this._measurementFrame);
-				}
-			});
-		});
-	}
-
-	private _observeContentElements(): void {
-		if (!this._resizeObserver) return;
-
-		for (const observedElement of this._observedElements) {
-			this._resizeObserver.unobserve(observedElement);
-		}
-		this._observedElements.clear();
-
-		const element = this._elementRef.nativeElement;
-		const elementsToObserve = element.children.length > 0 ? Array.from(element.children) : [element];
-
-		for (const elementToObserve of elementsToObserve) {
-			this._resizeObserver.observe(elementToObserve);
-			this._observedElements.add(elementToObserve);
-		}
-	}
-
-	private _queueMeasurement(): void {
-		if (this._measurementFrame) return;
-
-		this._measurementFrame = requestAnimationFrame(() => {
-			this._measurementFrame = 0;
-			this._ngZone.run(() => this._measureAndSetDimensions());
-		});
 	}
 }

--- a/libs/brain/accordion/src/lib/brn-accordion-content.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-content.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, afterEveryRender, computed, inject, input, signal } from '@angular/core';
+import { Directive, ElementRef, afterEveryRender, afterNextRender, computed, inject, input, signal } from '@angular/core';
 import { measureDimensions } from '@spartan-ng/brain/core';
 import { injectBrnAccordionConfig, injectBrnAccordionItem } from './brn-accordion-token';
 
@@ -37,19 +37,27 @@ export class BrnAccordionContent {
 		if (!this._item) {
 			throw Error('Accordion Content can only be used inside an AccordionItem. Add brnAccordionItem to parent.');
 		}
+		// The fallback mutates display styles to measure hidden content, so keep it out of the recurring read phase.
+		afterNextRender({
+			mixedReadWrite: () => this._measureAndSetDimensions({ allowDisplayFallback: true }),
+		});
 		afterEveryRender({
 			read: () => this._measureAndSetDimensions(),
 		});
 	}
 
-	private _measureAndSetDimensions(): void {
+	private _measureAndSetDimensions(options: { allowDisplayFallback?: boolean } = {}): void {
 		const element = this._elementRef.nativeElement;
 		let width = element.scrollWidth;
 		let height = element.scrollHeight;
 
 		if (width === 0 && height === 0) {
-			const elementToMeasure = (element.firstElementChild as HTMLElement | null) ?? element;
-			({ width, height } = measureDimensions(elementToMeasure, this._config.measurementDisplay));
+			if (options.allowDisplayFallback) {
+				const elementToMeasure = (element.firstElementChild as HTMLElement | null) ?? element;
+				({ width, height } = measureDimensions(elementToMeasure, this._config.measurementDisplay));
+			} else if (element.getClientRects().length === 0) {
+				return;
+			}
 		}
 
 		if (width !== this._width()) {

--- a/libs/brain/accordion/src/lib/brn-accordion-content.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-content.ts
@@ -1,4 +1,4 @@
-import { Directive, computed } from '@angular/core';
+import { Directive, computed, input } from '@angular/core';
 import { injectBrnAccordionItem } from './brn-accordion-token';
 
 @Directive({
@@ -9,6 +9,7 @@ import { injectBrnAccordionItem } from './brn-accordion-token';
 		role: 'region',
 		'[id]': 'id',
 		'[attr.inert]': '_inert()',
+		'[attr.style]': 'style()',
 	},
 })
 export class BrnAccordionContent {
@@ -19,6 +20,11 @@ export class BrnAccordionContent {
 	public readonly state = this._item?.state;
 	public readonly id = `brn-accordion-content-${this._item?.id}`;
 	public readonly ariaLabeledBy = `brn-accordion-trigger-${this._item?.id}`;
+	/**
+	 * The style to be applied to the host element.
+	 * @default 'overflow: hidden'
+	 */
+	public readonly style = input<string>('overflow: hidden');
 
 	constructor() {
 		if (!this._item) {

--- a/libs/brain/accordion/src/lib/brn-accordion-token.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-token.ts
@@ -1,5 +1,4 @@
-import { type ExistingProvider, inject, InjectionToken, type Type, type ValueProvider } from '@angular/core';
-import type { MeasurementDisplay } from '@spartan-ng/brain/core';
+import { type ExistingProvider, inject, InjectionToken, type Type } from '@angular/core';
 import type { BrnAccordion } from './brn-accordion';
 import type { BrnAccordionItem } from './brn-accordion-item';
 
@@ -21,26 +20,4 @@ export function injectBrnAccordionItem() {
 
 export function provideBrnAccordionItem(item: Type<BrnAccordionItem>): ExistingProvider {
 	return { provide: BrnAccordionItemToken, useExisting: item };
-}
-
-export interface BrBrnAccordionConfig {
-	/**
-	 * The display style to use when measuring element dimensions.
-	 * @default 'block'
-	 */
-	measurementDisplay: MeasurementDisplay;
-}
-
-const defaultConfig: BrBrnAccordionConfig = {
-	measurementDisplay: 'block',
-};
-
-const BrnAccordionConfigToken = new InjectionToken<BrBrnAccordionConfig>('BrnBrnAccordionConfig');
-
-export function provideBrnAccordionConfig(config: Partial<BrBrnAccordionConfig>): ValueProvider {
-	return { provide: BrnAccordionConfigToken, useValue: { ...defaultConfig, ...config } };
-}
-
-export function injectBrnAccordionConfig(): BrBrnAccordionConfig {
-	return inject(BrnAccordionConfigToken, { optional: true }) ?? defaultConfig;
 }

--- a/libs/brain/accordion/src/lib/brn-accordion.spec.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.spec.ts
@@ -1,6 +1,6 @@
 import { FocusMonitor, type FocusOrigin } from '@angular/cdk/a11y';
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
-import { render, screen, waitFor } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 import { config, type Observable, Subject } from 'rxjs';
 import { BrnAccordion } from './brn-accordion';
 import { BrnAccordionContent } from './brn-accordion-content';
@@ -97,30 +97,10 @@ class AccordionTriggerFocusDuringRenderSpec extends ProbeHost {}
 	imports: [BrnAccordion, BrnAccordionItem, BrnAccordionTrigger, BrnAccordionContent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
-		<style>
-			[data-accordion-dynamic] [brnaccordionitem] {
-				display: flex;
-				flex-direction: column;
-			}
-
-			[data-accordion-dynamic] brn-accordion-content {
-				display: block;
-				overflow: hidden;
-			}
-
-			[data-accordion-dynamic] brn-accordion-content[data-state='closed'] {
-				height: 0;
-			}
-
-			[data-accordion-dynamic] brn-accordion-content[data-state='open'] {
-				height: var(--brn-accordion-content-height);
-			}
-		</style>
-
-		<div brnAccordion data-accordion-dynamic>
+		<div brnAccordion>
 			<div brnAccordionItem [isOpened]="isOpened()">
 				<h3>
-					<button brnAccordionTrigger data-testid="dynamic-trigger">Dynamic item</button>
+					<button brnAccordionTrigger data-testid="state-trigger">State item</button>
 				</h3>
 				<brn-accordion-content data-testid="content">
 					<div>
@@ -172,35 +152,20 @@ describe('BrnAccordion', () => {
 		expect(ng0600Errors(errors)).toEqual([]);
 	});
 
-	it('updates the measured height when open content changes size', async () => {
+	it('keeps content state accessible when projected content changes', async () => {
 		const { fixture } = await render(AccordionDynamicContentSpec);
 		const content = screen.getByTestId('content');
 
-		await waitFor(() => expect(content.style.getPropertyValue('--brn-accordion-content-height')).toBe('20px'));
+		expect(content.getAttribute('data-state')).toBe('open');
+		expect(content.getAttribute('inert')).toBeNull();
 
 		fixture.componentInstance.contentItems.set([1, 2]);
 		await fixture.whenStable();
-
-		await waitFor(() => expect(content.style.getPropertyValue('--brn-accordion-content-height')).toBe('40px'));
-		await waitFor(() => expect(getComputedStyle(content).height).toBe('40px'));
-	});
-
-	it('updates the measured height when closed content changes size before opening', async () => {
-		const { fixture } = await render(AccordionDynamicContentSpec);
-		const content = screen.getByTestId('content');
 
 		fixture.componentInstance.isOpened.set(false);
 		await fixture.whenStable();
-		await waitFor(() => expect(getComputedStyle(content).height).toBe('0px'));
 
-		fixture.componentInstance.contentItems.set([1, 2]);
-		await fixture.whenStable();
-
-		await waitFor(() => expect(content.style.getPropertyValue('--brn-accordion-content-height')).toBe('40px'));
-
-		fixture.componentInstance.isOpened.set(true);
-		await fixture.whenStable();
-
-		await waitFor(() => expect(getComputedStyle(content).height).toBe('40px'));
+		expect(content.getAttribute('data-state')).toBe('closed');
+		expect(content.getAttribute('inert')).toBe('true');
 	});
 });

--- a/libs/brain/accordion/src/lib/brn-accordion.spec.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion.spec.ts
@@ -1,6 +1,6 @@
 import { FocusMonitor, type FocusOrigin } from '@angular/cdk/a11y';
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
-import { render, screen } from '@testing-library/angular';
+import { render, screen, waitFor } from '@testing-library/angular';
 import { config, type Observable, Subject } from 'rxjs';
 import { BrnAccordion } from './brn-accordion';
 import { BrnAccordionContent } from './brn-accordion-content';
@@ -93,6 +93,51 @@ class AccordionBlurDuringRenderSpec extends ProbeHost {}
 })
 class AccordionTriggerFocusDuringRenderSpec extends ProbeHost {}
 
+@Component({
+	imports: [BrnAccordion, BrnAccordionItem, BrnAccordionTrigger, BrnAccordionContent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<style>
+			[data-accordion-dynamic] [brnaccordionitem] {
+				display: flex;
+				flex-direction: column;
+			}
+
+			[data-accordion-dynamic] brn-accordion-content {
+				display: block;
+				overflow: hidden;
+			}
+
+			[data-accordion-dynamic] brn-accordion-content[data-state='closed'] {
+				height: 0;
+			}
+
+			[data-accordion-dynamic] brn-accordion-content[data-state='open'] {
+				height: var(--brn-accordion-content-height);
+			}
+		</style>
+
+		<div brnAccordion data-accordion-dynamic>
+			<div brnAccordionItem [isOpened]="isOpened()">
+				<h3>
+					<button brnAccordionTrigger data-testid="dynamic-trigger">Dynamic item</button>
+				</h3>
+				<brn-accordion-content data-testid="content">
+					<div>
+						@for (item of contentItems(); track item) {
+							<div style="height: 20px">Dynamic content</div>
+						}
+					</div>
+				</brn-accordion-content>
+			</div>
+		</div>
+	`,
+})
+class AccordionDynamicContentSpec {
+	public readonly isOpened = signal(true);
+	public readonly contentItems = signal([1]);
+}
+
 describe('BrnAccordion', () => {
 	// #1371: disabling a focused child blurs it during CD, so the FocusMonitor emits mid-render.
 	it('does not throw NG0600 when the focus monitor emits during change detection', async () => {
@@ -125,5 +170,37 @@ describe('BrnAccordion', () => {
 		});
 
 		expect(ng0600Errors(errors)).toEqual([]);
+	});
+
+	it('updates the measured height when open content changes size', async () => {
+		const { fixture } = await render(AccordionDynamicContentSpec);
+		const content = screen.getByTestId('content');
+
+		await waitFor(() => expect(content.style.getPropertyValue('--brn-accordion-content-height')).toBe('20px'));
+
+		fixture.componentInstance.contentItems.set([1, 2]);
+		await fixture.whenStable();
+
+		await waitFor(() => expect(content.style.getPropertyValue('--brn-accordion-content-height')).toBe('40px'));
+		await waitFor(() => expect(getComputedStyle(content).height).toBe('40px'));
+	});
+
+	it('updates the measured height when closed content changes size before opening', async () => {
+		const { fixture } = await render(AccordionDynamicContentSpec);
+		const content = screen.getByTestId('content');
+
+		fixture.componentInstance.isOpened.set(false);
+		await fixture.whenStable();
+		await waitFor(() => expect(getComputedStyle(content).height).toBe('0px'));
+
+		fixture.componentInstance.contentItems.set([1, 2]);
+		await fixture.whenStable();
+
+		await waitFor(() => expect(content.style.getPropertyValue('--brn-accordion-content-height')).toBe('40px'));
+
+		fixture.componentInstance.isOpened.set(true);
+		await fixture.whenStable();
+
+		await waitFor(() => expect(getComputedStyle(content).height).toBe('40px'));
 	});
 });

--- a/libs/cli/src/generators/ui/libs/accordion/files/lib/hlm-accordion-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/accordion/files/lib/hlm-accordion-content.ts.template
@@ -5,7 +5,7 @@ import { classes } from '<%- importAlias %>/utils';
 @Component({
 	selector: 'hlm-accordion-content',
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	hostDirectives: [BrnAccordionContent],
+	hostDirectives: [{ directive: BrnAccordionContent, inputs: ['style'] }],
 	host: {
 		'data-slot': 'accordion-content',
 	},

--- a/libs/cli/src/generators/ui/libs/accordion/files/lib/hlm-accordion-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/accordion/files/lib/hlm-accordion-content.ts.template
@@ -5,7 +5,7 @@ import { classes } from '<%- importAlias %>/utils';
 @Component({
 	selector: 'hlm-accordion-content',
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	hostDirectives: [{ directive: BrnAccordionContent, inputs: ['style'] }],
+	hostDirectives: [BrnAccordionContent],
 	host: {
 		'data-slot': 'accordion-content',
 	},
@@ -21,7 +21,7 @@ export class HlmAccordionContent {
 	constructor() {
 		classes(
 			() =>
-				'spartan-accordion-content transition-all data-[state=closed]:h-0 data-[state=open]:h-(--brn-accordion-content-height)',
+				'spartan-accordion-content overflow-hidden data-[state=closed]:h-0 data-[state=open]:h-auto',
 		);
 	}
 }

--- a/libs/helm/accordion/src/lib/hlm-accordion-content.spec.ts
+++ b/libs/helm/accordion/src/lib/hlm-accordion-content.spec.ts
@@ -1,0 +1,48 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { render, screen, waitFor } from '@testing-library/angular';
+import { HlmAccordionImports } from '../index';
+
+@Component({
+	imports: [HlmAccordionImports],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<hlm-accordion>
+			<hlm-accordion-item [isOpened]="isOpened()">
+				<hlm-accordion-trigger>Dynamic item</hlm-accordion-trigger>
+				<hlm-accordion-content class="custom-content" data-testid="content">
+					<div data-testid="inner">
+						@for (item of contentItems(); track item) {
+							<div>Dynamic content</div>
+						}
+					</div>
+				</hlm-accordion-content>
+			</hlm-accordion-item>
+		</hlm-accordion>
+	`,
+})
+class HlmAccordionDynamicContentSpec {
+	public readonly isOpened = signal(true);
+	public readonly contentItems = signal([1]);
+}
+
+describe('HlmAccordionContent', () => {
+	it('uses an understandable height collapse contract with natural open height', async () => {
+		const { fixture } = await render(HlmAccordionDynamicContentSpec);
+		const content = screen.getByTestId('content');
+		const inner = content.querySelector('.spartan-accordion-content-inner');
+
+		await waitFor(() => expect(content.classList.contains('spartan-accordion-content')).toBe(true));
+
+		expect(content.classList.contains('custom-content')).toBe(true);
+		expect(content.classList.contains('overflow-hidden')).toBe(true);
+		expect(content.classList.contains('data-[state=closed]:h-0')).toBe(true);
+		expect(content.classList.contains('data-[state=open]:h-auto')).toBe(true);
+		expect(inner?.classList.contains('spartan-accordion-content-inner')).toBe(true);
+
+		fixture.componentInstance.contentItems.set([1, 2]);
+		fixture.componentInstance.isOpened.set(false);
+		await fixture.whenStable();
+
+		expect(content.getAttribute('data-state')).toBe('closed');
+	});
+});

--- a/libs/helm/accordion/src/lib/hlm-accordion-content.ts
+++ b/libs/helm/accordion/src/lib/hlm-accordion-content.ts
@@ -5,7 +5,7 @@ import { classes } from '@spartan-ng/helm/utils';
 @Component({
 	selector: 'hlm-accordion-content',
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	hostDirectives: [{ directive: BrnAccordionContent, inputs: ['style'] }],
+	hostDirectives: [BrnAccordionContent],
 	host: {
 		'data-slot': 'accordion-content',
 	},
@@ -19,9 +19,6 @@ import { classes } from '@spartan-ng/helm/utils';
 })
 export class HlmAccordionContent {
 	constructor() {
-		classes(
-			() =>
-				'spartan-accordion-content transition-all data-[state=closed]:h-0 data-[state=open]:h-(--brn-accordion-content-height)',
-		);
+		classes(() => 'spartan-accordion-content overflow-hidden data-[state=closed]:h-0 data-[state=open]:h-auto');
 	}
 }

--- a/libs/helm/accordion/src/lib/hlm-accordion-content.ts
+++ b/libs/helm/accordion/src/lib/hlm-accordion-content.ts
@@ -5,7 +5,7 @@ import { classes } from '@spartan-ng/helm/utils';
 @Component({
 	selector: 'hlm-accordion-content',
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	hostDirectives: [BrnAccordionContent],
+	hostDirectives: [{ directive: BrnAccordionContent, inputs: ['style'] }],
 	host: {
 		'data-slot': 'accordion-content',
 	},


### PR DESCRIPTION
## Summary

Fixes accordion content clipping when panel content changes after the initial render.

`BrnAccordionContent` previously exposed a measured `--brn-accordion-content-height` value. HLM used that value for the open-state height, which meant dynamically added content could be clipped when the stored measurement no longer matched the panel's intrinsic height.

This changes the default HLM accordion content styling to use natural open height instead of a BRN-owned measured height variable:

- closed content uses `h-0`
- open content uses `h-auto`
- overflow remains hidden so closed content is clipped

BRN still owns the accordion semantics (`data-state`, `role`, `aria-labelledby`, `inert`, ids) and keeps the existing `style` input for compatibility, but it no longer performs layout measurement for accordion content.

## Root Cause

The old behavior depended on a one-time or manually refreshed DOM measurement. That made the open-state height a snapshot. If projected content changed after that snapshot, the host height could stay stale while the real content height grew.

This showed up in two cases:

- content appended while the panel is already open
- content appended while the panel is closed, then revealed later

## Fix

- Removed accordion content width/height CSS variable bindings from BRN.
- Removed accordion-specific DOM measurement and observer setup from BRN.
- Kept the existing BRN `style` input to avoid changing that documented input surface.
- Updated HLM accordion content classes from measured-height open state to natural-height open state.
- Updated the CLI accordion template so generated HLM components match the packaged HLM component.
- Added HLM coverage for the new accordion content class contract.
- Kept BRN coverage focused on semantic state and inert behavior.

## Notes

This intentionally removes the default numeric height target for accordion content. The default behavior now prioritizes correctness for dynamic content and keeps layout measurement out of the BRN primitive.

Consumers can still override HLM classes if they need a different animation strategy for a specific app.

## Testing

- `NX_DAEMON=false nx test tools --skip-nx-cache`
- `NX_DAEMON=false nx test brain --skip-nx-cache`
- `NX_DAEMON=false nx test helm --skip-nx-cache`
- `git diff --check`
- Storybook manual verification for dynamic content added while open and while closed before reopening


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic accordion content through improved content rendering.

* **Improvements**
  * Simplified accordion content height handling for more predictable behavior.

* **Breaking Changes**
  * Removed accordion configuration API.

* **Tests**
  * Added comprehensive tests for dynamic accordion content and height collapse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->