### PR TITLE
chore: standardize the canonical domain on www.spartan.ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spartan
 
-<a href="https://spartan.ng" target="_blank">
+<a href="https://www.spartan.ng" target="_blank">
 <img alt="A spartan shield" width="200px" src="./spartan.svg" title="Spartan logo"/>
 </a>
 
@@ -15,7 +15,7 @@ spartan/stack and spartan/ui libraries.
 
 All of spartan is an MIT-licensed open source project with its ongoing development made possible by contributors and sponsors.
 
-Our initial 300 contributors and sponsors are featured here and on the front page of [spartan.ng](https://spartan.ng)
+Our initial 300 contributors and sponsors are featured here and on the front page of [spartan.ng](https://www.spartan.ng)
 
 1. [goetzrobin](https://github.com/goetzrobin)
 2. [elite-benni](https://github.com/elite-benni)

--- a/apps/app/src/app/pages/(components)/components/(badge)/badge--link.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(badge)/badge--link.example.ts
@@ -12,7 +12,7 @@ import { HlmBadgeImports } from '@spartan-ng/helm/badge';
 	template: `
 		<div class="flex gap-2">
 			<a hlmBadge routerLink=".">Angular Route</a>
-			<a hlmBadge variant="secondary" href="https://spartan.ng" target="_blank" rel="noopener noreferrer">
+			<a hlmBadge variant="secondary" href="https://www.spartan.ng" target="_blank" rel="noopener noreferrer">
 				External Link
 				<ng-icon name="lucideArrowUpRight" />
 			</a>

--- a/apps/app/src/app/pages/(documentation)/documentation/about.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/about.page.ts
@@ -29,7 +29,7 @@ const aboutLink = 'h-6 underline text-sm px-0.5';
 			<spartan-section-sub-heading first id="about" class="pt-6">About</spartan-section-sub-heading>
 
 			<p class="${hlmP}">
-				<a hlmBtn variant="link" class="${aboutLink}" href="https://spartan.ng">spartan.ng</a>
+				<a hlmBtn variant="link" class="${aboutLink}" href="https://www.spartan.ng">spartan.ng</a>
 				is a project by
 				<a hlmBtn variant="link" class="${aboutLink}" href="https://twitter.com/goetzrobin">goetzrobin</a>
 				.

--- a/apps/app/src/app/shared/meta/meta.util.ts
+++ b/apps/app/src/app/shared/meta/meta.util.ts
@@ -21,7 +21,7 @@ export const metaWith = (title: string, description: string) => [
 	},
 	{
 		property: 'og:url',
-		content: 'https://spartan.ng/',
+		content: 'https://www.spartan.ng/',
 	},
 	{
 		property: 'og:description',
@@ -29,7 +29,7 @@ export const metaWith = (title: string, description: string) => [
 	},
 	{
 		property: 'og:image',
-		content: 'https://spartan.ng/assets/og-image.png',
+		content: 'https://www.spartan.ng/assets/og-image.png',
 	},
 
 	{
@@ -46,6 +46,6 @@ export const metaWith = (title: string, description: string) => [
 	},
 	{
 		property: 'twitter:image',
-		content: 'https://spartan.ng/assets/og-image.png',
+		content: 'https://www.spartan.ng/assets/og-image.png',
 	},
 ];

--- a/libs/brain/README.md
+++ b/libs/brain/README.md
@@ -5,9 +5,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Discord](https://img.shields.io/discord/1145806472172380160?style=flat-square&label=discord&logo=discord&logoColor=white&color=7289DA)](https://discord.gg/EqHnxQ4uQr)
 
-[Website](https://spartan.ng) • [Documentation](https://www.spartan.ng/documentation/installation) • [Components](https://www.spartan.ng/components) • [GitHub](https://github.com/spartan-ng/spartan)
+[Website](https://www.spartan.ng) • [Documentation](https://www.spartan.ng/documentation/installation) • [Components](https://www.spartan.ng/components) • [GitHub](https://github.com/spartan-ng/spartan)
 
-> Accessible, unstyled UI primitives for Angular. The behavior half of [spartan/ui](https://spartan.ng).
+> Accessible, unstyled UI primitives for Angular. The behavior half of [spartan/ui](https://www.spartan.ng).
 
 `@spartan-ng/brain` is a fully tree-shakable collection of headless Angular primitives - keyboard navigation, focus management, ARIA wiring, and state - with zero opinions about styling. Pair it with [`helm`](https://www.spartan.ng/documentation/installation) styles (copied into your codebase by the [spartan CLI](https://www.npmjs.com/package/@spartan-ng/cli)) for the full shadcn-style experience, or bring your own design system.
 

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -5,9 +5,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Discord](https://img.shields.io/discord/1145806472172380160?style=flat-square&label=discord&logo=discord&logoColor=white&color=7289DA)](https://discord.gg/EqHnxQ4uQr)
 
-[Website](https://spartan.ng) • [Documentation](https://www.spartan.ng/documentation/cli) • [Components](https://www.spartan.ng/components) • [GitHub](https://github.com/spartan-ng/spartan)
+[Website](https://www.spartan.ng) • [Documentation](https://www.spartan.ng/documentation/cli) • [Components](https://www.spartan.ng/components) • [GitHub](https://github.com/spartan-ng/spartan)
 
-> The official CLI for [spartan/ui](https://spartan.ng). Add accessible, beautifully styled Angular components to any project with one command.
+> The official CLI for [spartan/ui](https://www.spartan.ng). Add accessible, beautifully styled Angular components to any project with one command.
 
 `@spartan-ng/cli` is an [Nx plugin](https://nx.dev) and [Angular schematic](https://angular.io/guide/schematics) that wires up the spartan/ui two-layer architecture for you: the **brain** primitives are installed from npm and the **helm** styles are copied into your codebase where you own them. Works with both Angular CLI projects and Nx workspaces - no extra configuration required.
 

--- a/libs/trpc/README.md
+++ b/libs/trpc/README.md
@@ -2,4 +2,4 @@
 
 Spartan tRPC integration
 
-Learn more at [spartan.ng](https://spartan.ng)
+Learn more at [spartan.ng](https://www.spartan.ng)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe: canonical domain consistency

## Which package are you modifying?

### Others

- [x] repo

## What is the current behavior?

The canonical domain is inconsistent: SEO metadata (`og:url`, `og:image`), README links
and a couple of in-app example links use the bare `spartan.ng`, while the asset, AI-chat
and registry URLs already use `www.spartan.ng`.

## What is the new behavior?

Standardizes those remaining references on `www.spartan.ng` so the canonical domain is
consistent across the project. (A parser test fixture that uses an arbitrary `spartan.ng`
URL is intentionally left unchanged.)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation & Chores**
  * Updated all website domain references across documentation pages, component examples, library README files, meta tags, and social media configurations to consistently use the standardized `www` subdomain format throughout the project. This ensures consistent branding and uniform domain usage across the entire codebase and its public-facing materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->