### PR TITLE
fix: prerender missing routes and keep preview pages out of search

### DIFF
--- a/apps/app/src/public/robots.txt
+++ b/apps/app/src/public/robots.txt
@@ -1,4 +1,8 @@
 User-agent: *
 Allow: /
 
-sitemap: https://spartan.ng/sitemap.xml
+# iframe-only preview routes - not meant to be indexed or surfaced in search
+Disallow: /sidebar-preview
+Disallow: /blocks-preview
+
+sitemap: https://www.spartan.ng/sitemap.xml

--- a/apps/app/src/utils/prerender-routes.ts
+++ b/apps/app/src/utils/prerender-routes.ts
@@ -14,7 +14,7 @@ async function getComponentRoutes(): Promise<PrerenderRoute[]> {
 	const componentRoutes = await glob('apps/app/src/app/pages/[(]components[)]/**/*.page.ts');
 
 	const routes = componentRoutes.map((route) => ({
-		route: removePatterns(route, [PAGES_ROOT, PAGE_EXTENSION, REMOVE_PARENTHESES_PATH_PATTERN]),
+		route: stripTrailingIndex(removePatterns(route, [PAGES_ROOT, PAGE_EXTENSION, REMOVE_PARENTHESES_PATH_PATTERN])),
 		staticData: true,
 	}));
 	return routes;
@@ -27,12 +27,29 @@ export async function getPrerenderedRoutes(staticRoutes: PrerenderRoute[] = []):
 		// Combine static routes with dynamically discovered component routes
 		const allRoutes = [...staticRoutes, ...componentRoutes];
 
-		return allRoutes;
+		// De-duplicate by route: e.g. the components layout and its index page both resolve to `/components`.
+		const seen = new Set<string>();
+		const deduped: PrerenderRoute[] = [];
+		for (const entry of allRoutes) {
+			const route = typeof entry === 'string' ? entry : entry.route;
+			if (seen.has(route)) continue;
+			seen.add(route);
+			deduped.push(entry);
+		}
+		return deduped;
 	} catch (error) {
 		console.error('Error discovering routes:', error);
 		// Return static routes only if there's an error
 		return staticRoutes;
 	}
+}
+
+/**
+ * Analog treats `index.page.ts` as its parent path, so a derived `/foo/index` route is really `/foo`.
+ * Strip a trailing `/index` segment (falling back to the root) to avoid prerendering a bogus URL.
+ */
+function stripTrailingIndex(route: string): string {
+	return route.replace(/\/index$/, '') || '/';
 }
 
 /**

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -94,6 +94,7 @@ export default defineConfig(({ command, mode }) => {
 					routes: async () => {
 						const staticRoutes = [
 							'/',
+							'/colors',
 
 							'/documentation/introduction',
 							'/documentation/changelog',
@@ -109,9 +110,19 @@ export default defineConfig(({ command, mode }) => {
 							'/documentation/version-support',
 							'/documentation/health-checks',
 							'/documentation/update-guide',
+							'/documentation/mcp',
+							'/documentation/skills',
+							'/documentation/rtl',
 
 							'/blocks/sidebar',
 							'/blocks/calendar',
+							'/blocks/login',
+							'/blocks/signup',
+							'/blocks/stepper',
+
+							'/forms',
+							'/forms/reactive-forms',
+							'/forms/signal-forms',
 
 							'/stack/overview',
 							'/stack/technologies',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Others

- [x] repo

## What is the current behavior?

Several real pages (`/forms/*`, `/blocks/login|signup|stepper`, `/colors`,
`/documentation/mcp|skills|rtl`) are missing from the prerender + sitemap list. The route
derivation also emits a bogus `/components/index` route that gets prerendered and added to
the sitemap, and the iframe-only preview routes are crawlable.

## What is the new behavior?

- Adds the missing routes to the prerender + sitemap list.
- Strips the trailing `/index` segment from derived routes and de-duplicates them, so
  `/components` is prerendered once and the bogus `/components/index` is gone.
- Disallows `/sidebar-preview` and `/blocks-preview` in robots.txt and points the sitemap
  reference at the canonical host.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new documentation pages, component blocks, and form templates for improved discoverability.

* **Bug Fixes**
  * Corrected sitemap URL configuration.
  * Updated crawler directives to properly exclude preview-only routes from indexing.
  * Fixed duplicate route prevention in site rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->