### PR TITLE
docs: refresh changelog, home, and about pages for v1

### DIFF
--- a/apps/app/src/app/pages/(documentation)/documentation/about.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/about.page.ts
@@ -31,8 +31,9 @@ const aboutLink = 'h-6 underline text-sm px-0.5';
 			<p class="${hlmP}">
 				<a hlmBtn variant="link" class="${aboutLink}" href="https://www.spartan.ng">spartan.ng</a>
 				is a project by
-				<a hlmBtn variant="link" class="${aboutLink}" href="https://twitter.com/goetzrobin">goetzrobin</a>
-				.
+				<a hlmBtn variant="link" class="${aboutLink}" href="https://github.com/goetzrobin">goetzrobin</a>
+				and a growing community of contributors. Come say hi in our
+				<a hlmBtn variant="link" class="${aboutLink}" href="https://discord.gg/EqHnxQ4uQr" target="_blank">Discord.</a>
 			</p>
 
 			<spartan-section-sub-heading id="credits">Credits</spartan-section-sub-heading>
@@ -57,14 +58,6 @@ const aboutLink = 'h-6 underline text-sm px-0.5';
 
 			<p class="${hlmP}">Other incredible projects we build upon:</p>
 			<ul class="${hlmUl}">
-				<li>
-					<a class="${aboutLink}" hlmBtn href="https://ui.shadcn.com" target="_blank" variant="link">shadcn/ui</a>
-					- Design system and copy-paste philosophy that inspired spartan/ui.
-				</li>
-				<li>
-					<a class="${aboutLink}" hlmBtn href="https://radix-ui.com" target="_blank" variant="link">Radix UI</a>
-					- Patterns and architecture for accessible, unstyled primitives.
-				</li>
 				<li>
 					<a class="${aboutLink}" hlmBtn href="https://material.angular.io" target="_blank" variant="link">
 						Angular Material CDK
@@ -96,11 +89,57 @@ const aboutLink = 'h-6 underline text-sm px-0.5';
 				</li>
 			</ul>
 
+			<spartan-section-sub-heading id="maintainers">Core maintainers</spartan-section-sub-heading>
+
+			<p class="${hlmP}">
+				spartan is built and maintained by a small, dedicated core team who pour countless hours into the project:
+				<a hlmBtn variant="link" class="${aboutLink}" href="https://github.com/MerlinMoos" target="_blank">Merlin,</a>
+				<a hlmBtn variant="link" class="${aboutLink}" href="https://github.com/marcjulian" target="_blank">Marc,</a>
+				<a hlmBtn variant="link" class="${aboutLink}" href="https://github.com/ashley-hunter" target="_blank">
+					Ashley,
+				</a>
+				<a hlmBtn variant="link" class="${aboutLink}" href="https://github.com/elite-benni" target="_blank">Benni,</a>
+				<a hlmBtn variant="link" class="${aboutLink}" href="https://github.com/thatsamsonkid" target="_blank">Sammy,</a>
+				and
+				<a hlmBtn variant="link" class="${aboutLink}" href="https://github.com/toniskobic" target="_blank">Toni</a>
+				- alongside the
+				<a
+					hlmBtn
+					variant="link"
+					class="${aboutLink}"
+					href="https://github.com/spartan-ng/spartan/graphs/contributors"
+					target="_blank"
+				>
+					100+ contributors
+				</a>
+				who keep spartan moving.
+			</p>
+
+			<p class="${hlmP}">
+				Special thanks to
+				<a hlmBtn variant="link" class="${aboutLink}" href="https://zerops.io" target="_blank">Zerops</a>
+				, whose support funds dedicated development time. A true developer first platform for this new age of AI-powered
+				software engineering!
+			</p>
+
+			<spartan-section-sub-heading id="support">Support spartan</spartan-section-sub-heading>
+
+			<p class="${hlmP}">
+				spartan is MIT-licensed and free, forever - but free to use isn't free to build. Countless hours of hard-fought
+				work hold this phalanx together. If spartan benefits your company or team, consider returning the favor:
+				sponsoring keeps spartan actively maintained and its open-source work sustainable. No spartan holds the line
+				alone - every shield in the wall counts.
+			</p>
+			<div class="my-6 flex flex-wrap items-center gap-3">
+				<a hlmBtn href="https://github.com/sponsors/goetzrobin" target="_blank">Sponsor spartan</a>
+				<a hlmBtn variant="outline" href="https://discord.gg/EqHnxQ4uQr" target="_blank">Join us on Discord</a>
+			</div>
+
 			<spartan-section-sub-heading id="license">License</spartan-section-sub-heading>
 
 			<p class="${hlmP}">
 				MIT &copy; {{ currentYear }} -
-				<a hlmBtn variant="link" class="px-0.5 text-sm underline" href="https://twitter.com/goetzrobin">goetzrobin</a>
+				<a hlmBtn variant="link" class="px-0.5 text-sm underline" href="https://github.com/goetzrobin">goetzrobin</a>
 			</p>
 
 			<spartan-page-bottom-nav>

--- a/apps/app/src/app/pages/(documentation)/documentation/changelog.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/changelog.page.ts
@@ -35,9 +35,104 @@ export const routeMeta: RouteMeta = {
 	template: `
 		<section spartanMainSection>
 			<spartan-section-intro name="Changelog" lead="Latest updates and announcements." />
-			<spartan-section-sub-heading id="initial-alpha" first class="pt-6">
-				August 2023 - Initial Alpha release
-			</spartan-section-sub-heading>
+			<spartan-section-sub-heading id="v1" first class="pt-6">June 2026 - spartan/ui v1.0</spartan-section-sub-heading>
+			<p class="${hlmP}">
+				After a long and deliberate alpha,
+				<code class="${hlmCode}">spartan/ui</code>
+				is now
+				<strong>1.0</strong>
+				. What started as 30 primitives has grown into a stable, production-ready library of accessible Angular
+				components - built on signals, ready for zoneless, and compatible with server-side rendering out of the box.
+			</p>
+
+			<p class="${hlmP}">Here's a quick overview of what 1.0 means:</p>
+			<ul class="${hlmUl}">
+				<li>
+					<a class="font-medium hover:underline" routerLink="." fragment="v1__stable">Production-ready and stable</a>
+					- a committed, semver-versioned API you can build on.
+				</li>
+				<li>
+					<a class="font-medium hover:underline" routerLink="." fragment="v1__architecture">Built for modern Angular</a>
+					- signals throughout, zoneless-ready, and SSR compatible.
+				</li>
+				<li>
+					<a class="font-medium hover:underline" routerLink="." fragment="v1__components">More than 55 components</a>
+					- nearly double the initial 30, including Data Table, Sidebar, Calendar, and Date Picker.
+				</li>
+				<li>
+					<a class="font-medium hover:underline" routerLink="." fragment="v1__blocks">Blocks</a>
+					- ready-made layouts for authentication, sidebars, and steppers.
+				</li>
+			</ul>
+
+			<h3 id="v1__stable" spartanH4>Production-ready and stable</h3>
+			<p class="${hlmP}">
+				spartan/ui spent a long time in alpha so we could refine its APIs in the open. With 1.0 those APIs are stable:
+				we follow semantic versioning, so you can depend on
+				<code class="${hlmCode}">spartan/ui/brain</code>
+				and upgrade with confidence. The copy-in
+				<code class="${hlmCode}">spartan/ui/helm</code>
+				layer stays yours to own and customize - exactly as before.
+			</p>
+
+			<h3 id="v1__architecture" spartanH4>Built for modern Angular</h3>
+			<p class="${hlmP}">
+				Every primitive is built on Angular signals and standalone components. spartan is zoneless-ready and
+				server-side-rendering compatible out of the box, so it fits cleanly into today's Angular applications without
+				extra setup. You get maintained accessibility - ARIA, keyboard navigation, and focus management - through
+				<code class="${hlmCode}">spartan/ui/brain</code>
+				, with full styling control through
+				<code class="${hlmCode}">spartan/ui/helm</code>
+				.
+			</p>
+
+			<h3 id="v1__components" spartanH4>More than 55 components</h3>
+			<p class="${hlmP}">
+				The initial alpha shipped with 30 primitives. 1.0 ships with more than 55, including many of the most requested
+				additions:
+			</p>
+			<ul class="${hlmUl}">
+				<li><a class="font-medium hover:underline" routerLink="/components/data-table">Data Table</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/sidebar">Sidebar</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/calendar">Calendar</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/date-picker">Date Picker</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/carousel">Carousel</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/autocomplete">Autocomplete</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/pagination">Pagination</a></li>
+				<li><a class="font-medium hover:underline" routerLink="/components/breadcrumb">Breadcrumb</a></li>
+			</ul>
+			<p class="${hlmP}">
+				Browse the full set on the
+				<a class="font-medium hover:underline" routerLink="/components">components page</a>
+				.
+			</p>
+
+			<h3 id="v1__blocks" spartanH4>Blocks</h3>
+			<p class="${hlmP}">
+				Blocks are ready-made, fully responsive layouts built from spartan components. 1.0 includes authentication
+				pages, sidebar layouts, and multi-step steppers you can drop into your app and customize. Explore them on the
+				<a class="font-medium hover:underline" routerLink="/blocks">blocks page</a>
+				.
+			</p>
+
+			<h3 id="v1__getting_started" spartanH4>Getting started</h3>
+			<p class="${hlmP}">New to spartan? There's never been a better time to start.</p>
+			<div class="m-10 flex items-center justify-center">
+				<a hlmBtn size="lg" routerLink="/documentation/installation">Get started with spartan/ui</a>
+			</div>
+
+			<h3 id="v1__support" spartanH4>Support spartan</h3>
+			<p class="${hlmP}">
+				spartan is MIT-licensed and built in the open. If it saves you time, consider sponsoring its development -
+				sponsorships fund ongoing maintenance, new components, and keeping spartan free for the whole Angular community.
+			</p>
+			<div class="m-10 flex items-center justify-center">
+				<a hlmBtn size="lg" target="_blank" rel="noreferrer" href="https://github.com/sponsors/goetzrobin">
+					Sponsor spartan
+				</a>
+			</div>
+
+			<spartan-section-sub-heading id="initial-alpha">August 2023 - Initial Alpha release</spartan-section-sub-heading>
 
 			<p class="${hlmP}">
 				<code class="${hlmCode}">spartan/ui</code>

--- a/apps/app/src/app/pages/(home).page.ts
+++ b/apps/app/src/app/pages/(home).page.ts
@@ -127,7 +127,10 @@ const lead = 'text-foreground max-w-3xl text-base text-balance sm:text-lg';
 			</hlm-tabs>
 		</section>
 
-		<section id="the-300" class="space-y-6 py-8 [contain-intrinsic-size:auto_900px] [content-visibility:auto] md:py-12">
+		<section
+			id="the-300"
+			class="scroll-mt-24 space-y-6 py-8 [contain-intrinsic-size:auto_900px] [content-visibility:auto] md:py-12"
+		>
 			<div class="${container} max-w-[58rem]">
 				<h2 class="${subHeading}">Built By The 300</h2>
 				<p class="${lead} max-w-[42rem]">
@@ -138,11 +141,25 @@ const lead = 'text-foreground max-w-3xl text-base text-balance sm:text-lg';
 			<div class="mx-auto space-y-12 text-center md:max-w-[64rem]">
 				<spartan-three-hundred class="mt-12" />
 				<p class="${lead} mx-auto max-w-[42rem]">
-					Contribute code, share insights, or sponsor on GitHub. Let's build something extraordinary together!
+					spartan is MIT-licensed and free forever. Sponsoring funds ongoing maintenance, new components, and the people
+					who keep it moving. Contribute code, share insights, or sponsor the project - let's build something
+					extraordinary together!
 				</p>
-				<a hlmBtn size="lg" target="_blank" rel="noreferrer" href="https://github.com/spartan-ng/spartan">
-					Claim your spot in the 300 today!
-				</a>
+				<div class="flex flex-col items-center justify-center gap-3 sm:flex-row">
+					<a hlmBtn size="lg" target="_blank" rel="noreferrer" href="https://github.com/sponsors/goetzrobin">
+						Sponsor spartan
+					</a>
+					<a
+						hlmBtn
+						size="lg"
+						variant="outline"
+						target="_blank"
+						rel="noreferrer"
+						href="https://github.com/spartan-ng/spartan"
+					>
+						Claim your spot in the 300 today!
+					</a>
+				</div>
 			</div>
 		</section>
 	`,

--- a/apps/app/src/app/pages/(home).page.ts
+++ b/apps/app/src/app/pages/(home).page.ts
@@ -141,9 +141,8 @@ const lead = 'text-foreground max-w-3xl text-base text-balance sm:text-lg';
 			<div class="mx-auto space-y-12 text-center md:max-w-[64rem]">
 				<spartan-three-hundred class="mt-12" />
 				<p class="${lead} mx-auto max-w-[42rem]">
-					spartan is MIT-licensed and free forever. Sponsoring funds ongoing maintenance, new components, and the people
-					who keep it moving. Contribute code, share insights, or sponsor the project - let's build something
-					extraordinary together!
+					This project is MIT-licensed and free forever. Sponsoring funds ongoing maintenance, new components, and the
+					people who keep it moving!
 				</p>
 				<div class="flex flex-col items-center justify-center gap-3 sm:flex-row">
 					<a hlmBtn size="lg" target="_blank" rel="noreferrer" href="https://github.com/sponsors/goetzrobin">

--- a/apps/app/src/app/pages/(home)/components/overview/components/appearance-settings.ts
+++ b/apps/app/src/app/pages/(home)/components/overview/components/appearance-settings.ts
@@ -52,7 +52,7 @@ import { HlmSwitch } from '@spartan-ng/helm/switch';
 					<p hlmFieldDescription>You can add more later.</p>
 				</div>
 				<div hlmButtonGroup>
-					<input hlmInput class="h-8 !w-14 font-mono" [value]="_gpuCount()" />
+					<input hlmInput class="h-7 !w-14 font-mono" [value]="_gpuCount()" />
 					<button hlmBtn variant="outline" size="icon-sm" (click)="_gpuCountDecrease()">
 						<ng-icon name="lucideMinus" />
 					</button>

--- a/apps/app/src/app/pages/(home)/components/three-hundred.ts
+++ b/apps/app/src/app/pages/(home)/components/three-hundred.ts
@@ -73,7 +73,7 @@ export class ThreeHundred {
 		'dongphuong0905',
 		'DominikPieper',
 		'brandonroberts',
-		'izikd-',
+		'izikd',
 		'ryancraigmartin',
 		'gaetanBloch',
 		'gergobergo',

--- a/apps/app/src/app/shared/header/header.ts
+++ b/apps/app/src/app/shared/header/header.ts
@@ -2,7 +2,8 @@ import { httpResource } from '@angular/common/http';
 import { Component, computed } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { lucideGithub, lucideTwitter } from '@ng-icons/lucide';
+import { lucideGithub } from '@ng-icons/lucide';
+import { tablerBrandDiscord } from '@ng-icons/tabler-icons';
 import { DocsDialog } from '@spartan-ng/app/app/shared/header/docs-dialog';
 import { HeaderLayoutMode } from '@spartan-ng/app/app/shared/header/header-layout-mode';
 import { HlmButton } from '@spartan-ng/helm/button';
@@ -27,7 +28,7 @@ import { HeaderMobileNav } from './header-mobile-nav';
 
 		DocsDialog,
 	],
-	providers: [provideIcons({ lucideTwitter, lucideGithub })],
+	providers: [provideIcons({ tablerBrandDiscord, lucideGithub })],
 	host: {
 		class: 'backdrop-blur-sm sticky top-0 z-50 w-full',
 	},
@@ -54,9 +55,9 @@ import { HeaderMobileNav } from './header-mobile-nav';
 				<div class="ml-auto flex items-center gap-2 md:flex-1 md:justify-end">
 					<spartan-docs-dialog class="hidden w-full flex-1 md:flex md:w-auto md:flex-none" />
 					<hlm-separator orientation="vertical" class="!h-4 !self-center" />
-					<a href="https://twitter.com/goetzrobin" target="_blank" size="sm" variant="ghost" hlmBtn>
-						<span class="sr-only">Twitter</span>
-						<ng-icon name="lucideTwitter" />
+					<a href="https://discord.gg/EqHnxQ4uQr" target="_blank" size="sm" variant="ghost" hlmBtn>
+						<span class="sr-only">Discord</span>
+						<ng-icon name="tablerBrandDiscord" />
 					</a>
 					<hlm-separator orientation="vertical" class="!h-4 !self-center" />
 					<a href="https://github.com/spartan-ng/spartan" target="_blank" size="sm" variant="ghost" hlmBtn>

--- a/apps/app/src/app/shared/header/header.ts
+++ b/apps/app/src/app/shared/header/header.ts
@@ -55,12 +55,26 @@ import { HeaderMobileNav } from './header-mobile-nav';
 				<div class="ml-auto flex items-center gap-2 md:flex-1 md:justify-end">
 					<spartan-docs-dialog class="hidden w-full flex-1 md:flex md:w-auto md:flex-none" />
 					<hlm-separator orientation="vertical" class="!h-4 !self-center" />
-					<a href="https://discord.gg/EqHnxQ4uQr" target="_blank" size="sm" variant="ghost" hlmBtn>
+					<a
+						href="https://discord.gg/EqHnxQ4uQr"
+						target="_blank"
+						rel="noopener noreferrer"
+						size="sm"
+						variant="ghost"
+						hlmBtn
+					>
 						<span class="sr-only">Discord</span>
 						<ng-icon name="tablerBrandDiscord" />
 					</a>
 					<hlm-separator orientation="vertical" class="!h-4 !self-center" />
-					<a href="https://github.com/spartan-ng/spartan" target="_blank" size="sm" variant="ghost" hlmBtn>
+					<a
+						href="https://github.com/spartan-ng/spartan"
+						target="_blank"
+						rel="noopener noreferrer"
+						size="sm"
+						variant="ghost"
+						hlmBtn
+					>
 						<ng-icon name="lucideGithub" />
 						<span class="text-muted-foreground text-xs">{{ _stars() }}</span>
 					</a>

--- a/apps/app/src/app/shared/layout/section-sub-heading.ts
+++ b/apps/app/src/app/shared/layout/section-sub-heading.ts
@@ -3,7 +3,7 @@ import { Component, booleanAttribute, input } from '@angular/core';
 @Component({
 	selector: 'spartan-section-sub-heading',
 	host: {
-		class: 'block',
+		class: 'block scroll-mt-28',
 		'[class.-mt-12]': 'first()',
 	},
 	template: `


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (n/a - docs content)
- [x] Docs have been added / updated

## PR Type

- [x] Documentation content changes

## Which package are you modifying?

Docs app (`apps/app`) - not a published package.

## What is the current behavior?

The home page has a single contribute CTA, the changelog page is out of date, a contributor handle in the
300 is wrong, in-page anchors scroll under the sticky header, the About page has no maintainer/sponsor
credits, and the header + About page link to Robin's Twitter.

## What is the new behavior?

- Adds a v1.0 entry to the changelog with a sponsor call-to-action.
- Adds a sponsor CTA to the home page and fixes a contributor handle in the 300.
- Adds scroll-margin offsets so in-page anchors clear the sticky header.
- Adds Core maintainers and Support sections to the About page, crediting Merlin, Marc, Ashley, Benni,
  Sammy, and Toni alongside Zerops, Brandon Roberts, and AnalogJs.
- Moves the header and About page social links from Twitter to Discord.

## Does this PR introduce a breaking change?

- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog with a new “June 2026 - v1.0” section, richer narrative, and improved in-page navigation.
  * Refreshed the About page with updated maintainer/support links and added new sections (including support and core maintainers).

* **New Features**
  * Updated the header to link to Discord (and show a Discord icon) instead of Twitter.

* **Improvements / UI**
  * Enhanced the homepage with a new anchor section and reworked the “Sponsor/Claim” call-to-action layout.
  * Improved scroll positioning for subheadings and refined input sizing.

* **Bug Fixes**
  * Corrected the displayed contributor name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->