### PR TITLE
fix: calendar select form error

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(date-picker)/date-picker--form.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(date-picker)/date-picker--form.example.ts
@@ -16,7 +16,13 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 			<hlm-field-group>
 				<hlm-field>
 					<label for="date-birthday" hlmFieldLabel>Date of birth</label>
-					<hlm-date-picker [min]="minDate" [max]="maxDate" formControlName="birthday" [autoCloseOnSelect]="true">
+					<hlm-date-picker
+						[min]="minDate"
+						[max]="maxDate"
+						captionLayout="dropdown"
+						formControlName="birthday"
+						[autoCloseOnSelect]="true"
+					>
 						<hlm-date-picker-trigger buttonId="date-birthday">Pick a date</hlm-date-picker-trigger>
 					</hlm-date-picker>
 					<hlm-field-description>Your date of birth is used to calculate your age.</hlm-field-description>

--- a/apps/app/src/app/pages/(components)/components/(date-picker)/date-picker.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(date-picker)/date-picker.page.ts
@@ -183,7 +183,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_formatCode()" />
 			</spartan-tabs>
 
-			<h3 id="input_picker" spartanH4>Input Picker</h3>
+			<h3 id="input-picker" spartanH4>Input Picker</h3>
 			<p class="${hlmP} mb-6">
 				Use
 				<code class="${hlmCode}">hlm-date-picker-input</code>

--- a/apps/app/src/app/pages/(components)/components/(date-picker)/date-picker.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(date-picker)/date-picker.page.ts
@@ -100,7 +100,7 @@ export const routeMeta: RouteMeta = {
 			</div>
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
-			<h3 id="examples__custom_config" spartanH4>Custom Configs</h3>
+			<h3 id="custom-config" spartanH4>Custom Configs</h3>
 
 			<p class="${hlmP} mb-6">
 				Use
@@ -131,7 +131,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_configCode()" />
 			</spartan-tabs>
 
-			<h3 id="examples__multiple_selecton" spartanH4>Multiple Selection</h3>
+			<h3 id="multiple-selecton" spartanH4>Multiple Selection</h3>
 
 			<p class="${hlmP} mb-6">
 				Use
@@ -150,7 +150,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_multiCode()" />
 			</spartan-tabs>
 
-			<h3 id="examples__range" spartanH4>Range Picker</h3>
+			<h3 id="range" spartanH4>Range Picker</h3>
 
 			<p class="${hlmP} mb-6">
 				Use
@@ -169,7 +169,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_rangeCode()" />
 			</spartan-tabs>
 
-			<h3 id="examples__format_date" spartanH4>Format Date</h3>
+			<h3 id="format-date" spartanH4>Format Date</h3>
 
 			<p class="${hlmP} mb-6">
 				Use
@@ -183,7 +183,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_formatCode()" />
 			</spartan-tabs>
 
-			<h3 id="examples__input_picker" spartanH4>Input Picker</h3>
+			<h3 id="input_picker" spartanH4>Input Picker</h3>
 			<p class="${hlmP} mb-6">
 				Use
 				<code class="${hlmCode}">hlm-date-picker-input</code>
@@ -204,7 +204,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_inputCode()" />
 			</spartan-tabs>
 
-			<h3 id="examples__date_and_time_picker" spartanH4>Date and Time picker</h3>
+			<h3 id="date-and-time-picker" spartanH4>Date and Time picker</h3>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-date-and-time-picker />
@@ -212,7 +212,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_dateTimeCode()" />
 			</spartan-tabs>
 
-			<h3 id="examples__form" spartanH4>Form</h3>
+			<h3 id="form" spartanH4>Form</h3>
 			<p class="${hlmP} mb-6">
 				Sync the date to a form by adding
 				<code class="${hlmCode}">formControlName</code>
@@ -227,7 +227,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_formCode()" />
 			</spartan-tabs>
 
-			<h3 id="examples__form_input" spartanH4>Form with Input Picker</h3>
+			<h3 id="form-input" spartanH4>Form with Input Picker</h3>
 			<p class="${hlmP} mb-6">
 				Combine
 				<code class="${hlmCode}">formControlName</code>
@@ -242,7 +242,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_formInputCode()" />
 			</spartan-tabs>
 
-			<h3 id="examples__form_multiple_selection" spartanH4>Form Multiple Selection</h3>
+			<h3 id="form-multiple-selection" spartanH4>Form Multiple Selection</h3>
 			<p class="${hlmP} mb-6">
 				Sync the dates to a form by adding
 				<code class="${hlmCode}">formControlName</code>
@@ -257,7 +257,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_formMultiCode()" />
 			</spartan-tabs>
 
-			<h3 id="examples__form_range" spartanH4>Form Range Picker</h3>
+			<h3 id="form-range" spartanH4>Form Range Picker</h3>
 			<p class="${hlmP} mb-6">
 				Sync the dates to a form by adding
 				<code class="${hlmCode}">formControlName</code>

--- a/apps/app/src/app/pages/(components)/components/(popover)/popover.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(popover)/popover.page.ts
@@ -5,6 +5,7 @@ import { PopoverRtlPreview } from '@spartan-ng/app/app/pages/(components)/compon
 import { CodeRtlPreview } from '@spartan-ng/app/app/shared/code/code-rtl-preview';
 import { RtlHeader } from '@spartan-ng/app/app/shared/code/rtl-header';
 import { InstallTabs } from '@spartan-ng/app/app/shared/layout/install-tabs';
+import { SectionSubSubHeading } from '@spartan-ng/app/app/shared/layout/section-sub-sub-heading';
 import { Code } from '../../../../shared/code/code';
 import { CodePreview } from '../../../../shared/code/code-preview';
 import { MainSection } from '../../../../shared/layout/main-section';
@@ -34,6 +35,7 @@ export const routeMeta: RouteMeta = {
 		Code,
 		SectionIntro,
 		SectionSubHeading,
+		SectionSubSubHeading,
 		Tabs,
 
 		CodePreview,

--- a/libs/brain/field/src/lib/brn-field-control.ts
+++ b/libs/brain/field/src/lib/brn-field-control.ts
@@ -39,7 +39,8 @@ export class BrnFieldControl implements OnInit, DoCheck {
 	}
 
 	ngOnInit(): void {
-		this.ngControl = this._injector.get(NgControl, null);
+		// `self` prevents descendants (e.g. calendar selects) from inheriting an ancestor's NgControl.
+		this.ngControl = this._injector.get(NgControl, null, { optional: true, self: true });
 
 		// Try to sync the tracker eagerly.
 		this._syncTracker();

--- a/libs/brain/field/src/lib/brn-field-control.ts
+++ b/libs/brain/field/src/lib/brn-field-control.ts
@@ -31,7 +31,6 @@ export class BrnFieldControl implements OnInit, DoCheck {
 	public readonly touched = computed(() => this._stateTracker()?.touched() ?? null);
 
 	constructor() {
-		this._field?.registerFieldControl(this);
 		this._destroyRef.onDestroy(() => {
 			this._idEffectRef?.destroy();
 			this._stateTracker()?.destroy();
@@ -41,6 +40,12 @@ export class BrnFieldControl implements OnInit, DoCheck {
 	ngOnInit(): void {
 		// `self` prevents descendants (e.g. calendar selects) from inheriting an ancestor's NgControl.
 		this.ngControl = this._injector.get(NgControl, null, { optional: true, self: true });
+
+		// Only register with BrnField when this control has its own NgControl, otherwise descendant
+		// field controls rendered in portals (e.g. calendar selects) overwrite the real control's registration.
+		if (this.ngControl) {
+			this._field?.registerFieldControl(this);
+		}
 
 		// Try to sync the tracker eagerly.
 		this._syncTracker();

--- a/libs/helm/date-picker/src/lib/__tests__/hlm-date-picker-form.spec.ts
+++ b/libs/helm/date-picker/src/lib/__tests__/hlm-date-picker-form.spec.ts
@@ -107,12 +107,11 @@ describe('HlmDatePicker form integration', () => {
 		}
 	});
 
-	it('marks the field host and label as invalid when the trigger is opened then closed', async () => {
+	it('marks the field host as invalid when the trigger is opened then closed', async () => {
 		fixture.detectChanges();
 		await fixture.whenStable();
 
 		const field: HTMLElement | null = fixture.nativeElement.querySelector('[data-slot="field"]');
-		const label: HTMLElement | null = fixture.nativeElement.querySelector('[data-slot="field-label"]');
 		expect(field?.getAttribute('data-matches-spartan-invalid')).toBeNull();
 
 		const trigger: HTMLButtonElement | null = fixture.nativeElement.querySelector('hlm-date-picker-trigger button');
@@ -130,6 +129,5 @@ describe('HlmDatePicker form integration', () => {
 
 		expect(field?.getAttribute('data-matches-spartan-invalid')).toBe('true');
 		expect(field?.getAttribute('data-invalid')).toBe('true');
-		expect(label).toBeTruthy();
 	});
 });

--- a/libs/helm/date-picker/src/lib/__tests__/hlm-date-picker-form.spec.ts
+++ b/libs/helm/date-picker/src/lib/__tests__/hlm-date-picker-form.spec.ts
@@ -14,7 +14,7 @@ import { HlmDatePicker } from '../hlm-date-picker';
 			<div hlmField>
 				<!-- eslint-disable-next-line @angular-eslint/template/label-has-associated-control -->
 				<label hlmFieldLabel>Date *</label>
-				<hlm-date-picker formControlName="date">
+				<hlm-date-picker captionLayout="dropdown" formControlName="date">
 					<hlm-date-picker-trigger>Pick date</hlm-date-picker-trigger>
 				</hlm-date-picker>
 				<p hlmFieldDescription>Pick a date for the event.</p>
@@ -105,8 +105,31 @@ describe('HlmDatePicker form integration', () => {
 			expect(selectTrigger.getAttribute('aria-invalid')).toBeNull();
 			expect(selectTrigger.getAttribute('data-matches-spartan-invalid')).toBeNull();
 		}
+	});
 
-		datePicker.close();
-		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	it('marks the field host and label as invalid when the trigger is opened then closed', async () => {
+		fixture.detectChanges();
+		await fixture.whenStable();
+
+		const field: HTMLElement | null = fixture.nativeElement.querySelector('[data-slot="field"]');
+		const label: HTMLElement | null = fixture.nativeElement.querySelector('[data-slot="field-label"]');
+		expect(field?.getAttribute('data-matches-spartan-invalid')).toBeNull();
+
+		const trigger: HTMLButtonElement | null = fixture.nativeElement.querySelector('hlm-date-picker-trigger button');
+		trigger?.click();
+		fixture.detectChanges();
+		await fixture.whenStable();
+
+		trigger?.click();
+		fixture.detectChanges();
+		await fixture.whenStable();
+
+		const host = fixture.componentInstance as HlmDatePickerHost;
+		expect(host.form.get('date')?.touched).toBe(true);
+		expect(host.form.invalid).toBe(true);
+
+		expect(field?.getAttribute('data-matches-spartan-invalid')).toBe('true');
+		expect(field?.getAttribute('data-invalid')).toBe('true');
+		expect(label).toBeTruthy();
 	});
 });

--- a/libs/helm/date-picker/src/lib/__tests__/hlm-date-picker-form.spec.ts
+++ b/libs/helm/date-picker/src/lib/__tests__/hlm-date-picker-form.spec.ts
@@ -1,8 +1,9 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { HlmFieldImports } from '@spartan-ng/helm/field';
 import { HlmDatePickerImports } from '../../index';
+import { HlmDatePicker } from '../hlm-date-picker';
 
 @Component({
 	selector: 'hlm-date-picker-host',
@@ -26,6 +27,25 @@ class HlmDatePickerHost {
 	public readonly form = new FormGroup({
 		date: new FormControl<Date | null>(null, { validators: [Validators.required] }),
 	});
+}
+
+@Component({
+	selector: 'hlm-date-picker-dropdown-host',
+	imports: [ReactiveFormsModule, HlmDatePickerImports],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<form [formGroup]="form">
+			<hlm-date-picker captionLayout="dropdown" formControlName="date">
+				<hlm-date-picker-trigger buttonId="date">Pick date</hlm-date-picker-trigger>
+			</hlm-date-picker>
+		</form>
+	`,
+})
+class HlmDatePickerDropdownHost {
+	public readonly form = new FormGroup({
+		date: new FormControl<Date | null>(null, { validators: [Validators.required] }),
+	});
+	public readonly datePicker = viewChild.required(HlmDatePicker);
 }
 
 describe('HlmDatePicker form integration', () => {
@@ -56,5 +76,37 @@ describe('HlmDatePicker form integration', () => {
 		const describedBy = button?.getAttribute('aria-describedby') ?? '';
 		expect(describedBy.split(' ')).toContain(description!.id);
 		expect(describedBy.split(' ')).toContain(error!.id);
+	});
+
+	it('does not mark the calendar month/year selects as invalid when the date picker is invalid', async () => {
+		const dropdownFixture = TestBed.createComponent(HlmDatePickerDropdownHost);
+		dropdownFixture.detectChanges();
+		await dropdownFixture.whenStable();
+
+		const host = dropdownFixture.componentInstance;
+		host.form.markAllAsTouched();
+		host.form.get('date')?.updateValueAndValidity();
+		dropdownFixture.detectChanges();
+
+		const datePicker = host.datePicker();
+		datePicker.open();
+		dropdownFixture.detectChanges();
+		await dropdownFixture.whenStable();
+
+		const trigger: HTMLButtonElement | null = dropdownFixture.nativeElement.querySelector(
+			'hlm-date-picker-trigger button',
+		);
+		expect(trigger?.getAttribute('aria-invalid')).toBe('true');
+
+		const overlay = document.querySelector('.cdk-overlay-container');
+		const selectTriggers = overlay ? Array.from(overlay.querySelectorAll('[data-slot="select-trigger"]')) : [];
+		expect(selectTriggers.length).toBeGreaterThan(0);
+		for (const selectTrigger of selectTriggers) {
+			expect(selectTrigger.getAttribute('aria-invalid')).toBeNull();
+			expect(selectTrigger.getAttribute('data-matches-spartan-invalid')).toBeNull();
+		}
+
+		datePicker.close();
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
 	});
 });

--- a/libs/helm/date-picker/src/lib/hlm-date-picker-multi.ts
+++ b/libs/helm/date-picker/src/lib/hlm-date-picker-multi.ts
@@ -42,12 +42,7 @@ export const HLM_DATE_PICKER_MUTLI_VALUE_ACCESSOR = {
 	hostDirectives: [BrnFieldControl],
 	host: { class: 'block' },
 	template: `
-		<hlm-popover
-			sideOffset="5"
-			[state]="_popoverState()"
-			(stateChanged)="_popoverState.set($event)"
-			(closed)="_onTouched?.()"
-		>
+		<hlm-popover sideOffset="5" [state]="_popoverState()" (stateChanged)="_onStateChange($event)">
 			<ng-content />
 
 			<hlm-popover-content class="w-fit p-0" *hlmPopoverPortal="let ctx">
@@ -135,6 +130,11 @@ export class HlmDatePickerMulti<T> implements HlmDatePickerBase<T>, ControlValue
 
 	protected _onChange?: ChangeFn<T[]>;
 	protected _onTouched?: TouchFn;
+
+	protected _onStateChange(state: BrnOverlayState) {
+		this._popoverState.set(state);
+		if (state === 'closed') this._onTouched?.();
+	}
 
 	protected _handleChange(value: T[] | undefined) {
 		if (value === undefined) return;

--- a/libs/helm/date-picker/src/lib/hlm-date-picker.ts
+++ b/libs/helm/date-picker/src/lib/hlm-date-picker.ts
@@ -36,12 +36,7 @@ export const HLM_DATE_PICKER_VALUE_ACCESSOR = {
 	hostDirectives: [BrnFieldControl],
 	host: { class: 'block' },
 	template: `
-		<hlm-popover
-			sideOffset="5"
-			[state]="_popoverState()"
-			(stateChanged)="_popoverState.set($event)"
-			(closed)="_onTouched?.()"
-		>
+		<hlm-popover sideOffset="5" [state]="_popoverState()" (stateChanged)="_onStateChange($event)">
 			<ng-content />
 
 			<hlm-popover-content class="w-fit p-0" *hlmPopoverPortal="let ctx">
@@ -121,6 +116,11 @@ export class HlmDatePicker<T> implements HlmDatePickerBase<T>, ControlValueAcces
 
 	protected _onChange?: ChangeFn<T>;
 	protected _onTouched?: TouchFn;
+
+	protected _onStateChange(state: BrnOverlayState) {
+		this._popoverState.set(state);
+		if (state === 'closed') this._onTouched?.();
+	}
 
 	protected _handleChange(value: T | undefined) {
 		if (this._disabled()) return;

--- a/libs/helm/date-picker/src/lib/hlm-date-range-picker.ts
+++ b/libs/helm/date-picker/src/lib/hlm-date-range-picker.ts
@@ -42,12 +42,7 @@ export const HLM_DATE_RANGE_PICKER_VALUE_ACCESSOR = {
 	hostDirectives: [BrnFieldControl],
 	host: { class: 'block' },
 	template: `
-		<hlm-popover
-			sideOffset="5"
-			[state]="_popoverState()"
-			(stateChanged)="_popoverState.set($event)"
-			(closed)="_onClose(); _onTouched?.()"
-		>
+		<hlm-popover sideOffset="5" [state]="_popoverState()" (stateChanged)="_onStateChange($event)">
 			<ng-content />
 
 			<hlm-popover-content class="w-fit p-0" *hlmPopoverPortal="let ctx">
@@ -129,6 +124,14 @@ export class HlmDateRangePicker<T> implements HlmDatePickerBase<T>, ControlValue
 
 	protected _onChange?: ChangeFn<[T, T] | null>;
 	protected _onTouched?: TouchFn;
+
+	protected _onStateChange(state: BrnOverlayState) {
+		this._popoverState.set(state);
+		if (state === 'closed') {
+			this._onClose();
+			this._onTouched?.();
+		}
+	}
 
 	protected _handleStartDayChange(value: T | undefined) {
 		this._start.set(value);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [x] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When a date picker is in a form with `captionLayout` displays a dropdown for year/month, the select receives also the invalid state of the date picker.

<img width="792" height="684" alt="CleanShot 2026-06-22 at 12 47 59@2x" src="https://github.com/user-attachments/assets/42eb68b4-39ab-41ee-9484-d65b79b6ad21" />

## What is the new behavior?

- BrnFieldControl prevent descendants to inject NgControl using `self` - prevents calendar select to inherit date-picker NgControl
- BrnFieldControl only call `field?.registerFieldControl(this)` when NgControl is available - prevents calendar select to override date picker registration for the label

<img width="568" height="668" alt="CleanShot 2026-06-22 at 13 11 54@2x" src="https://github.com/user-attachments/assets/4145bdce-fbd7-486c-845f-4d1c389819a0" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Date picker form example now uses dropdown caption layout for month/year selection.

* **Documentation**
  * Improved “Examples” navigation by simplifying anchor IDs and updating the heading structure.
  * Updated the popover documentation page to include the shared sub-sub-heading component.

* **Bug Fixes**
  * Enhanced form control detection to avoid descendant binding interference.
  * Unified overlay close/touch handling across date picker variants for consistent invalid-state updates.

* **Tests**
  * Added accessibility coverage for dropdown-caption mode invalid-state behavior and touch/invalid transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->