### PR TITLE
test: add per-style cli smoke coverage with deterministic scaffolding

### DIFF
--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -43,6 +43,13 @@ jobs:
           - acli
           - all-components
           - all-components-nx-entry
+          # Style coverage: one cell per non-default style, split across angular-cli and nx. Keep in sync
+          # with the style-* cells in matrix.ts.
+          - style-acli-nova
+          - style-nx-lyra
+          - style-acli-maia
+          - style-nx-mira
+          - style-acli-luma
     name: ${{ matrix.cell }}
     steps:
       - uses: actions/checkout@v6

--- a/apps/cli-smoke/README.md
+++ b/apps/cli-smoke/README.md
@@ -33,8 +33,18 @@ and builds with themed styles**, but they do not run the app or assert runtime b
 - `all-components` - generates **every** supported primitive into an Angular CLI app and builds them all
   in one `ng build`; the slowest cell, but fans out to its own runner. Set `nightlyOnly: true` in
   `src/matrix.ts` to drop it from per-PR CI if it proves too slow.
+- `style-acli-<style>` / `style-nx-<style>` - one cell per supported **style**, split across angular-cli
+  and nx so both generator paths are exercised: `nova`/`maia`/`luma` on angular-cli, `lyra`/`mira` on nx
+  (`vega` is the default the other cells already use). Each generates with that style and asserts the CLI
+  replaced the `spartan-*` placeholders with **that style's** registry classes - no leftover
+  non-allowlisted placeholders, and at least one class unique to the style (derived from
+  `libs/registry/src/styles`, never hardcoded) reaches the output. The standard build's themed-CSS check is
+  style-blind (those vars come from the `--theme`, not the style), so these cells are the only coverage that
+  the per-style class replacement works.
 
-Tailwind is fixed at v4. Add or remove combinations in `src/matrix.ts`.
+Tailwind is fixed at v4. Add or remove combinations in `src/matrix.ts`. When a style is added to or removed
+from `libs/registry/src/styles/style.ts`, update the `styleCells` list in `src/matrix.ts` (and the matching
+`style-*` entries in `.github/workflows/cli-smoke.yml`).
 
 ## Running
 

--- a/apps/cli-smoke/src/matrix.ts
+++ b/apps/cli-smoke/src/matrix.ts
@@ -25,6 +25,13 @@ export interface SetupCell {
 	allComponents?: boolean;
 	/** Excluded from the per-PR CI matrix (too slow); runs only in the nightly full run. */
 	nightlyOnly?: boolean;
+	/**
+	 * Component style the CLI generates with (written into components.json). Defaults to 'vega' when
+	 * omitted - the style every non-style cell uses. The style decides which Tailwind classes the
+	 * generator pulls from the registry to replace the `spartan-*` placeholders; the dedicated
+	 * `style-*` cells below vary it to verify that replacement for every supported style.
+	 */
+	style?: string;
 }
 
 const nxCells: SetupCell[] = (['library', 'entrypoint'] as GenerateAs[]).flatMap((generateAs) =>
@@ -71,7 +78,28 @@ const allComponentsCells: SetupCell[] = [
 	},
 ];
 
-export const setupMatrix: SetupCell[] = [...nxCells, ...nxStandaloneCells, ...angularCliCells, ...allComponentsCells];
+// Style coverage: scaffold -> generate -> build once per supported style and assert the CLI replaced the
+// `spartan-*` placeholders with THAT style's registry classes (see assertStyleClassesApplied). The six
+// styles are split across the two workspace types so both the angular-cli and the nx generator path are
+// exercised while no style runs more than once: vega (the default) is covered by the cells above, and the
+// remaining five alternate between angular-cli and nx (entrypoint + buildable - the nx shape most sensitive
+// to the style transform). Keep in sync with libs/registry/src/styles/style.ts (STYLES) when a style is
+// added or removed.
+const styleCells: SetupCell[] = [
+	{ id: 'style-acli-nova', workspace: 'angular-cli', style: 'nova' },
+	{ id: 'style-nx-lyra', workspace: 'nx', generateAs: 'entrypoint', buildable: true, style: 'lyra' },
+	{ id: 'style-acli-maia', workspace: 'angular-cli', style: 'maia' },
+	{ id: 'style-nx-mira', workspace: 'nx', generateAs: 'entrypoint', buildable: true, style: 'mira' },
+	{ id: 'style-acli-luma', workspace: 'angular-cli', style: 'luma' },
+];
+
+export const setupMatrix: SetupCell[] = [
+	...nxCells,
+	...nxStandaloneCells,
+	...angularCliCells,
+	...allComponentsCells,
+	...styleCells,
+];
 
 /**
  * Default components generated in every cell. `button` is a standalone primitive; `card` exercises a

--- a/apps/cli-smoke/src/setup-matrix.spec.ts
+++ b/apps/cli-smoke/src/setup-matrix.spec.ts
@@ -3,6 +3,7 @@ import { isSmokeAffected } from './support/affected';
 import {
 	assertHealthcheckClean,
 	assertMigrateHelmLibrariesLoads,
+	assertStyleClassesApplied,
 	buildWorkspace,
 	cleanupWorkspace,
 	prepareWorkspace,
@@ -31,7 +32,7 @@ describe('CLI setup matrix', () => {
 	// name the per-cell pattern can anchor to.
 	for (const cell of setupMatrix) {
 		describe(cell.id, () => {
-			it('scaffolds, generates, passes healthcheck, consumes components, and builds with themed styles', () => {
+			it('scaffolds, generates, passes healthcheck, applies the style classes, consumes components, and builds with themed styles', () => {
 				if (!affected) {
 					console.log(`[cli-smoke] ${cell.id}: skipped (nothing affecting the CLI changed).`);
 					return;
@@ -42,6 +43,9 @@ describe('CLI setup matrix', () => {
 				assertMigrateHelmLibrariesLoads(ws);
 				runGenerators(ws);
 				assertHealthcheckClean(ws);
+				// Verify the configured style's registry classes replaced the spartan-* placeholders before we
+				// build (the build's themed-CSS check is style-blind - those vars come from the theme).
+				assertStyleClassesApplied(ws);
 				useGeneratedComponents(ws);
 				buildWorkspace(ws);
 				cleanupWorkspace(ws);

--- a/apps/cli-smoke/src/utils/workspace.ts
+++ b/apps/cli-smoke/src/utils/workspace.ts
@@ -1,4 +1,4 @@
-import { createStyleMap, STYLES } from '@spartan-ng/cli';
+import { createStyleMap, STYLE_PLACEHOLDER_ALLOWLIST, STYLES } from '@spartan-ng/cli';
 import { execSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -302,11 +302,6 @@ export function assertHealthcheckClean(ws: CellWorkspace): void {
 	}
 }
 
-// Mirror of the transform's ALLOWLIST (libs/cli .../styles/transform-style-map.ts): the only `spartan-*`
-// tokens the generator intentionally leaves in the output. Anything else remaining means a placeholder the
-// style map should have replaced was not replaced.
-const STYLE_ALLOWLIST = new Set(['spartan-menu-target', 'spartan-logical-sides', 'spartan-invalid']);
-
 /** Build a style's class map from the registry CSS exactly as the CLI does, so the expected classes are
  *  derived (never hardcoded) and stay correct as the registry styles change. */
 function registryStyleMap(style: string): Record<string, string> {
@@ -315,6 +310,18 @@ function registryStyleMap(style: string): Record<string, string> {
 		'utf-8',
 	);
 	return createStyleMap(css);
+}
+
+/** Every registry placeholder selector across all styles (minus the allowlist), so a leftover survives the
+ *  check even when the cell's own style is the one that dropped the selector. */
+function allStylePlaceholders(): Set<string> {
+	const placeholders = new Set<string>();
+	for (const style of STYLES) {
+		for (const selector of Object.keys(registryStyleMap(style))) {
+			if (!STYLE_PLACEHOLDER_ALLOWLIST.has(selector)) placeholders.add(selector);
+		}
+	}
+	return placeholders;
 }
 
 /** Selectors of the generated components (so the differential below only considers classes that can
@@ -376,7 +383,7 @@ export function assertStyleClassesApplied(ws: CellWorkspace): void {
 	const source = readGeneratedSource(ws);
 	const styleMap = registryStyleMap(style);
 
-	const placeholders = new Set(Object.keys(styleMap).filter((selector) => !STYLE_ALLOWLIST.has(selector)));
+	const placeholders = allStylePlaceholders();
 	const leftover = [...new Set(Array.from(source.matchAll(/\bspartan-[\w-]+\b/g), (m) => m[0]))].filter((token) =>
 		placeholders.has(token),
 	);
@@ -388,7 +395,14 @@ export function assertStyleClassesApplied(ws: CellWorkspace): void {
 	}
 
 	const distinctive = distinctiveTokens(styleMap, style, generatedComponentSelectors(ws));
-	if (distinctive.size > 0 && ![...distinctive].some((token) => containsClass(source, token))) {
+	if (distinctive.size === 0) {
+		console.warn(
+			`[${ws.cell.id}] style "${style}" has no classes distinctive from the other styles for the ` +
+				`generated components - the style-identity assertion is skipped for this cell.`,
+		);
+		return;
+	}
+	if (![...distinctive].some((token) => containsClass(source, token))) {
 		throw new Error(
 			`[${ws.cell.id}] none of style "${style}"'s distinctive registry classes reached the generated ` +
 				`output - the generator may have applied the wrong style's classes.`,

--- a/apps/cli-smoke/src/utils/workspace.ts
+++ b/apps/cli-smoke/src/utils/workspace.ts
@@ -1,9 +1,13 @@
+import { createStyleMap, STYLES } from '@spartan-ng/cli';
 import { execSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { componentsUnderTest, type SetupCell } from '../matrix';
 import { readRegistryInfo, type RegistryInfo } from '../support/registry';
+
+/** The style every cell uses unless it sets its own (matches matrix.ts's documented default). */
+const DEFAULT_STYLE = 'vega';
 
 // Read lazily (not at import time): when a cell is skipped because nothing affecting the CLI changed,
 // global-setup never writes registry.json, and this module is still imported by the spec.
@@ -12,9 +16,12 @@ function registryInfo(): RegistryInfo {
 	return (cachedRegistry ??= readRegistryInfo());
 }
 
-// Match the workspace's own Angular/Nx versions so scaffolded projects mirror real consumers.
+// Match the workspace's own Angular/Nx versions so scaffolded projects mirror real consumers. Strip any
+// leading ^/~ so create-nx-workspace is pinned to the EXACT version, not a floating range: newer
+// create-nx-workspace releases progressively remap legacy presets (e.g. `angular-monorepo`) to remote
+// GitHub template clones, so an unpinned range could silently change the scaffold out from under us.
 const rootPkg = require(join(workspaceRootDir(), 'package.json'));
-const NX_VERSION: string = rootPkg.devDependencies?.nx ?? rootPkg.dependencies?.nx ?? 'latest';
+const NX_VERSION: string = (rootPkg.devDependencies?.nx ?? rootPkg.dependencies?.nx ?? 'latest').replace(/^[\^~]/, '');
 const NG_CLI_VERSION: string = (
 	rootPkg.devDependencies?.['@angular/cli'] ??
 	rootPkg.dependencies?.['@angular/cli'] ??
@@ -41,9 +48,24 @@ function workspaceRootDir(): string {
 	return join(__dirname, '..', '..', '..', '..');
 }
 
+/** AI-agent host markers that make create-nx-workspace switch into "AI mode" (see its isAiAgent()). In that
+ * mode it remaps the `angular-monorepo` preset to cloning the remote `nrwl/angular-template` and auto-wires
+ * Nx Cloud, ignoring our `--preset`/`--nxCloud=skip` - so the scaffold stops being deterministic (it depends
+ * on a live remote template) and differs between a plain terminal, CI, and an agent like Claude Code. We
+ * strip them from every child env so the local, pinned scaffold runs identically regardless of host. */
+const AI_AGENT_ENV_VARS = [
+	'CLAUDECODE',
+	'CLAUDE_CODE',
+	'OPENCODE',
+	'CURSOR_TRACE_ID',
+	'COMPOSER_NO_INTERACTION',
+	'GEMINI_CLI',
+	'REPL_ID',
+] as const;
+
 /** Registry + auth env shared by every child process so installs hit the local registry. */
 function execEnv(): NodeJS.ProcessEnv {
-	return {
+	const env: NodeJS.ProcessEnv = {
 		...process.env,
 		npm_config_registry: registryInfo().registry,
 		NPM_CONFIG_REGISTRY: registryInfo().registry,
@@ -59,6 +81,11 @@ function execEnv(): NodeJS.ProcessEnv {
 		// exceeds the 4GB default heap. Raise it for all cells (harmless for the small ones).
 		NODE_OPTIONS: '--max-old-space-size=8192',
 	};
+	// Force standard (non-AI-agent) tooling behaviour so the scaffold is deterministic on any host.
+	for (const key of AI_AGENT_ENV_VARS) {
+		delete env[key];
+	}
+	return env;
 }
 
 function run(command: string, cwd: string): void {
@@ -72,6 +99,26 @@ function capture(command: string, cwd: string): string {
 
 /** Tag applied to the spartan-generated nx libraries so the build step can target just them. */
 const SPARTAN_TAG = 'scope:spartan-smoke';
+
+/**
+ * Defence-in-depth canary: confirm create-nx-workspace produced the classic local scaffold we asked for, not
+ * a remote GitHub template clone. The `--preset=angular-monorepo --appName=sample` run always lands an
+ * `apps/sample` project; in AI/template mode (see AI_AGENT_ENV_VARS) it instead clones `nrwl/angular-template`
+ * (apps/api, apps/shop, ...) and there is no `apps/sample`. Failing loudly here turns a later cryptic
+ * `nx g`/config-load error into a one-line diagnosis. Only the monorepo preset is remapped in AI mode
+ * (angular-standalone is not, and the angular-cli cell uses `ng new`), so only this layout needs the canary.
+ */
+function assertClassicScaffold(cell: SetupCell, dir: string): void {
+	const isMonorepo = cell.workspace === 'nx' && cell.nxLayout !== 'standalone';
+	if (!isMonorepo) return;
+	if (!existsSync(join(dir, 'apps', 'sample'))) {
+		throw new Error(
+			`[${cell.id}] create-nx-workspace did not produce the expected classic angular-monorepo layout ` +
+				`(missing apps/sample) - it likely entered AI/template mode and cloned a remote template. Ensure the ` +
+				`AI_AGENT_ENV_VARS are stripped from the scaffold env (see execEnv).`,
+		);
+	}
+}
 
 /** Scaffold the workspace, pin Tailwind v4, install the CLI, and write components.json. */
 export function prepareWorkspace(cell: SetupCell): CellWorkspace {
@@ -124,6 +171,7 @@ export function prepareWorkspace(cell: SetupCell): CellWorkspace {
 		throw new Error(`Scaffolding ${cell.id} did not produce a workspace at ${dir}`);
 	}
 
+	assertClassicScaffold(cell, dir);
 	writeNpmrc(dir);
 
 	if (cell.workspace === 'nx' && !isStandalone) {
@@ -176,6 +224,7 @@ function writeTailwindConfig(dir: string): void {
 }
 
 function writeComponentsJson(dir: string, cell: SetupCell, componentsPath: string): void {
+	const style = cell.style ?? DEFAULT_STYLE;
 	const config =
 		cell.workspace === 'nx'
 			? {
@@ -183,9 +232,9 @@ function writeComponentsJson(dir: string, cell: SetupCell, componentsPath: strin
 					buildable: cell.buildable,
 					generateAs: cell.generateAs,
 					importAlias: '@spartan-ng/helm',
-					style: 'vega',
+					style,
 				}
-			: { componentsPath, importAlias: '@spartan-ng/helm', style: 'vega' };
+			: { componentsPath, importAlias: '@spartan-ng/helm', style };
 	writeFileSync(join(dir, 'components.json'), `${JSON.stringify(config, null, 2)}\n`);
 }
 
@@ -250,6 +299,100 @@ export function assertHealthcheckClean(ws: CellWorkspace): void {
 		.filter((line) => !line.includes('Dependency Check'));
 	if (failures.length > 0) {
 		throw new Error(`Healthcheck reported issues on freshly generated output:\n${failures.join('\n')}`);
+	}
+}
+
+// Mirror of the transform's ALLOWLIST (libs/cli .../styles/transform-style-map.ts): the only `spartan-*`
+// tokens the generator intentionally leaves in the output. Anything else remaining means a placeholder the
+// style map should have replaced was not replaced.
+const STYLE_ALLOWLIST = new Set(['spartan-menu-target', 'spartan-logical-sides', 'spartan-invalid']);
+
+/** Build a style's class map from the registry CSS exactly as the CLI does, so the expected classes are
+ *  derived (never hardcoded) and stay correct as the registry styles change. */
+function registryStyleMap(style: string): Record<string, string> {
+	const css = readFileSync(
+		join(workspaceRootDir(), 'libs', 'registry', 'src', 'styles', `style-${style}.css`),
+		'utf-8',
+	);
+	return createStyleMap(css);
+}
+
+/** Selectors of the generated components (so the differential below only considers classes that can
+ *  actually appear in this cell's output). The all-components cell generates everything, so it matches all. */
+function generatedComponentSelectors(ws: CellWorkspace): (selector: string) => boolean {
+	if (ws.cell.allComponents) return () => true;
+	const components = [...componentsUnderTest];
+	return (selector) => components.some((c) => selector === `spartan-${c}` || selector.startsWith(`spartan-${c}-`));
+}
+
+/** Tailwind tokens this style assigns to a generated-component selector that NO other style assigns to the
+ *  same selector - the fingerprint proving the generator pulled THIS style's classes, not just any style's. */
+function distinctiveTokens(
+	mine: Record<string, string>,
+	style: string,
+	isRelevant: (selector: string) => boolean,
+): Set<string> {
+	const others = STYLES.filter((s) => s !== style).map(registryStyleMap);
+	const distinctive = new Set<string>();
+	for (const [selector, classes] of Object.entries(mine)) {
+		if (!isRelevant(selector)) continue;
+		for (const token of classes.split(/\s+/).filter(Boolean)) {
+			const sharedElsewhere = others.some((m) => (m[selector] ?? '').split(/\s+/).includes(token));
+			if (!sharedElsewhere) distinctive.add(token);
+		}
+	}
+	return distinctive;
+}
+
+/** A class token is present only when it appears delimited by class separators (whitespace/quotes/backtick),
+ *  so `bg-primary` does not spuriously match inside `bg-primary/80`. Tokens carry regex-special chars. */
+function containsClass(source: string, token: string): boolean {
+	const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	return new RegExp(`(?:^|[\\s"'\`])${escaped}(?=$|[\\s"'\`])`).test(source);
+}
+
+/** Concatenated source of every generated component file (specs excluded - they carry no styled classes). */
+function readGeneratedSource(ws: CellWorkspace): string {
+	const root = join(ws.dir, ws.componentsPath);
+	return readdirSync(root, { recursive: true, withFileTypes: true })
+		.filter((entry) => entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.spec.ts'))
+		.map((entry) => readFileSync(join(entry.parentPath, entry.name), 'utf-8'))
+		.join('\n');
+}
+
+/**
+ * The heart of the style coverage: assert the CLI replaced the `spartan-*` placeholders with the configured
+ * style's registry classes. Two checks, both reading the freshly generated source:
+ *   1. No registry placeholder survives - a leftover is a `spartan-*` class the style map should have
+ *      replaced (the build's themed-CSS check would not catch this; those CSS vars come from the theme, not
+ *      the style). A genuine placeholder is one of the registry's `.spartan-*` selector names, so we match
+ *      against those rather than any `spartan-*` substring - otherwise import paths (`@spartan-ng/...`) and
+ *      file names (`provide-spartan-hlm`) would read as false leftovers.
+ *   2. At least one class unique to this style (vs every other style, derived from the registry) reached the
+ *      output - proving the RIGHT style's classes were applied, not merely some style's.
+ */
+export function assertStyleClassesApplied(ws: CellWorkspace): void {
+	const style = ws.cell.style ?? DEFAULT_STYLE;
+	const source = readGeneratedSource(ws);
+	const styleMap = registryStyleMap(style);
+
+	const placeholders = new Set(Object.keys(styleMap).filter((selector) => !STYLE_ALLOWLIST.has(selector)));
+	const leftover = [...new Set(Array.from(source.matchAll(/\bspartan-[\w-]+\b/g), (m) => m[0]))].filter((token) =>
+		placeholders.has(token),
+	);
+	if (leftover.length > 0) {
+		throw new Error(
+			`[${ws.cell.id}] generated source still contains unreplaced spartan-* placeholders for style ` +
+				`"${style}": ${leftover.join(', ')}`,
+		);
+	}
+
+	const distinctive = distinctiveTokens(styleMap, style, generatedComponentSelectors(ws));
+	if (distinctive.size > 0 && ![...distinctive].some((token) => containsClass(source, token))) {
+		throw new Error(
+			`[${ws.cell.id}] none of style "${style}"'s distinctive registry classes reached the generated ` +
+				`output - the generator may have applied the wrong style's classes.`,
+		);
 	}
 }
 

--- a/libs/cli/src/generators/base/lib/styles/transform-style-map.ts
+++ b/libs/cli/src/generators/base/lib/styles/transform-style-map.ts
@@ -11,7 +11,8 @@ import {
 import { type StyleMap } from './create-style-map';
 import type { TransformerStyle } from './transform';
 
-const ALLOWLIST = new Set(['spartan-menu-target', 'spartan-logical-sides', 'spartan-invalid']);
+/** `spartan-*` tokens the transform intentionally leaves in place (everything else is a replaced placeholder). */
+export const STYLE_PLACEHOLDER_ALLOWLIST = new Set(['spartan-menu-target', 'spartan-logical-sides', 'spartan-invalid']);
 
 function isStringLiteralLike(node: Node): node is StringLiteral | NoSubstitutionTemplateLiteral {
 	return Node.isStringLiteral(node) || Node.isNoSubstitutionTemplateLiteral(node);
@@ -181,7 +182,7 @@ function extractSpartanClasses(str: string) {
 function removeSpartanClasses(str: string) {
 	return str
 		.replace(/\bspartan-[\w-]+\b/g, (match) => {
-			if (ALLOWLIST.has(match)) return match;
+			if (STYLE_PLACEHOLDER_ALLOWLIST.has(match)) return match;
 			return '';
 		})
 		.replace(/\s+/g, ' ')
@@ -317,7 +318,7 @@ function removeCnClasses(str: string) {
 	return str
 		.replace(/\bspartan-[\w-]+\b/g, (match) => {
 			// Preserve allowlisted classes
-			if (ALLOWLIST.has(match)) {
+			if (STYLE_PLACEHOLDER_ALLOWLIST.has(match)) {
 				return match;
 			}
 			return '';


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated (cli-smoke README)

## PR Type

- [x] CI related changes (test coverage / smoke matrix)

## Which package are you modifying?

### Others

- [x] cli

## What is the current behavior?

The cli-smoke matrix scaffolds real workspaces for every supported setup but only ever exercised a single
style (vega). Nothing verified that the CLI replaces the `spartan-*` placeholders with the right style's
registry classes - the build's themed-CSS check only looks at `--theme` variables, so a broken style map
would pass. Separately, the nx scaffold was non-deterministic when run from an AI-agent host.

## What is the new behavior?

- One smoke cell per supported style (`nova`, `lyra`, `maia`, `mira`, `luma`), split across angular-cli and
  nx, asserting no leftover `spartan-*` placeholders and that a style-distinctive class (derived from
  `libs/registry`, not hardcoded) reaches the generated output.
- Deterministic scaffolding on any host: strip the AI-agent env markers (`CLAUDECODE`/`OPENCODE`/...) so
  `create-nx-workspace` runs its classic local preset instead of cloning a remote template and forcing Nx
  Cloud, pin it to the exact nx version, and add a canary that fails loudly if the classic layout is missing.

## Does this PR introduce a breaking change?

- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded CLI smoke test coverage with additional per-style configurations across both Angular CLI and Nx generator paths.
  * Strengthened smoke-test validation to ensure configured style registry class placeholders are correctly replaced and that style-specific tokens are present before builds.

* **Documentation**
  * Updated smoke-test “matrix” documentation to explain per-style cells and how to keep style entries in sync when supported styles change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->