### PR TITLE
refactor(cli): tidy style support config handling

### DIFF
--- a/libs/cli/src/generators/migrate-helm-libraries/generator.ts
+++ b/libs/cli/src/generators/migrate-helm-libraries/generator.ts
@@ -3,7 +3,7 @@ import { getRootTsConfigPathInTree } from '@nx/js';
 import { prompt } from 'enquirer';
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'path';
-import { getOrCreateConfig } from '../../utils/config';
+import { loadOrInitConfig } from '../../utils/config';
 import { readTsConfigPathsFromTree } from '../../utils/tsconfig';
 import { deleteFiles } from '../base/lib/deleteFiles';
 import type { SupportedLibraries } from '../base/lib/supported-libs';
@@ -45,7 +45,7 @@ function loadRemoveGenerator(): RemoveGenerator {
 export async function migrateHelmLibrariesGenerator(tree: Tree, options: MigrateHelmLibrariesGeneratorSchema) {
 	// Detect the libraries that are already installed
 
-	const config = await getOrCreateConfig(tree, { angularCli: options.angularCli });
+	const config = await loadOrInitConfig(tree, { angularCli: options.angularCli });
 
 	const existingLibraries = await detectLibraries(tree, config.importAlias);
 
@@ -206,7 +206,7 @@ async function regenerateLibraries(tree: Tree, options: MigrateHelmLibrariesGene
 	const supportedLibraries = (await import('../ui/supported-ui-libraries.json').then(
 		(m) => m.default,
 	)) as SupportedLibraries;
-	const config = await getOrCreateConfig(tree, { angularCli: options.angularCli });
+	const config = await loadOrInitConfig(tree, { angularCli: options.angularCli });
 
 	await createPrimitiveLibraries(
 		{

--- a/libs/cli/src/generators/migrate-hlm/generator.spec.ts
+++ b/libs/cli/src/generators/migrate-hlm/generator.spec.ts
@@ -3,7 +3,7 @@ import type { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { migrateHlmGenerator } from './generator';
 
-import { getOrCreateConfig } from '../../utils/config';
+import { loadOrInitConfig } from '../../utils/config';
 import { createPrimitiveLibraries } from '../ui/generator';
 
 // patch some imports to avoid running the actual code
@@ -24,7 +24,7 @@ vi.mock('../ui/generator', () => ({
 	createPrimitiveLibraries: vi.fn(),
 }));
 vi.mock('../../utils/config', () => ({
-	getOrCreateConfig: vi.fn().mockResolvedValue({}),
+	loadOrInitConfig: vi.fn().mockResolvedValue({}),
 }));
 
 describe('migrate-hlm', () => {
@@ -166,7 +166,7 @@ describe('migrate-hlm', () => {
 
 			await migrateHlmGenerator(tree, { skipFormat: true, angularCli: false });
 
-			expect(getOrCreateConfig).toHaveBeenCalled();
+			expect(loadOrInitConfig).toHaveBeenCalled();
 			expect(createPrimitiveLibraries).toHaveBeenCalledWith(
 				{ primitives: ['utils'] },
 				expect.any(Array),

--- a/libs/cli/src/generators/migrate-hlm/generator.ts
+++ b/libs/cli/src/generators/migrate-hlm/generator.ts
@@ -1,5 +1,5 @@
 import { formatFiles, readJson, type Tree } from '@nx/devkit';
-import { getOrCreateConfig } from '../../utils/config';
+import { loadOrInitConfig } from '../../utils/config';
 import { visitFiles } from '../../utils/visit-files';
 import type { SupportedLibraries } from '../base/lib/supported-libs';
 import { createPrimitiveLibraries } from '../ui/generator';
@@ -37,7 +37,7 @@ async function ensureHelmUtilsInstalled(tree: Tree, angularCli: boolean) {
 		const supportedLibraries = (await import('../ui/supported-ui-libraries.json').then(
 			(m) => m.default,
 		)) as SupportedLibraries;
-		const config = await getOrCreateConfig(tree, { angularCli });
+		const config = await loadOrInitConfig(tree, { angularCli });
 
 		await createPrimitiveLibraries(
 			{

--- a/libs/cli/src/generators/ui/generator.ts
+++ b/libs/cli/src/generators/ui/generator.ts
@@ -1,7 +1,7 @@
 import { type GeneratorCallback, getProjects, runTasksInSerial, type Tree } from '@nx/devkit';
 
 import { prompt } from 'enquirer';
-import { type Config, getOrCreateConfig } from '../../utils/config';
+import { backfillStyleInComponentsJson, type Config, loadOrInitConfig } from '../../utils/config';
 import type { Style } from '../../utils/supported-styles';
 import type { GenerateAs } from '../base/lib/generate-as';
 import { initializeAngularEntrypoint } from '../base/lib/initialize-angular-library';
@@ -15,9 +15,10 @@ type PrimitiveResponse = Primitive | 'all';
 
 export default async function hlmUIGenerator(tree: Tree, options: HlmUIGeneratorSchema & { angularCli?: boolean }) {
 	const tasks: GeneratorCallback[] = [];
-	const config = await getOrCreateConfig(tree, {
+	await backfillStyleInComponentsJson(tree);
+	const config = await loadOrInitConfig(tree, {
 		componentsPath: options.directory,
-		angularCli: options.angularCli,
+		angularCli: options.angularCli ?? true,
 	});
 
 	const availablePrimitives: PrimitiveDefinitions = await import('./supported-ui-libraries.json').then(
@@ -89,7 +90,7 @@ export async function createPrimitiveLibraries(
 		const task = await initializeAngularEntrypoint(tree, {
 			tags: options.tags,
 			directory: options.directory ?? config.componentsPath,
-			buildable: config.buildable,
+			buildable: config.buildable ?? true,
 			importAlias: config.importAlias,
 			style: config.style,
 		});
@@ -111,7 +112,7 @@ export async function createPrimitiveLibraries(
 				tags: options.tags,
 				rootProject: options.rootProject,
 				angularCli: options.angularCli,
-				buildable: options.buildable ?? config.buildable,
+				buildable: options.buildable ?? config.buildable ?? true,
 				generateAs: options.generateAs ?? config.generateAs ?? 'library',
 				importAlias: options.importAlias ?? config.importAlias ?? `@spartan-ng/helm`,
 				style: options.style ?? config.style,

--- a/libs/cli/src/index.ts
+++ b/libs/cli/src/index.ts
@@ -5,4 +5,5 @@ export * from './generators/migrate-brain-imports/generator';
 // path) so the tools build does not pull CLI sources outside its rootDir (TS6059). The tools test
 // env polyfills TextDecoder for the @nx/angular graph this transitively loads.
 export { createPrimitiveLibraries } from './generators/ui/generator';
-export { getOrCreateConfig } from './utils/config';
+export { loadOrInitConfig } from './utils/config';
+export { STYLES, type Style } from './utils/supported-styles';

--- a/libs/cli/src/utils/config.spec.ts
+++ b/libs/cli/src/utils/config.spec.ts
@@ -1,6 +1,6 @@
-import { type Tree, writeJson } from '@nx/devkit';
+import { readJson, type Tree, writeJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { getImportAlias } from './config';
+import { backfillStyleInComponentsJson, getImportAlias, loadOrInitConfig } from './config';
 
 describe('getImportAlias', () => {
 	let tree: Tree;
@@ -14,7 +14,7 @@ describe('getImportAlias', () => {
 	});
 
 	it('returns the configured alias from a valid config', async () => {
-		writeJson(tree, 'components.json', { importAlias: '@my-org/ui', style: 'vega' });
+		writeJson(tree, 'components.json', { importAlias: '@my-org/ui' });
 
 		await expect(getImportAlias(tree, false)).resolves.toBe('@my-org/ui');
 	});
@@ -22,8 +22,47 @@ describe('getImportAlias', () => {
 	// A present-but-invalid config must fail loudly rather than silently fall back to the default
 	// alias, which would run every migration against the wrong imports.
 	it('throws when the config exists but is invalid', async () => {
-		writeJson(tree, 'components.json', { importAlias: 123, style: 'vega' });
+		writeJson(tree, 'components.json', { importAlias: 123 });
 
 		await expect(getImportAlias(tree, false)).rejects.toThrow();
+	});
+});
+
+describe('loadOrInitConfig', () => {
+	let tree: Tree;
+
+	beforeEach(() => {
+		tree = createTreeWithEmptyWorkspace();
+	});
+
+	it('applies the default style in memory and leaves the file untouched', async () => {
+		writeJson(tree, 'components.json', { importAlias: '@spartan-ng/helm' });
+
+		const config = await loadOrInitConfig(tree, { angularCli: false });
+
+		expect(config.style).toBe('vega');
+		expect(readJson(tree, 'components.json').style).toBeUndefined();
+	});
+});
+
+describe('backfillStyleInComponentsJson', () => {
+	let tree: Tree;
+
+	beforeEach(() => {
+		tree = createTreeWithEmptyWorkspace();
+	});
+
+	it('writes the fallback style when components.json omits it', async () => {
+		writeJson(tree, 'components.json', { importAlias: '@spartan-ng/helm' });
+
+		await backfillStyleInComponentsJson(tree);
+
+		expect(readJson(tree, 'components.json').style).toBe('vega');
+	});
+
+	it('is a no-op when there is no config', async () => {
+		await backfillStyleInComponentsJson(tree);
+
+		expect(tree.exists('components.json')).toBe(false);
 	});
 });

--- a/libs/cli/src/utils/config.ts
+++ b/libs/cli/src/utils/config.ts
@@ -7,9 +7,12 @@ import { type Style, STYLES } from './supported-styles';
 
 const configPath = 'components.json';
 
+// Default style used when components.json does not set one.
+const FALLBACK_STYLE: Style = 'vega';
+
 export const AngularCliConfigSchema = z.object({
 	componentsPath: z.string().optional().default('libs/ui'),
-	style: z.enum(STYLES),
+	style: z.enum(STYLES).optional().default(FALLBACK_STYLE),
 	importAlias: z
 		.string()
 		.optional()
@@ -21,7 +24,7 @@ export const NXConfigSchema = z.object({
 	componentsPath: z.string().optional().default('libs/ui'),
 	buildable: z.boolean().optional().default(true),
 	generateAs: z.enum(generateOptions).optional().default('library'),
-	style: z.enum(STYLES),
+	style: z.enum(STYLES).optional().default(FALLBACK_STYLE),
 	importAlias: z
 		.string()
 		.optional()
@@ -29,27 +32,13 @@ export const NXConfigSchema = z.object({
 		.refine((val) => !val.endsWith('/'), { message: 'importAlias should not end with a slash' }),
 });
 
-export type Config = z.infer<typeof NXConfigSchema>;
+// buildable and generateAs only exist for NX configs; an Angular CLI config omits them.
+export type Config = z.infer<typeof AngularCliConfigSchema> &
+	Partial<Pick<z.infer<typeof NXConfigSchema>, 'buildable' | 'generateAs'>>;
 
 const getConfig = async (tree: Tree, isAngularCli: boolean): Promise<Config> => {
 	const raw = await readJson(tree, configPath);
 	try {
-		if (!raw.style) {
-			const add = (
-				await prompt<{ confirmed: boolean }>({
-					type: 'confirm',
-					name: 'confirmed',
-					message: "A style is required in your components.json. We'll add the vega style for you.",
-					initial: true,
-				})
-			).confirmed;
-
-			if (add) {
-				updateJson(tree, configPath, (json) => ({ ...json, style: 'vega' }));
-				raw.style = 'vega';
-			}
-		}
-
 		if (isAngularCli) {
 			return AngularCliConfigSchema.parse(raw);
 		} else {
@@ -93,7 +82,18 @@ export async function getImportAlias(tree: Tree, isAngularCli: boolean): Promise
 	return config.importAlias;
 }
 
-export async function getOrCreateConfig(
+// Add the default "style" to components.json when it is missing.
+export async function backfillStyleInComponentsJson(tree: Tree): Promise<void> {
+	if (!tree.exists(configPath)) return;
+
+	const raw = await readJson(tree, configPath);
+	if (raw.style) return;
+
+	updateJson(tree, configPath, (json) => ({ ...json, style: FALLBACK_STYLE }));
+	console.log(`No "style" in components.json - added "${FALLBACK_STYLE}".`);
+}
+
+export async function loadOrInitConfig(
 	tree: Tree,
 	defaults?: Partial<Config> & { angularCli: boolean },
 ): Promise<Config> {
@@ -143,7 +143,7 @@ export async function getOrCreateConfig(
 			message: 'Which design system style do you want to use?',
 			name: 'style',
 			initial: 0,
-			skip: !!defaults?.style, // Only relevant for Angular CLI projects, which generate components with styles by default
+			skip: !!defaults?.style, // Skip when a style was already provided by the caller.
 		},
 	];
 

--- a/libs/cli/src/utils/supported-styles.ts
+++ b/libs/cli/src/utils/supported-styles.ts
@@ -1,3 +1,4 @@
-// todo remove them when the registry is build up and published to npm
+// Mirror of `libs/registry/src/styles/style.ts`; keep them in sync (the first entry is the default
+// style). The published cli cannot depend on the unpublished registry, hence the local copy.
 export const STYLES = ['nova', 'vega', 'lyra', 'maia', 'mira', 'luma'] as const;
 export type Style = (typeof STYLES)[number];

--- a/libs/tools/src/generators/generate-hlm-component-preview/generator.ts
+++ b/libs/tools/src/generators/generate-hlm-component-preview/generator.ts
@@ -1,12 +1,15 @@
 import { formatFiles, joinPathFragments, logger, type Tree, visitNotIgnoredFiles } from '@nx/devkit';
 import { createTree } from '@nx/devkit/testing';
-import { createPrimitiveLibraries, createStyleMap, getOrCreateConfig, transformStyle } from '@spartan-ng/cli';
+import {
+	createPrimitiveLibraries,
+	createStyleMap,
+	loadOrInitConfig,
+	type Style,
+	STYLES,
+	transformStyle,
+} from '@spartan-ng/cli';
 import { copyFileSync, existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-
-// todo remove this when the registry is build and published
-const STYLES = ['nova', 'vega', 'lyra', 'maia', 'mira', 'luma'] as const;
-type Style = (typeof STYLES)[number];
 
 function shouldIgnoreImport(importLine: string) {
 	const match = importLine.match(/from\s+['"](.*)['"]/);
@@ -335,7 +338,7 @@ async function writeStackblitzProject(tree: Tree): Promise<void> {
 		readFileSync(join(__dirname, '../../../../cli/src/generators/ui/supported-ui-libraries.json'), 'utf-8'),
 	);
 	const names = Object.keys(supported);
-	const config = await getOrCreateConfig(cli, {
+	const config = await loadOrInitConfig(cli, {
 		angularCli: true,
 		componentsPath: 'libs/ui',
 		importAlias: '@spartan-ng/helm',


### PR DESCRIPTION
## PR Type

- [x] Refactoring (no functional changes, no api changes)

## Which package are you modifying?

- [x] cli

## What is the current behavior?

Stacked on top of #1507 (`add-style-support-in-cli`). Addresses review feedback on the
new style support.

In #1507, `style` is a **required** schema field, and `getConfig` compensates with an
imperative block that **prompts the user and rewrites `components.json` from inside the
read/validate path**:

- The validation function does interactive I/O and mutates the config file. `getImportAlias`
  calls it from the `migrate-*` generators, so reading the import alias could trigger a style
  prompt and a file write.
- The prompt offers yes/no but only handles "yes"; answering **no** leaves `style` unset and
  the required enum throws the generic `Config validation failed` error.
- Because the field is required, the Angular CLI branch of `getConfig`
  (`return AngularCliConfigSchema.parse(raw)`) returns a shape without `buildable`/`generateAs`
  while the function is typed `Promise<Config>` (the NX shape), which is a latent type error
  (masked by incremental builds; surfaces in a strict editor).
- The `STYLES` list is duplicated in three places (cli, registry, tools preview generator).

## What is the new behavior?

- **Deterministic backfill instead of a prompt.** When an existing config omits `style`, the
  fallback (`vega`, matching the style the base generator historically hardcoded) is written to
  `components.json` and persisted. This now lives in `getOrCreateConfig` (the create/update
  path), so `getConfig` is a pure read+validate again and migrations stay side-effect free. No
  prompt, safe under CI.
- **`style` is optional with a default** in both schemas, so a styleless config validates
  rather than throwing.
- **`Config` types `buildable`/`generateAs` as the NX-only optional fields they are**, so the
  Angular CLI branch type-checks (with `?? true` fallbacks where they're consumed).
- **`STYLES` deduped from three copies to two**: exported from the cli package and consumed by
  the tools preview generator. The cli<->registry copy remains because the published cli cannot
  depend on the unpublished registry (nx's module-boundary rule also forbids the buildable cli
  from importing the non-buildable registry); this is now documented, and the copies are aligned
  (order included - the first entry is the default style).

Tests updated accordingly (config backfill + persistence covered).

### Deliberately out of scope

- The `libs/registry` packaging (publish-vs-internal) is left to #1507.
- The ~70 pre-existing strict-mode type findings across the cli lib (the project tsconfig does
  not enable `strict`); unrelated to this change.

## Does this PR introduce a breaking change?

- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now publicly exports `loadOrInitConfig`, plus supported `STYLES` and the `Style` type.
* **Refactor**
  * Generators now use `loadOrInitConfig` for configuration, defaulting `angularCli` to `true` and `buildable` to `true` when unspecified.
  * If `style` is missing in `components.json`, it is backfilled to `vega` and persisted.
* **Documentation**
  * Clarified how the CLI’s supported styles list is defined and ordered.
* **Tests**
  * Updated config tests to validate `loadOrInitConfig` behavior and the `vega` backfill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->