### PR TITLE
feat: add selectable logo variant to the docs app

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -30,6 +30,10 @@
 			if (localStorage.layout) {
 				document.documentElement.classList.add('layout-' + localStorage.layout);
 			}
+			const logoVariant = ['default', 'legacy'].includes(localStorage.logoVariant)
+				? localStorage.logoVariant
+				: 'default';
+			document.documentElement.classList.add('logo-' + logoVariant);
 			if (window.navigator.userAgent.toUpperCase().includes('MAC')) {
 				document.documentElement.style.setProperty('--is-mac', 'true');
 			}

--- a/apps/app/src/app/pages/(home)/components/th-item-placeholder.ts
+++ b/apps/app/src/app/pages/(home)/components/th-item-placeholder.ts
@@ -9,7 +9,8 @@ import { SpartanLogo } from '@spartan-ng/app/app/shared/spartan-logo';
 	},
 	template: `
 		<spartan-logo
-			class="bg-muted/40 h-10 w-10 -rotate-90 rounded-full p-1 [&>svg]:opacity-10 [&>svg]:grayscale dark:[&>svg]:opacity-50"
+			flat
+			class="bg-muted/40 logo-legacy:[&>svg]:translate-y-0 h-10 w-10 rounded-full p-1.5 [&>svg]:translate-y-[1px] [&>svg]:opacity-10 [&>svg]:grayscale dark:[&>svg]:opacity-50"
 		/>
 		<div class="h-6"></div>
 	`,

--- a/apps/app/src/app/shared/header/header.ts
+++ b/apps/app/src/app/shared/header/header.ts
@@ -1,15 +1,18 @@
 import { httpResource } from '@angular/common/http';
-import { Component, computed } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { lucideGithub } from '@ng-icons/lucide';
+import { lucideGithub, lucideRepeat } from '@ng-icons/lucide';
 import { tablerBrandDiscord } from '@ng-icons/tabler-icons';
 import { DocsDialog } from '@spartan-ng/app/app/shared/header/docs-dialog';
 import { HeaderLayoutMode } from '@spartan-ng/app/app/shared/header/header-layout-mode';
 import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmContextMenuImports } from '@spartan-ng/helm/context-menu';
+import { HlmDropdownMenuImports } from '@spartan-ng/helm/dropdown-menu';
 import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
 import { SpartanLogo } from '../spartan-logo';
 import { NavLink } from '../spartan-nav-link';
+import { ThemeService } from '../theme.service';
 import { HeaderDarkMode } from './header-dark-mode';
 import { HeaderMobileNav } from './header-mobile-nav';
 
@@ -25,10 +28,12 @@ import { HeaderMobileNav } from './header-mobile-nav';
 		SpartanLogo,
 		HlmSeparatorImports,
 		HeaderLayoutMode,
+		HlmContextMenuImports,
+		HlmDropdownMenuImports,
 
 		DocsDialog,
 	],
-	providers: [provideIcons({ tablerBrandDiscord, lucideGithub })],
+	providers: [provideIcons({ tablerBrandDiscord, lucideGithub, lucideRepeat })],
 	host: {
 		class: 'backdrop-blur-sm sticky top-0 z-50 w-full',
 	},
@@ -37,10 +42,29 @@ import { HeaderMobileNav } from './header-mobile-nav';
 			<div
 				class="3xl:fixed:container A composable, themeable and customizable sidebar component. flex h-(--header-height) items-center gap-2"
 			>
-				<a hlmBtn variant="ghost" class="hidden p-1.5 lg:flex" routerLink="/">
-					<spartan-logo class="w-14" />
+				<a
+					hlmBtn
+					variant="ghost"
+					class="hidden h-fit p-1.5 lg:flex"
+					routerLink="/"
+					[hlmContextMenuTrigger]="logoMenu"
+					align="start"
+					side="bottom"
+				>
+					<spartan-logo class="w-10" />
 					<span class="sr-only">spartan</span>
 				</a>
+
+				<ng-template #logoMenu>
+					<hlm-dropdown-menu class="w-52">
+						<hlm-dropdown-menu-group>
+							<button hlmDropdownMenuItem (click)="_toggleLogoVariant()">
+								<ng-icon name="lucideRepeat" />
+								{{ _logoVariant() === 'legacy' ? 'Switch to new logo' : 'Switch to legacy logo' }}
+							</button>
+						</hlm-dropdown-menu-group>
+					</hlm-dropdown-menu>
+				</ng-template>
 
 				<spartan-mobile-nav class="lg:hidden" />
 
@@ -87,6 +111,13 @@ import { HeaderMobileNav } from './header-mobile-nav';
 	`,
 })
 export class Header {
+	private readonly _themeService = inject(ThemeService);
+	protected readonly _logoVariant = this._themeService.logoVariant;
+
+	protected _toggleLogoVariant(): void {
+		this._themeService.toggleLogoVariant();
+	}
+
 	private readonly _githubInfo = httpResource<{ stars: number }>(() => '/api/github-info');
 
 	protected readonly _stars = computed(() => {

--- a/apps/app/src/app/shared/spartan-logo.ts
+++ b/apps/app/src/app/shared/spartan-logo.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { booleanAttribute, Component, input } from '@angular/core';
 
 @Component({
 	selector: 'spartan-logo',
@@ -6,7 +6,117 @@ import { Component } from '@angular/core';
 		class: 'flex items-center justify-center',
 	},
 	template: `
-		<svg class="w-full" viewBox="0 0 630 268" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<svg
+			class="logo-legacy:hidden max-h-10 w-full"
+			viewBox="0 0 873 923"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				d="M351.019 572.876L436.247 619.524L521.474 572.876L480.551 498.463L559.034 431.269L436.247 22.0439L313.459 431.269L391.942 498.463L351.019 572.876Z"
+				[attr.fill]="flat() ? '#DD0031' : 'url(#paint0_linear_1019_272)'"
+			/>
+			@if (!flat()) {
+				<path
+					d="M351.019 572.876L436.247 619.524L521.474 572.876L480.551 498.463L559.034 431.269L436.247 22.0439L313.459 431.269L391.942 498.463L351.019 572.876Z"
+					fill="url(#paint1_radial_1019_272)"
+				/>
+			}
+			<path
+				d="M873 153.885L841.477 648.314L540.078 0L873 153.885ZM664.241 793.208L436.502 923L208.759 793.208L255.079 681.084H617.921L664.241 793.208ZM31.2009 648.314L0 153.885L332.922 0L31.2009 648.314Z"
+				[attr.fill]="flat() ? '#DD0031' : 'url(#paint2_linear_1019_272)'"
+			/>
+			<path
+				d="M370.772 546.67L435.924 582.342L501.076 546.67L469.792 489.766L529.789 438.382L435.924 125.445L342.059 438.382L402.056 489.766L370.772 546.67Z"
+				[attr.fill]="flat() ? '#DD0031' : 'url(#paint3_linear_1019_272)'"
+			/>
+			@if (!flat()) {
+				<path
+					d="M873 153.885L841.477 648.314L540.078 0L873 153.885ZM664.241 793.208L436.502 923L208.759 793.208L255.079 681.084H617.921L664.241 793.208ZM31.2009 648.314L0 153.885L332.922 0L31.2009 648.314Z"
+					fill="url(#paint4_radial_1019_272)"
+				/>
+				<path
+					d="M370.772 546.67L435.924 582.342L501.076 546.67L469.792 489.766L529.789 438.382L435.924 125.445L342.059 438.382L402.056 489.766L370.772 546.67Z"
+					fill="url(#paint5_radial_1019_272)"
+				/>
+				<defs>
+					<linearGradient
+						id="paint0_linear_1019_272"
+						x1="-134"
+						y1="843.838"
+						x2="1222.51"
+						y2="646.408"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stop-color="#75011D" />
+						<stop offset="0.526" stop-color="#A30024" />
+						<stop offset="1" stop-color="#DD0031" />
+					</linearGradient>
+					<radialGradient
+						id="paint1_radial_1019_272"
+						cx="0"
+						cy="0"
+						r="1"
+						gradientTransform="matrix(-913.077 788.538 -790.215 -912.594 1140.12 -142)"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stop-color="#DD0031" />
+						<stop offset="0.707" stop-color="#DB0030" stop-opacity="0.5" />
+						<stop offset="1" stop-color="#DB0030" stop-opacity="0" />
+					</radialGradient>
+					<linearGradient
+						id="paint2_linear_1019_272"
+						x1="-2.84247e-06"
+						y1="753.876"
+						x2="1037"
+						y2="603"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stop-color="#75011D" />
+						<stop offset="0.526" stop-color="#A30024" />
+						<stop offset="1" stop-color="#DD0031" />
+					</linearGradient>
+					<linearGradient
+						id="paint3_linear_1019_272"
+						x1="-2.84247e-06"
+						y1="753.876"
+						x2="1037"
+						y2="603"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stop-color="#75011D" />
+						<stop offset="0.526" stop-color="#A30024" />
+						<stop offset="1" stop-color="#DD0031" />
+					</linearGradient>
+					<radialGradient
+						id="paint4_radial_1019_272"
+						cx="0"
+						cy="0"
+						r="1"
+						gradientTransform="matrix(-698 603 -604.079 -697.866 974 1.14292e-05)"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stop-color="#DD0031" />
+						<stop offset="0.707" stop-color="#DB0030" stop-opacity="0.5" />
+						<stop offset="1" stop-color="#DB0030" stop-opacity="0" />
+					</radialGradient>
+					<radialGradient
+						id="paint5_radial_1019_272"
+						cx="0"
+						cy="0"
+						r="1"
+						gradientTransform="matrix(-698 603 -604.079 -697.866 974 1.14292e-05)"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stop-color="#DD0031" />
+						<stop offset="0.707" stop-color="#DB0030" stop-opacity="0.5" />
+						<stop offset="1" stop-color="#DB0030" stop-opacity="0" />
+					</radialGradient>
+				</defs>
+			}
+		</svg>
+
+		<svg class="logo-legacy:block hidden w-full" viewBox="0 0 630 268" fill="none" xmlns="http://www.w3.org/2000/svg">
 			<path
 				d="M191.5 244.5L560 135L191.5 23.5L126.5 98.5L69.5 62L24 137.5L64.5 211L131 174.5L191.5 244.5Z"
 				fill="#DD0031"
@@ -28,4 +138,8 @@ import { Component } from '@angular/core';
 		</svg>
 	`,
 })
-export class SpartanLogo {}
+export class SpartanLogo {
+	/** Render a solid-fill mark without gradient <defs> - used where multiple logos render at once (e.g. the
+	 *  300-item placeholder) so the gradient ids stay unique to the single header instance. */
+	public readonly flat = input(false, { transform: booleanAttribute });
+}

--- a/apps/app/src/app/shared/theme.service.ts
+++ b/apps/app/src/app/shared/theme.service.ts
@@ -22,6 +22,9 @@ export type Theme = (typeof AppThemes)[number];
 export const Layouts = ['full', 'fixed'] as const;
 export type Layout = (typeof Layouts)[number];
 
+export const LogoVariants = ['default', 'legacy'] as const;
+export type LogoVariant = (typeof LogoVariants)[number];
+
 @Injectable({
 	providedIn: 'root',
 })
@@ -36,9 +39,11 @@ export class ThemeService {
 	private readonly _systemPrefersDark = signal<boolean>(false);
 	private readonly _theme = signal<Theme>('default');
 	private readonly _layout = signal<Layout>('fixed');
+	private readonly _logoVariant = signal<LogoVariant>('default');
 
 	public readonly theme = this._theme.asReadonly();
 	public readonly layout = this._layout.asReadonly();
+	public readonly logoVariant = this._logoVariant.asReadonly();
 
 	constructor() {
 		if (!isPlatformBrowser(this._platformId)) return;
@@ -60,6 +65,10 @@ export class ThemeService {
 		this._destroyRef.onDestroy(() => this._query.removeEventListener('change', handleChange));
 		this._theme.set((localStorage.getItem('theme') as Theme) ?? 'default');
 		this._layout.set((localStorage.getItem('layout') as Layout) ?? 'fixed');
+		const storedLogoVariant = localStorage.getItem('logoVariant');
+		this._logoVariant.set(
+			LogoVariants.includes(storedLogoVariant as LogoVariant) ? (storedLogoVariant as LogoVariant) : 'default',
+		);
 
 		effect(() => {
 			const mode = this._darkMode();
@@ -86,6 +95,17 @@ export class ThemeService {
 			if (newTheme !== 'default') {
 				this._document.body.classList.add(`theme-${newTheme}`);
 			}
+		});
+
+		effect(() => {
+			const newVariant = this._logoVariant();
+			const oldVariant = this._document.documentElement.className.match(/logo-(\w+)/)?.[1];
+
+			if (oldVariant) {
+				this._document.documentElement.classList.remove(`logo-${oldVariant}`);
+			}
+
+			this._document.documentElement.classList.add(`logo-${newVariant}`);
 		});
 
 		effect(() => {
@@ -121,5 +141,18 @@ export class ThemeService {
 	public setLayout(layout: Layout): void {
 		localStorage.setItem('layout', layout);
 		this._layout.set(layout);
+	}
+
+	public setLogoVariant(variant: LogoVariant): void {
+		if (variant === 'default') {
+			localStorage.removeItem('logoVariant');
+		} else {
+			localStorage.setItem('logoVariant', variant);
+		}
+		this._logoVariant.set(variant);
+	}
+
+	public toggleLogoVariant(): void {
+		this.setLogoVariant(this._logoVariant() === 'legacy' ? 'default' : 'legacy');
 	}
 }

--- a/apps/app/src/styles.css
+++ b/apps/app/src/styles.css
@@ -40,6 +40,8 @@
 
 @custom-variant fixed (&:is(.layout-fixed *));
 
+@custom-variant logo-legacy (&:is(.logo-legacy *));
+
 @theme inline {
 	--font-ar: var(--font-ar);
 	--font-he: var(--font-he);


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (n/a - docs-app UI)
- [ ] Docs have been added / updated (n/a)

## PR Type

- [x] Feature

## Which package are you modifying?

Docs app (`apps/app`) - not a published package.

## What is the current behavior?

The docs app renders a single spartan logo with no way to switch marks.

## What is the new behavior?

Adds a selectable logo variant (`default`/`legacy`) persisted in `localStorage` and applied via a `logo-*`
class on the document, with a context menu on the header logo to switch between the new and legacy marks.

## Does this PR introduce a breaking change?

- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a logo variant switcher in the header via a dropdown (default/legacy).
  * The chosen logo variant now persists across sessions and updates site-wide theming.
* **Bug Fixes**
  * Improved legacy logo rendering consistency, including correct rotation behavior for logo placeholders.
* **Other**
  * Updated the Spartan logo to support a flat (solid) vs. gradient rendering mode.
  * Added a custom styling variant to scope legacy logo styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->