### PR TITLE
fix: contain preview styles so the default never leaks into islands or overlays

### DIFF
--- a/apps/app/src/app.config.ts
+++ b/apps/app/src/app.config.ts
@@ -1,8 +1,10 @@
 import { provideFileRouter, requestContextInterceptor } from '@analogjs/router';
+import { OverlayContainer } from '@angular/cdk/overlay';
 import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import type { ApplicationConfig } from '@angular/core';
 import { provideClientHydration } from '@angular/platform-browser';
 import { PreloadAllModules, withInMemoryScrolling, withNavigationErrorHandler, withPreloading } from '@angular/router';
+import { StyleAwareOverlayContainer } from './app/shared/style-aware-overlay-container';
 import { provideTrpcClient } from './trpc-client';
 
 export const appConfig: ApplicationConfig = {
@@ -15,5 +17,7 @@ export const appConfig: ApplicationConfig = {
 		provideClientHydration(),
 		provideTrpcClient(),
 		provideHttpClient(withFetch(), withInterceptors([requestContextInterceptor])),
+		// Overlays inherit the style of their trigger's island instead of one global value (see the class).
+		{ provide: OverlayContainer, useClass: StyleAwareOverlayContainer },
 	],
 };

--- a/apps/app/src/app/shared/style-aware-overlay-container.ts
+++ b/apps/app/src/app/shared/style-aware-overlay-container.ts
@@ -40,8 +40,10 @@ export class StyleAwareOverlayContainer extends OverlayContainer {
 	}
 
 	override ngOnDestroy(): void {
-		this._document.removeEventListener('pointerdown', this._track, true);
-		this._document.removeEventListener('keydown', this._track, true);
+		if (this._platform.isBrowser) {
+			this._document.removeEventListener('pointerdown', this._track, true);
+			this._document.removeEventListener('keydown', this._track, true);
+		}
 		super.ngOnDestroy();
 	}
 

--- a/apps/app/src/app/shared/style-aware-overlay-container.ts
+++ b/apps/app/src/app/shared/style-aware-overlay-container.ts
@@ -1,0 +1,56 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { Injectable } from '@angular/core';
+
+const STYLE_PREFIX = 'style-';
+const DEFAULT_STYLE = 'style-nova';
+
+/**
+ * CDK renders every overlay into one shared root container, so the docs can't scope it per-component
+ * (Overlay/Dialog are root singletons and ignore scoped OverlayContainer providers). Instead we stamp the
+ * container with the `.style-*` of whatever opened the overlay: chrome triggers live under the body's
+ * `.style-nova`, preview triggers under a `.style-<theme>` island. The donut @scope then keeps nova out of
+ * a themed panel. Replaces StyleService's old global stamping, which forced the selected style onto chrome
+ * overlays (search, AI Assist, the style switcher itself) too.
+ */
+@Injectable()
+export class StyleAwareOverlayContainer extends OverlayContainer {
+	private _lastTrigger: Element | null = null;
+
+	private readonly _track = (event: Event) => {
+		if (event.target instanceof Element) this._lastTrigger = event.target;
+	};
+
+	constructor() {
+		super();
+		if (!this._platform.isBrowser) return;
+		// capture phase: see the trigger before the overlay opens, even if it stops propagation
+		this._document.addEventListener('pointerdown', this._track, true);
+		this._document.addEventListener('keydown', this._track, true);
+	}
+
+	override getContainerElement(): HTMLElement {
+		const container = super.getContainerElement();
+		const style = this._resolveStyle();
+		// Called again on every scroll/resize reposition - skip the DOM when the style is unchanged.
+		if (!container.classList.contains(style)) {
+			container.classList.remove(...Array.from(container.classList).filter((cls) => cls.startsWith(STYLE_PREFIX)));
+			container.classList.add(style);
+		}
+		return container;
+	}
+
+	override ngOnDestroy(): void {
+		this._document.removeEventListener('pointerdown', this._track, true);
+		this._document.removeEventListener('keydown', this._track, true);
+		super.ngOnDestroy();
+	}
+
+	// Nearest ancestor `.style-*` of the trigger; the body's `.style-nova` is the backstop.
+	private _resolveStyle(): string {
+		for (let el = this._lastTrigger; el; el = el.parentElement) {
+			const match = Array.from(el.classList).find((cls) => cls.startsWith(STYLE_PREFIX));
+			if (match) return match;
+		}
+		return DEFAULT_STYLE;
+	}
+}

--- a/apps/app/src/app/shared/style.service.ts
+++ b/apps/app/src/app/shared/style.service.ts
@@ -1,24 +1,9 @@
-import { OverlayContainer } from '@angular/cdk/overlay';
-import { effect, inject, Injectable, signal } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { Style } from '@spartan-ng/registry';
 
 @Injectable({
 	providedIn: 'root',
 })
 export class StyleService {
-	private readonly _overlayContainer = inject(OverlayContainer);
-
 	public readonly style = signal<Style>('nova');
-
-	constructor() {
-		// Keep the CDK overlay container class in sync with the active style so that
-		// dialogs, popovers and other overlay-rendered components receive the correct theme.
-		effect(() => {
-			const el = this._overlayContainer.getContainerElement();
-			for (const cls of Array.from(el.classList)) {
-				if (cls.startsWith('style-')) el.classList.remove(cls);
-			}
-			el.classList.add(`style-${this.style()}`);
-		});
-	}
 }

--- a/apps/app/src/styles.css
+++ b/apps/app/src/styles.css
@@ -130,43 +130,6 @@
 	}
 }
 
-/* Docs-app only leak patches. This app loads every style at once with NOVA as the global baseline (see
-   the spartan-nova-baseline layer above); the body permanently carries `.style-nova`, so nova's rules
-   reach every island. For classes nova defines but another style does not, nova's baseline leaks into
-   that style's island - so we restore the island style's intended look here, in its own language.
-   Kept OUT of the registry style-*.css files on purpose: the CLI copies those into consumer projects,
-   which only ever load a single style and so never hit the leak. Left unlayered so they win over the
-   nova baseline from anywhere; their position is not load-bearing. */
-
-/* Lyra is square: it omits the rounding/gap rules nova defines, so nova's rounding leaks in. */
-.style-lyra .spartan-button-group-orientation-horizontal {
-	@apply [&>[data-slot]:not(:has(~[data-slot]))]:rounded-e-none!;
-}
-.style-lyra .spartan-button-group-orientation-vertical {
-	@apply [&>[data-slot]:not(:has(~[data-slot]))]:rounded-b-none!;
-}
-.style-lyra .spartan-carousel-previous {
-	@apply rounded-none;
-}
-.style-lyra .spartan-carousel-next {
-	@apply rounded-none;
-}
-.style-lyra .spartan-dialog-footer {
-	@apply gap-2;
-}
-
-/* `spartan-alert-dialog-footer` is nova-only: nova styles it as a muted, bordered, rounded panel
-   (bg-muted/50 -mx-4 -mb-4 rounded-b-xl border-t p-4); every other style leaves the footer plain - this
-   mirrors shadcn, where only the nova style adds that treatment. As the baseline, nova would push that
-   panel into all the other islands, so reset it back to plain there. */
-.style-vega .spartan-alert-dialog-footer,
-.style-lyra .spartan-alert-dialog-footer,
-.style-maia .spartan-alert-dialog-footer,
-.style-mira .spartan-alert-dialog-footer,
-.style-luma .spartan-alert-dialog-footer {
-	@apply m-0 rounded-none border-0 bg-transparent p-0;
-}
-
 [hidden]:where(:not([hidden='until-found'])) {
 	display: none !important;
 }

--- a/libs/registry/src/styles/style-nova.css
+++ b/libs/registry/src/styles/style-nova.css
@@ -1,4 +1,34 @@
-.style-nova {
+/* =============================================================================================
+ * DONUT @scope - DOCS-ONLY CONTAINMENT. READ BEFORE EDITING.
+ * =============================================================================================
+ * Why this looks weird: nova (the default style) is the page-wide baseline in the docs app - its
+ * <body> permanently carries `.style-nova`. The docs render every OTHER style as a nested preview
+ * "island" (`<div class="style-vega">`, etc.) inside that body. Plain `.style-nova .spartan-*`
+ * rules cascade THROUGH those islands, so for any property nova sets but the island's style does
+ * not, nova "leaks" into the island and the preview no longer matches a real single-style project.
+ *
+ * The donut fixes that structurally instead of per-property: `@scope (.style-nova) to (<every other
+ * style>)` applies nova within `.style-nova` but STOPS at any other style's island - nova reaches
+ * the docs chrome but never another style's island. Each island is fully self-contained, with zero
+ * per-property "reset" patches.
+ *
+ * Only nova carries this: nova is the ONLY style ever used as the page-wide baseline. The other five
+ * are only ever islands, already contained by their own `.style-X` selector, so they stay plain.
+ *
+ * It does NOT reach consumer projects. The CLI does not copy this file; `createStyleMap`
+ * (libs/cli/.../create-style-map.ts) harvests each `.spartan-* { @apply ... }` rule and inlines the
+ * utilities directly into the generated components - it ignores the wrapper entirely, whether it is
+ * `.style-nova {` or this `@scope`. So no `@scope`, and no extra browser-support requirement, ever
+ * ships to a single-style consumer.
+ *
+ * Authored here (not in the docs app) ON PURPOSE: feeding nova into a `@scope` from the docs via
+ * `@import` does not survive the dev build (the whole baseline silently drops and the docs render
+ * unstyled). Wrapping nova's own rules directly avoids any `@import`, so it works in dev and prod.
+ *
+ * MAINTENANCE: keep the `to (...)` list in sync with `STYLES` in ./style.ts - it must name every
+ * style EXCEPT nova. The closing `}` for this block is at the very end of the file.
+ * ============================================================================================= */
+@scope (.style-nova) to (.style-vega, .style-lyra, .style-maia, .style-mira, .style-luma) {
 	.spartan-rtl-flip {
 		@apply rtl:rotate-180;
 	}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Others

- [x] repo

## What is the current behavior?

The docs site loads every style at once with **nova** as the page-wide baseline (the `<body>`
permanently carries `.style-nova`) and renders the other styles as nested `.style-*` preview
"islands". Two things leak as a result:

1. **Previews** — `.style-nova .spartan-*` rules cascade through an island, so for any property the
   island's style does not set, nova's value bleeds in. The preview no longer matches what a real
   single-style consumer project would render. This had been worked around with a growing pile of
   per-property reset patches in the docs `styles.css`.
2. **Overlays** — CDK renders every overlay into one shared root container, which was stamped with
   the globally-selected style. So chrome overlays that have nothing to do with previews (the search
   palette, the **AI Assist** dropdown, and the **style switcher** itself) adopted whatever preview
   style was selected.

Closes # N/A

## What is the new behavior?

Containment is now structural, in one place per concern — no per-property patches:

- **Donut `@scope` in `style-nova.css`** — the nova baseline is wrapped in
  `@scope (.style-nova) to (<every other style>)`, so it applies to the docs chrome but **stops at any
  other style's island**. Each island renders exactly like a single-style project. The wrapper is
  invisible to the CLI (`createStyleMap` inlines each `.spartan-* { @apply … }` regardless of the
  wrapper), so no `@scope` and no extra browser-support requirement ship to consumers. A big in-file
  comment explains the why, the CLI transparency, and the dev-`@import` gotcha.
- **`StyleAwareOverlayContainer`** — a single root provider that stamps the shared overlay container
  with the **triggering element's** island style (tracked via capture-phase pointer/keydown) instead
  of one global value. Chrome overlays stay nova; preview overlays follow the selection. Replaces the
  old global stamping in `StyleService`.
- **Removed** the now-redundant per-property docs leak patches.

Verified: app builds, `create-style-map` CLI tests pass (consumer extraction unchanged), and the four
chrome overlays stay nova while preview overlays follow the selected style.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

`@scope` containment requires Chrome 118+, Safari 17.4+, Firefox 128+ — docs-only, never shipped to
consumers (see above).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Overlays (such as dropdowns, modals, and popovers) now correctly inherit styling from their trigger element's design theme instead of defaulting to a global style value.

* **Refactor**
  * Simplified styling system architecture to improve style isolation between design theme contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->