### PR TITLE
fix(resizable): support dynamically added panels

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(resizable)/resizable--dynamic.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(resizable)/resizable--dynamic.preview.ts
@@ -1,0 +1,41 @@
+import { Component, signal } from '@angular/core';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmResizableImports } from '@spartan-ng/helm/resizable';
+
+@Component({
+	selector: 'spartan-resizable-dynamic-preview',
+	imports: [HlmResizableImports, HlmButton],
+	template: `
+		<div class="flex flex-col gap-4">
+			<button hlmBtn class="self-start" variant="outline" (click)="showPanel.update((visible) => !visible)">
+				{{ showPanel() ? 'Remove panel' : 'Add panel' }}
+			</button>
+
+			<hlm-resizable-group class="min-h-[200px] max-w-md rounded-lg border md:min-w-[450px]" [(layout)]="layout">
+				<hlm-resizable-panel defaultSize="40">
+					<div class="flex h-full items-center justify-center p-6">
+						<span class="font-semibold">One</span>
+					</div>
+				</hlm-resizable-panel>
+				<hlm-resizable-handle withHandle />
+				@if (showPanel()) {
+					<hlm-resizable-panel defaultSize="25">
+						<div class="flex h-full items-center justify-center p-6">
+							<span class="font-semibold">Dynamic</span>
+						</div>
+					</hlm-resizable-panel>
+					<hlm-resizable-handle withHandle />
+				}
+				<hlm-resizable-panel defaultSize="60">
+					<div class="flex h-full items-center justify-center p-6">
+						<span class="font-semibold">Two</span>
+					</div>
+				</hlm-resizable-panel>
+			</hlm-resizable-group>
+		</div>
+	`,
+})
+export class ResizableDynamicPreview {
+	public readonly showPanel = signal(false);
+	public readonly layout = signal([40, 60]);
+}

--- a/apps/app/src/app/pages/(components)/components/(resizable)/resizable.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(resizable)/resizable.page.ts
@@ -14,6 +14,7 @@ import { Tabs } from '../../../../shared/layout/tabs';
 import { UIApiDocs } from '../../../../shared/layout/ui-docs-section/ui-docs-section';
 import { metaWith } from '../../../../shared/meta/meta.util';
 
+import { ResizableDynamicPreview } from '@spartan-ng/app/app/pages/(components)/components/(resizable)/resizable--dynamic.preview';
 import { ResizableHandlePreview } from '@spartan-ng/app/app/pages/(components)/components/(resizable)/resizable--handle.preview';
 import { ResizableRtlPreview } from '@spartan-ng/app/app/pages/(components)/components/(resizable)/resizable--rtl.example';
 import { ResizableVerticalPreview } from '@spartan-ng/app/app/pages/(components)/components/(resizable)/resizable--vertical.preview';
@@ -47,6 +48,7 @@ export const routeMeta: RouteMeta = {
 		SectionSubSubHeading,
 		ResizableVerticalPreview,
 		ResizableHandlePreview,
+		ResizableDynamicPreview,
 		HlmP,
 		HlmCode,
 		RtlHeader,
@@ -106,6 +108,15 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_handleCode()" />
 			</spartan-tabs>
 
+			<h3 id="examples__dynamic-panels" spartanH4>Dynamic panels</h3>
+			<p hlmP>Panels can be added or removed after the resizable group has rendered.</p>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-resizable-dynamic-preview />
+				</div>
+				<spartan-code secondTab [code]="_dynamicCode()" />
+			</spartan-tabs>
+
 			<spartan-header-rtl />
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanRtlCodePreview firstTab>
@@ -133,6 +144,7 @@ export default class ResizablePage {
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
 	protected readonly _verticalCode = computed(() => this._snippets()['vertical']);
 	protected readonly _handleCode = computed(() => this._snippets()['handle']);
+	protected readonly _dynamicCode = computed(() => this._snippets()['dynamic']);
 	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;

--- a/apps/ui-storybook/stories/resizable.stories.ts
+++ b/apps/ui-storybook/stories/resizable.stories.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { HlmResizableImports } from '@spartan-ng/helm/resizable';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
@@ -32,13 +32,56 @@ import { moduleMetadata } from '@storybook/angular';
 })
 class ResizableExample {}
 
+@Component({
+	selector: 'resizable-dynamic-panels-example',
+	imports: [HlmResizableImports],
+	template: `
+		<div class="flex flex-col gap-4">
+			<div class="flex items-center gap-4">
+				<button
+					type="button"
+					class="rounded-md border px-3 py-2 text-sm font-medium"
+					(click)="showExtra.update((value) => !value)"
+				>
+					{{ showExtra() ? 'Remove' : 'Add' }} extra panel
+				</button>
+				<span class="text-muted-foreground text-sm">Layout: {{ layout().join(', ') }}</span>
+			</div>
+
+			<hlm-resizable-group
+				direction="vertical"
+				class="h-[360px] w-[500px] max-w-md rounded-lg border"
+				[(layout)]="layout"
+			>
+				<hlm-resizable-panel [defaultSize]="25">
+					<div class="flex h-full items-center justify-center p-6 font-semibold">Header</div>
+				</hlm-resizable-panel>
+				<hlm-resizable-handle withHandle />
+				<hlm-resizable-panel [defaultSize]="75">
+					<div class="flex h-full items-center justify-center p-6 font-semibold">Content</div>
+				</hlm-resizable-panel>
+				@if (showExtra()) {
+					<hlm-resizable-handle withHandle />
+					<hlm-resizable-panel [defaultSize]="25">
+						<div class="flex h-full items-center justify-center p-6 font-semibold">Extra Dynamic Panel</div>
+					</hlm-resizable-panel>
+				}
+			</hlm-resizable-group>
+		</div>
+	`,
+})
+class ResizableDynamicPanelsExample {
+	protected readonly showExtra = signal(false);
+	protected readonly layout = signal<number[]>([]);
+}
+
 export default {
 	title: 'Resizable',
 	component: ResizableExample,
 	tags: ['autodocs'],
 	decorators: [
 		moduleMetadata({
-			imports: [HlmResizableImports],
+			imports: [HlmResizableImports, ResizableDynamicPanelsExample],
 		}),
 	],
 } as Meta<ResizableExample>;
@@ -49,6 +92,14 @@ export const Default: Story = {
 	render: () => ({
 		template: `
 <resizable-example></resizable-example>
+		`,
+	}),
+};
+
+export const DynamicPanels: Story = {
+	render: () => ({
+		template: `
+<resizable-dynamic-panels-example></resizable-dynamic-panels-example>
 		`,
 	}),
 };

--- a/libs/brain/resizable/src/lib/brn-resizable-group.spec.ts
+++ b/libs/brain/resizable/src/lib/brn-resizable-group.spec.ts
@@ -81,6 +81,11 @@ describe('BrnResizableGroup', () => {
 
 	const firstPanelSize = () =>
 		Number(document.querySelector('[data-slot="resizable-panel"]')?.getAttribute('data-panel-size'));
+	const expectLayout = (actual: readonly number[], expected: readonly number[]) => {
+		expect(actual).toHaveLength(expected.length);
+		expected.forEach((size, index) => expect(actual[index]).toBeCloseTo(size));
+		expect(actual.reduce((total, size) => total + size, 0)).toBeCloseTo(100);
+	};
 
 	it('grows the first panel when dragging the handle right in LTR', async () => {
 		const { handle, detectChanges } = await setup();
@@ -155,13 +160,13 @@ describe('BrnResizableGroup', () => {
 		view.detectChanges();
 		await view.fixture.whenStable();
 
-		expect(view.fixture.componentInstance.layout()).toEqual([40, 60, 25]);
+		expectLayout(view.fixture.componentInstance.layout(), [30, 45, 25]);
 
 		const handles = view.container.querySelectorAll<HTMLElement>('brn-resizable-handle');
 		handles[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
 		view.detectChanges();
 
-		expect(view.fixture.componentInstance.layout()).toEqual([40, 61, 24]);
+		expectLayout(view.fixture.componentInstance.layout(), [30, 46, 24]);
 	});
 
 	it('keeps default sizes ahead of the initial layout values', async () => {
@@ -176,7 +181,13 @@ describe('BrnResizableGroup', () => {
 		view.detectChanges();
 		await view.fixture.whenStable();
 
-		expect(view.fixture.componentInstance.layout()).toEqual([100 / 3, 40, 60]);
+		expectLayout(view.fixture.componentInstance.layout(), [100 / 3, (40 * 2) / 3, 40]);
+
+		const handles = view.container.querySelectorAll<HTMLElement>('brn-resizable-handle');
+		handles[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+		view.detectChanges();
+
+		expectLayout(view.fixture.componentInstance.layout(), [100 / 3, (40 * 2) / 3 + 1, 39]);
 	});
 
 	it('uses an equal share for a panel inserted in the middle without a default size', async () => {
@@ -185,7 +196,7 @@ describe('BrnResizableGroup', () => {
 		view.detectChanges();
 		await view.fixture.whenStable();
 
-		expect(view.fixture.componentInstance.layout()).toEqual([40, 100 / 3, 60]);
+		expectLayout(view.fixture.componentInstance.layout(), [(40 * 2) / 3, 100 / 3, 40]);
 	});
 
 	it('preserves surviving panel sizes when a dynamic panel is removed', async () => {
@@ -193,16 +204,16 @@ describe('BrnResizableGroup', () => {
 		view.fixture.componentInstance.showMiddle.set(true);
 		view.detectChanges();
 		await view.fixture.whenStable();
-		expect(view.fixture.componentInstance.layout()).toEqual([40, 100 / 3, 60]);
+		expectLayout(view.fixture.componentInstance.layout(), [(40 * 2) / 3, 100 / 3, 40]);
 
 		view.fixture.componentInstance.showMiddle.set(false);
 		view.detectChanges();
 		await view.fixture.whenStable();
 
-		expect(view.fixture.componentInstance.layout()).toEqual([40, 60]);
+		expectLayout(view.fixture.componentInstance.layout(), [40, 60]);
 	});
 
-	it('preserves resized panel sizes when a new panel is added', async () => {
+	it('preserves resized panel proportions when a new panel is added', async () => {
 		const view = await render(DynamicResizableHost);
 		const handle = view.container.querySelector<HTMLElement>('brn-resizable-handle') as HTMLElement;
 		handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
@@ -213,7 +224,7 @@ describe('BrnResizableGroup', () => {
 		view.detectChanges();
 		await view.fixture.whenStable();
 
-		expect(view.fixture.componentInstance.layout()).toEqual([41, 59, 25]);
+		expectLayout(view.fixture.componentInstance.layout(), [30.75, 44.25, 25]);
 	});
 
 	it('honors a complete external layout supplied with a panel insertion', async () => {

--- a/libs/brain/resizable/src/lib/brn-resizable-group.spec.ts
+++ b/libs/brain/resizable/src/lib/brn-resizable-group.spec.ts
@@ -22,7 +22,37 @@ class ResizableHost {
 	public readonly layout = signal<number[]>([50, 50]);
 }
 
-describe('BrnResizableGroup horizontal RTL resize', () => {
+@Component({
+	imports: [BrnResizableGroup, BrnResizablePanel, BrnResizableHandle],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<brn-resizable-group direction="vertical" [(layout)]="layout">
+			@if (showStart()) {
+				<brn-resizable-panel />
+				<brn-resizable-handle />
+			}
+			<brn-resizable-panel [defaultSize]="40" />
+			<brn-resizable-handle />
+			@if (showMiddle()) {
+				<brn-resizable-panel />
+				<brn-resizable-handle />
+			}
+			<brn-resizable-panel [defaultSize]="60" />
+			@if (showEnd()) {
+				<brn-resizable-handle />
+				<brn-resizable-panel [defaultSize]="25" />
+			}
+		</brn-resizable-group>
+	`,
+})
+class DynamicResizableHost {
+	public readonly layout = signal<number[]>([10, 90]);
+	public readonly showStart = signal(false);
+	public readonly showMiddle = signal(false);
+	public readonly showEnd = signal(false);
+}
+
+describe('BrnResizableGroup', () => {
 	let rafSpy: MockInstance;
 
 	beforeEach(() => {
@@ -117,5 +147,101 @@ describe('BrnResizableGroup horizontal RTL resize', () => {
 		expect(() =>
 			document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 180, clientY: 0 })),
 		).not.toThrow();
+	});
+
+	it('initializes a panel added after the group has rendered', async () => {
+		const view = await render(DynamicResizableHost);
+		view.fixture.componentInstance.showEnd.set(true);
+		view.detectChanges();
+		await view.fixture.whenStable();
+
+		expect(view.fixture.componentInstance.layout()).toEqual([40, 60, 25]);
+
+		const handles = view.container.querySelectorAll<HTMLElement>('brn-resizable-handle');
+		handles[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+		view.detectChanges();
+
+		expect(view.fixture.componentInstance.layout()).toEqual([40, 61, 24]);
+	});
+
+	it('keeps default sizes ahead of the initial layout values', async () => {
+		const view = await render(DynamicResizableHost);
+
+		expect(view.fixture.componentInstance.layout()).toEqual([40, 60]);
+	});
+
+	it('uses an equal share for a panel inserted at the beginning without a default size', async () => {
+		const view = await render(DynamicResizableHost);
+		view.fixture.componentInstance.showStart.set(true);
+		view.detectChanges();
+		await view.fixture.whenStable();
+
+		expect(view.fixture.componentInstance.layout()).toEqual([100 / 3, 40, 60]);
+	});
+
+	it('uses an equal share for a panel inserted in the middle without a default size', async () => {
+		const view = await render(DynamicResizableHost);
+		view.fixture.componentInstance.showMiddle.set(true);
+		view.detectChanges();
+		await view.fixture.whenStable();
+
+		expect(view.fixture.componentInstance.layout()).toEqual([40, 100 / 3, 60]);
+	});
+
+	it('preserves surviving panel sizes when a dynamic panel is removed', async () => {
+		const view = await render(DynamicResizableHost);
+		view.fixture.componentInstance.showMiddle.set(true);
+		view.detectChanges();
+		await view.fixture.whenStable();
+		expect(view.fixture.componentInstance.layout()).toEqual([40, 100 / 3, 60]);
+
+		view.fixture.componentInstance.showMiddle.set(false);
+		view.detectChanges();
+		await view.fixture.whenStable();
+
+		expect(view.fixture.componentInstance.layout()).toEqual([40, 60]);
+	});
+
+	it('preserves resized panel sizes when a new panel is added', async () => {
+		const view = await render(DynamicResizableHost);
+		const handle = view.container.querySelector<HTMLElement>('brn-resizable-handle') as HTMLElement;
+		handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+		view.detectChanges();
+		expect(view.fixture.componentInstance.layout()).toEqual([41, 59]);
+
+		view.fixture.componentInstance.showEnd.set(true);
+		view.detectChanges();
+		await view.fixture.whenStable();
+
+		expect(view.fixture.componentInstance.layout()).toEqual([41, 59, 25]);
+	});
+
+	it('honors a complete external layout supplied with a panel insertion', async () => {
+		const view = await render(DynamicResizableHost);
+		view.fixture.componentInstance.showMiddle.set(true);
+		view.fixture.componentInstance.layout.set([20, 30, 50]);
+		view.detectChanges();
+		await view.fixture.whenStable();
+
+		expect(view.fixture.componentInstance.layout()).toEqual([20, 30, 50]);
+		expect(
+			Array.from(view.container.querySelectorAll('[data-slot="resizable-panel"]'), (panel) =>
+				Number(panel.getAttribute('data-panel-size')),
+			),
+		).toEqual([20, 30, 50]);
+	});
+
+	it('applies an external layout update without a panel membership change', async () => {
+		const view = await render(DynamicResizableHost);
+		view.fixture.componentInstance.layout.set([35, 65]);
+		view.detectChanges();
+		await view.fixture.whenStable();
+
+		expect(view.fixture.componentInstance.layout()).toEqual([35, 65]);
+		expect(
+			Array.from(view.container.querySelectorAll('[data-slot="resizable-panel"]'), (panel) =>
+				Number(panel.getAttribute('data-panel-size')),
+			),
+		).toEqual([35, 65]);
 	});
 });

--- a/libs/brain/resizable/src/lib/brn-resizable-group.ts
+++ b/libs/brain/resizable/src/lib/brn-resizable-group.ts
@@ -106,9 +106,28 @@ export class BrnResizableGroup {
 			// A complete changed layout is explicit consumer intent for the current panel order.
 			sizes = [...currentLayout];
 		} else {
-			// Membership changed on its own: retain known panels by identity and initialize only new panels.
+			// Membership changed on its own: reserve new panel sizes, then preserve the relative proportions
+			// of known panels within the remaining space.
 			const previousSizes = new Map(this._knownPanels.map((panel, index) => [panel, this._appliedLayout[index]]));
-			sizes = panels.map((panel) => previousSizes.get(panel) ?? panel.defaultSize() ?? 100 / totalPanels);
+			const newPanelSizes = new Map(
+				panels
+					.filter((panel) => !previousSizes.has(panel))
+					.map((panel) => [panel, panel.defaultSize() ?? 100 / totalPanels]),
+			);
+			const newPanelsTotal = Array.from(newPanelSizes.values()).reduce((total, size) => total + size, 0);
+			const previousPanelsTotal = panels.reduce((total, panel) => total + (previousSizes.get(panel) ?? 0), 0);
+
+			if (newPanelsTotal <= 100 && previousPanelsTotal > 0) {
+				const remainingSize = 100 - newPanelsTotal;
+				sizes = panels.map(
+					(panel) =>
+						newPanelSizes.get(panel) ?? ((previousSizes.get(panel) ?? 0) / previousPanelsTotal) * remainingSize,
+				);
+			} else {
+				const rawSizes = panels.map((panel) => newPanelSizes.get(panel) ?? previousSizes.get(panel) ?? 0);
+				const totalSize = rawSizes.reduce((total, size) => total + size, 0);
+				sizes = totalSize > 0 ? rawSizes.map((size) => (size / totalSize) * 100) : rawSizes;
+			}
 		}
 
 		panels.forEach((panel, index) => panel.setSize(sizes[index]));

--- a/libs/brain/resizable/src/lib/brn-resizable-group.ts
+++ b/libs/brain/resizable/src/lib/brn-resizable-group.ts
@@ -1,6 +1,6 @@
 import { Directionality } from '@angular/cdk/bidi';
 import {
-	afterNextRender,
+	afterRenderEffect,
 	contentChildren,
 	DestroyRef,
 	Directive,
@@ -11,6 +11,7 @@ import {
 	model,
 	NgZone,
 	output,
+	untracked,
 } from '@angular/core';
 import { BrnResizablePanel } from './brn-resizable-panel';
 
@@ -65,35 +66,62 @@ export class BrnResizableGroup {
 
 	/** Tears down the in-flight drag (document listeners, queued frame, cursor); null when idle. */
 	private _stopResize: (() => void) | null = null;
+	/** Panel order and sizes from the last layout applied to the rendered panels. */
+	private _knownPanels: readonly BrnResizablePanel[] = [];
+	private _appliedLayout: number[] = [];
 
 	constructor() {
 		// If the group is destroyed mid-drag, the document listeners would otherwise stay attached
 		// (document is never GC'd), pinning this directive and firing against a torn-down view.
 		inject(DestroyRef).onDestroy(() => this._stopResize?.());
 
-		afterNextRender(() => {
-			this._initializePanelSizes();
+		afterRenderEffect(() => {
+			// Track both membership and external model updates, but not the writes performed while reconciling them.
+			const panels = this.panels();
+			const layout = this.layout();
+			untracked(() => this._synchronizePanelSizes(panels, layout));
 		});
 	}
 
-	private _initializePanelSizes(): void {
-		const panels = this.panels();
+	private _synchronizePanelSizes(panels: readonly BrnResizablePanel[], currentLayout: number[]): void {
 		const totalPanels = panels.length;
 
-		if (totalPanels === 0) return;
+		if (totalPanels === 0) {
+			this._knownPanels = panels;
+			this._appliedLayout = [];
+			return;
+		}
 
-		const sizes: number[] = [];
+		const isInitialLayout = this._knownPanels.length === 0;
+		const hasCompleteExternalLayout =
+			!isInitialLayout &&
+			currentLayout.length === totalPanels &&
+			!this._layoutsEqual(currentLayout, this._appliedLayout);
 
-		panels.forEach((panel, index) => {
-			const defaultSize = panel.defaultSize() ?? this.layout()[index];
-			const size = defaultSize !== undefined ? defaultSize : 100 / totalPanels;
-			sizes.push(size);
-			panel.setSize(size);
-		});
+		let sizes: number[];
+		if (isInitialLayout) {
+			// Preserve the existing initialization contract: defaults take precedence over the input layout.
+			sizes = panels.map((panel, index) => panel.defaultSize() ?? currentLayout[index] ?? 100 / totalPanels);
+		} else if (hasCompleteExternalLayout) {
+			// A complete changed layout is explicit consumer intent for the current panel order.
+			sizes = [...currentLayout];
+		} else {
+			// Membership changed on its own: retain known panels by identity and initialize only new panels.
+			const previousSizes = new Map(this._knownPanels.map((panel, index) => [panel, this._appliedLayout[index]]));
+			sizes = panels.map((panel) => previousSizes.get(panel) ?? panel.defaultSize() ?? 100 / totalPanels);
+		}
 
-		if (this.layout().toString() !== sizes.toString()) {
+		panels.forEach((panel, index) => panel.setSize(sizes[index]));
+		this._knownPanels = panels;
+		this._appliedLayout = [...sizes];
+
+		if (!this._layoutsEqual(currentLayout, sizes)) {
 			this._setLayout(sizes);
 		}
+	}
+
+	private _layoutsEqual(first: readonly number[], second: readonly number[]): boolean {
+		return first.length === second.length && first.every((size, index) => size === second[index]);
 	}
 
 	public startResize(handleIndex: number, event: MouseEvent | TouchEvent): void {
@@ -233,6 +261,8 @@ export class BrnResizableGroup {
 				panel.setSize(size);
 			}
 		});
+		// Keyboard resizing writes to the public model directly, so capture the applied value here as well.
+		this._appliedLayout = [...sizes];
 	}
 
 	private _getEventPosition(event: MouseEvent | TouchEvent): number {
@@ -292,6 +322,7 @@ export class BrnResizableGroup {
 	}
 
 	private _setLayout(sizes: number[]): void {
+		this._appliedLayout = [...sizes];
 		this.layout.set(sizes);
 		this.layoutChanged.emit(sizes);
 	}

--- a/libs/brain/resizable/src/lib/brn-resizable-handle.ts
+++ b/libs/brain/resizable/src/lib/brn-resizable-handle.ts
@@ -35,13 +35,13 @@ export class BrnResizableHandle {
 	/** Computed layout orientation based on the parent group. */
 	protected readonly _layout = computed(() => this._resizable?.direction() || 'horizontal');
 
-	/** Index of this handle relative to panels in the group. */
-	private _handleIndex = 0;
+	/** Always-current index of this handle relative to panels in the group. */
+	private get _handleIndex(): number {
+		return this._getHandleIndex();
+	}
 
 	constructor() {
 		afterNextRender(() => {
-			this._handleIndex = this._getHandleIndex();
-
 			this._el.nativeElement.onpointerdown = (e: PointerEvent) => {
 				this._el.nativeElement.setPointerCapture(e.pointerId);
 			};


### PR DESCRIPTION
Previously, panels added after initialization had no matching layout entry and could not resize.

Reconcile membership after render while preserving existing sizes and complete external layouts.

Closes #1055



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Storybook example for dynamic resizable panels, including a toggle to conditionally render an extra panel and track live layout changes.
  * Added a “Dynamic panels” section to the Resizable documentation with an interactive preview and snippet.
* **Bug Fixes**
  * Improved `ResizableGroup` behavior for dynamic panel insertion/removal, including correct default sizing precedence and more reliable layout synchronization during resizing.
* **Tests**
  * Expanded test coverage for dynamic panel membership, sizing decisions, and rendered size output via `layout` updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->