### PR TITLE
fix(tooltip): restore exit animation and align data-state vocabulary

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip--group.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip--group.example.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { provideBrnTooltipGroup } from '@spartan-ng/brain/tooltip';
+import { HlmButtonImports } from '@spartan-ng/helm/button';
+import { HlmTooltipImports } from '@spartan-ng/helm/tooltip';
+
+@Component({
+	selector: 'spartan-tooltip-group',
+	imports: [HlmButtonImports, HlmTooltipImports],
+	providers: [provideBrnTooltipGroup({ skipDelayDuration: 300 })],
+	template: `
+		<div class="flex gap-2">
+			<button [hlmTooltip]="'Save'" hlmBtn variant="outline">Save</button>
+			<button [hlmTooltip]="'Copy'" hlmBtn variant="outline">Copy</button>
+			<button [hlmTooltip]="'Paste'" hlmBtn variant="outline">Paste</button>
+		</div>
+	`,
+})
+export class TooltipGroup {}

--- a/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
@@ -22,6 +22,7 @@ import { SectionSubHeading } from '../../../../shared/layout/section-sub-heading
 import { Tabs } from '../../../../shared/layout/tabs';
 import { UIApiDocs } from '../../../../shared/layout/ui-docs-section/ui-docs-section';
 import { metaWith } from '../../../../shared/meta/meta.util';
+import { TooltipGroup } from './tooltip--group.example';
 import { TooltipSimple } from './tooltip--simple.example';
 import { defaultImports, defaultSkeleton, TooltipPreview } from './tooltip.preview';
 
@@ -52,6 +53,7 @@ export const routeMeta: RouteMeta = {
 		TooltipSimple,
 		SectionSubSubHeading,
 		TooltipSimple,
+		TooltipGroup,
 		TooltipPosition,
 		TooltipSimple,
 		TooltipDisabled,
@@ -92,6 +94,20 @@ export const routeMeta: RouteMeta = {
 					<spartan-tooltip-simple />
 				</div>
 				<spartan-code secondTab [code]="_simpleCode()" />
+			</spartan-tabs>
+
+			<h3 id="examples__group" spartanH4>Group</h3>
+			<p class="text-muted-foreground mt-2 mb-4 text-sm">
+				Provide
+				<code>provideBrnTooltipGroup</code>
+				on a wrapping component so that once one tooltip opens, the others in the group open instantly until the
+				skip-delay window elapses.
+			</p>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-tooltip-group />
+				</div>
+				<spartan-code secondTab [code]="_groupCode()" />
 			</spartan-tabs>
 
 			<h3 id="examples__position" spartanH4>Positions</h3>
@@ -156,6 +172,7 @@ export default class TooltipPage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('tooltip');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
 	protected readonly _simpleCode = computed(() => this._snippets()['simple']);
+	protected readonly _groupCode = computed(() => this._snippets()['group']);
 	protected readonly _positionCode = computed(() => this._snippets()['position']);
 	protected readonly _templateCode = computed(() => this._snippets()['template']);
 	protected readonly _disabledCode = computed(() => this._snippets()['disabled']);

--- a/libs/brain/core/src/helpers/skip-delay.spec.ts
+++ b/libs/brain/core/src/helpers/skip-delay.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import { injectSkipDelay, type SkipDelay } from './skip-delay';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function create(skipDelayDuration: () => number): SkipDelay {
+	return TestBed.runInInjectionContext(() => injectSkipDelay(skipDelayDuration));
+}
+
+describe('injectSkipDelay', () => {
+	it('requires a delay until a member opens', () => {
+		const skip = create(() => 50);
+		expect(skip.isOpenDelayed()).toBe(true);
+
+		skip.open();
+		expect(skip.isOpenDelayed()).toBe(false);
+	});
+
+	it('keeps skipping within the window after close, then re-requires the delay', async () => {
+		const skip = create(() => 50);
+		skip.open();
+		skip.close();
+
+		expect(skip.isOpenDelayed()).toBe(false);
+		await wait(90);
+		expect(skip.isOpenDelayed()).toBe(true);
+	});
+
+	it('a new open cancels the pending reset', async () => {
+		const skip = create(() => 50);
+		skip.open();
+		skip.close();
+		await wait(20);
+
+		skip.open();
+		await wait(60);
+		expect(skip.isOpenDelayed()).toBe(false);
+	});
+
+	it('never skips when skipDelayDuration is 0', async () => {
+		const skip = create(() => 0);
+		skip.open();
+		expect(skip.isOpenDelayed()).toBe(true);
+
+		skip.close();
+		await wait(10);
+		expect(skip.isOpenDelayed()).toBe(true);
+	});
+});

--- a/libs/brain/core/src/helpers/skip-delay.ts
+++ b/libs/brain/core/src/helpers/skip-delay.ts
@@ -1,0 +1,34 @@
+import { DestroyRef, inject, type Signal, signal } from '@angular/core';
+
+/** Skip-delay grouping: once one member opens, siblings skip their delay until the window elapses. */
+export interface SkipDelay {
+	/** Whether the next open should still wait for its delay (`true`) or open instantly (`false`). */
+	readonly isOpenDelayed: Signal<boolean>;
+	/** Report that a member opened: opens the skip window so siblings skip their delay. */
+	open(): void;
+	/** Report that a member closed: re-require the delay once the window elapses. */
+	close(): void;
+}
+
+/** Must be called in an injection context; cleans up its pending timer on destroy. */
+export function injectSkipDelay(skipDelayDuration: () => number): SkipDelay {
+	const isOpenDelayed = signal(true);
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	inject(DestroyRef).onDestroy(() => clearTimeout(timer));
+
+	return {
+		isOpenDelayed: isOpenDelayed.asReadonly(),
+		open(): void {
+			clearTimeout(timer);
+			if (skipDelayDuration() > 0) isOpenDelayed.set(false);
+		},
+		close(): void {
+			clearTimeout(timer);
+			const duration = skipDelayDuration();
+			if (duration > 0) {
+				timer = setTimeout(() => isOpenDelayed.set(true), duration);
+			}
+		},
+	};
+}

--- a/libs/brain/core/src/index.ts
+++ b/libs/brain/core/src/index.ts
@@ -10,6 +10,7 @@ export * from './helpers/inject-content-dimensions';
 export * from './helpers/inject-element-size';
 export * from './helpers/menu-align';
 export * from './helpers/resolve-value-label';
+export * from './helpers/skip-delay';
 export * from './helpers/table-classes-settable';
 export * from './helpers/wait-for-element-animations';
 export * from './helpers/zone-free';

--- a/libs/brain/navigation-menu/src/lib/brn-navigation-menu.ts
+++ b/libs/brain/navigation-menu/src/lib/brn-navigation-menu.ts
@@ -11,10 +11,9 @@ import {
 	model,
 	NgZone,
 	OnDestroy,
-	signal,
 } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
-import { computedPrevious, createHoverObservable } from '@spartan-ng/brain/core';
+import { computedPrevious, createHoverObservable, injectSkipDelay } from '@spartan-ng/brain/core';
 import { BehaviorSubject, combineLatest, merge, of, Subject } from 'rxjs';
 import { debounceTime, delay, filter, map, pairwise, startWith, switchMap, takeUntil } from 'rxjs/operators';
 import { BrnNavigationMenuItem } from './brn-navigation-menu-item';
@@ -76,10 +75,8 @@ export class BrnNavigationMenu implements OnDestroy {
 	 */
 	public readonly orientation = input<'horizontal' | 'vertical'>('horizontal');
 
-	private readonly _isOpenDelayed = signal(true);
-	public readonly isOpenDelayed = this._isOpenDelayed.asReadonly();
-
-	private _skipDelayTimerRef: ReturnType<typeof setTimeout> | undefined;
+	private readonly _skipDelay = injectSkipDelay(() => this.skipDelayDuration());
+	public readonly isOpenDelayed = this._skipDelay.isOpenDelayed;
 
 	private readonly _navAndSubnavMenuItems = contentChildren(BrnNavigationMenuItem, { descendants: true });
 
@@ -131,18 +128,8 @@ export class BrnNavigationMenu implements OnDestroy {
 
 	constructor() {
 		effect(() => {
-			const isOpen = this.value() !== undefined;
-			const hasSkipDelayDuration = this.skipDelayDuration() > 0;
-
-			if (isOpen) {
-				clearTimeout(this._skipDelayTimerRef);
-				if (hasSkipDelayDuration) this._isOpenDelayed.set(false);
-			} else {
-				clearTimeout(this._skipDelayTimerRef);
-				this._skipDelayTimerRef = setTimeout(() => {
-					this._isOpenDelayed.set(true);
-				}, this.skipDelayDuration());
-			}
+			if (this.value() !== undefined) this._skipDelay.open();
+			else this._skipDelay.close();
 		});
 
 		combineLatest([this._hovered$, this._contentHovered$, this._anyTriggerHovered$])
@@ -189,6 +176,5 @@ export class BrnNavigationMenu implements OnDestroy {
 	ngOnDestroy() {
 		this._destroy$.next();
 		this._destroy$.complete();
-		clearTimeout(this._skipDelayTimerRef);
 	}
 }

--- a/libs/brain/tooltip/src/index.ts
+++ b/libs/brain/tooltip/src/index.ts
@@ -3,6 +3,7 @@ import { BrnTooltipContent } from './lib/brn-tooltip-content';
 
 export * from './lib/brn-tooltip';
 export * from './lib/brn-tooltip-content';
+export * from './lib/brn-tooltip-group';
 export { BRN_TOOLTIP_FALLBACK_POSITIONS, BrnTooltipPosition, resolveTooltipPosition } from './lib/brn-tooltip-position';
 export * from './lib/brn-tooltip-type';
 export * from './lib/brn-tooltip.token';

--- a/libs/brain/tooltip/src/lib/brn-tooltip-content.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-content.ts
@@ -28,7 +28,7 @@ let uniqueId = 0;
 })
 export class BrnTooltipContent {
 	public readonly id = input<string>(`brn-tooltip-${++uniqueId}`);
-	public readonly state = signal<'closed' | 'open'>('closed');
+	public readonly state = signal<'closed' | 'open' | 'instant-open'>('closed');
 
 	protected readonly _tooltipClass = signal<ClassValue>('');
 	protected readonly _arrowClass = signal<ClassValue>('');

--- a/libs/brain/tooltip/src/lib/brn-tooltip-content.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-content.ts
@@ -28,7 +28,7 @@ let uniqueId = 0;
 })
 export class BrnTooltipContent {
 	public readonly id = input<string>(`brn-tooltip-${++uniqueId}`);
-	public readonly state = signal<'closed' | 'opened'>('closed');
+	public readonly state = signal<'closed' | 'open'>('closed');
 
 	protected readonly _tooltipClass = signal<ClassValue>('');
 	protected readonly _arrowClass = signal<ClassValue>('');

--- a/libs/brain/tooltip/src/lib/brn-tooltip-group.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-group.ts
@@ -1,0 +1,33 @@
+import { inject, Injectable, InjectionToken, type Provider } from '@angular/core';
+import { injectSkipDelay } from '@spartan-ng/brain/core';
+
+export interface BrnTooltipGroupOptions {
+	/** Time (ms) after the last tooltip closes during which others open instantly. `0` disables it. */
+	skipDelayDuration: number;
+}
+
+const defaultGroupOptions: BrnTooltipGroupOptions = { skipDelayDuration: 300 };
+
+const BRN_TOOLTIP_GROUP_OPTIONS = new InjectionToken<BrnTooltipGroupOptions>('BrnTooltipGroupOptions');
+
+/** Skip-delay coordinator for grouped tooltips; provide via `provideBrnTooltipGroup` on the wrapper. */
+@Injectable()
+export class BrnTooltipGroup {
+	private readonly _options = inject(BRN_TOOLTIP_GROUP_OPTIONS);
+	private readonly _skipDelay = injectSkipDelay(() => this._options.skipDelayDuration);
+
+	/** Whether the next tooltip waits for its show delay, or opens instantly within the skip window. */
+	public readonly isOpenDelayed = this._skipDelay.isOpenDelayed;
+
+	public onOpen(): void {
+		this._skipDelay.open();
+	}
+
+	public onClose(): void {
+		this._skipDelay.close();
+	}
+}
+
+export function provideBrnTooltipGroup(options?: Partial<BrnTooltipGroupOptions>): Provider[] {
+	return [{ provide: BRN_TOOLTIP_GROUP_OPTIONS, useValue: { ...defaultGroupOptions, ...options } }, BrnTooltipGroup];
+}

--- a/libs/brain/tooltip/src/lib/brn-tooltip.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip.ts
@@ -33,6 +33,7 @@ import { waitForElementAnimations } from '@spartan-ng/brain/core';
 import { of, Subject, Subscription, timer } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { BrnTooltipContent } from './brn-tooltip-content';
+import { BrnTooltipGroup } from './brn-tooltip-group';
 import {
 	BRN_TOOLTIP_FALLBACK_POSITIONS,
 	BRN_TOOLTIP_POSITIONS_MAP,
@@ -45,6 +46,8 @@ import { injectBrnTooltipDefaultOptions } from './brn-tooltip.token';
 interface DelayConfig {
 	isShow: boolean;
 	delay: number;
+	/** Snapshotted at request time: open instantly (no enter animation) because the group window was open. */
+	instant: boolean;
 }
 
 @Directive({ selector: '[brnTooltip]', exportAs: 'brnTooltip' })
@@ -59,6 +62,7 @@ export class BrnTooltip {
 	private readonly _overlayPositionBuilder = inject(OverlayPositionBuilder);
 	private readonly _renderer = inject(Renderer2);
 	private readonly _dir = inject(Directionality);
+	private readonly _group = inject(BrnTooltipGroup, { optional: true });
 
 	private _tooltipHovered = false;
 	private _listenersRefs: (() => void)[] = [];
@@ -172,11 +176,18 @@ export class BrnTooltip {
 	private _initHoverListeners(): void {
 		this._listenersRefs = [
 			...this._listenersRefs,
-			this._renderer.listen(this._elementRef.nativeElement, 'mouseenter', () => this.delay(true, this.showDelay())),
+			this._renderer.listen(this._elementRef.nativeElement, 'mouseenter', () => this._requestShow()),
 			this._renderer.listen(this._elementRef.nativeElement, 'mouseleave', () => this.delay(false, this.hideDelay())),
-			this._renderer.listen(this._elementRef.nativeElement, 'focus', () => this.delay(true, this.showDelay())),
+			this._renderer.listen(this._elementRef.nativeElement, 'focus', () => this._requestShow()),
 			this._renderer.listen(this._elementRef.nativeElement, 'blur', () => this.delay(false, this.hideDelay())),
 		];
+	}
+
+	/** Snapshot the group skip decision once, so the delay and the instant-open state agree even if a
+	 *  sibling flips the window during the show delay. */
+	private _requestShow(): void {
+		const skip = !!this._group && !this._group.isOpenDelayed();
+		this.delay(true, skip ? 0 : this.showDelay(), skip);
 	}
 
 	private _initScrollListener(): void {
@@ -193,8 +204,8 @@ export class BrnTooltip {
 		this._listenersRefs = [];
 	}
 
-	private delay(isShow: boolean, delay = -1): void {
-		this._delaySubject?.next({ isShow, delay });
+	private delay(isShow: boolean, delay = -1, instant = false): void {
+		this._delaySubject?.next({ isShow, delay, instant });
 	}
 
 	private _setupDelayMechanism(): void {
@@ -208,27 +219,32 @@ export class BrnTooltip {
 			)
 			.subscribe((config) => {
 				if (config.isShow) {
-					this._show();
+					this._show(config.instant);
 				} else {
 					this._hide();
 				}
 			});
 	}
 
-	private _show(): void {
+	private _show(instant = false): void {
 		if (!this._tooltipText() || this.mutableTooltipDisabled()) {
 			return;
 		}
+
+		// 'instant-open' suppresses the enter animation. Decided with the delay at request time so a sibling
+		// flipping the group window mid-delay can't desync the animation from the wait that actually happened.
+		const openState = instant ? 'instant-open' : 'open';
 
 		// Already attached: revive only if it is mid-close (exit animation playing). Cancel the
 		// pending teardown and flip it back open instead of letting it fade out and detach.
 		if (this._componentRef) {
 			if (this._componentRef.instance.state() === 'closed') {
 				this._closeGeneration++;
-				this._componentRef.instance.state.set('open');
+				this._componentRef.instance.state.set(openState);
 				// Re-apply props so a programmatic text change during the close is reflected on revive.
 				// Keep the live (possibly flipped) position rather than resetting to the raw input.
 				this._applyContentProps(this._componentRef.instance, this._activePosition ?? this.position());
+				this._group?.onOpen();
 				this.show.emit();
 			}
 			return;
@@ -239,7 +255,8 @@ export class BrnTooltip {
 		this._componentRef?.onDestroy(() => {
 			this._componentRef = undefined;
 		});
-		this._componentRef?.instance.state.set('open');
+		this._componentRef?.instance.state.set(openState);
+		this._group?.onOpen();
 		if (this._componentRef) {
 			this._applyContentProps(this._componentRef.instance, this.position());
 		}
@@ -295,6 +312,7 @@ export class BrnTooltip {
 		// Already closing (exit animation in flight): nothing to do.
 		if (this._componentRef.instance.state() === 'closed') return;
 		this._componentRef.instance.state.set('closed');
+		this._group?.onClose();
 		this.hide.emit();
 		this._scheduleDetach(this._componentRef);
 	}

--- a/libs/brain/tooltip/src/lib/brn-tooltip.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip.ts
@@ -69,6 +69,8 @@ export class BrnTooltip {
 	private _positionChangeSub: Subscription | undefined = undefined;
 	/** Bumped on every close/show so a pending exit-animation teardown can detect it was superseded. */
 	private _closeGeneration = 0;
+	/** The position currently applied to the content - the CDK-resolved one after a flip, not the raw input. */
+	private _activePosition: BrnTooltipPosition | undefined = undefined;
 
 	public readonly tooltipDisabled = input<boolean, boolean>(false, { transform: booleanAttribute });
 	public readonly mutableTooltipDisabled = linkedSignal(this.tooltipDisabled);
@@ -224,6 +226,9 @@ export class BrnTooltip {
 			if (this._componentRef.instance.state() === 'closed') {
 				this._closeGeneration++;
 				this._componentRef.instance.state.set('open');
+				// Re-apply props so a programmatic text change during the close is reflected on revive.
+				// Keep the live (possibly flipped) position rather than resetting to the raw input.
+				this._applyContentProps(this._componentRef.instance, this._activePosition ?? this.position());
 				this.show.emit();
 			}
 			return;
@@ -235,13 +240,9 @@ export class BrnTooltip {
 			this._componentRef = undefined;
 		});
 		this._componentRef?.instance.state.set('open');
-		this._componentRef?.instance.setProps(
-			this._tooltipText(),
-			this.position(),
-			this._config.tooltipContentClasses,
-			this._config.arrowClasses(this.position()),
-			this._config.svgClasses,
-		);
+		if (this._componentRef) {
+			this._applyContentProps(this._componentRef.instance, this.position());
+		}
 
 		// Subscribe to position changes for the lifetime of the tooltip so that
 		// arrow direction and CSS classes stay in sync when the CDK flips the
@@ -254,13 +255,7 @@ export class BrnTooltip {
 				.subscribe((change) => {
 					const resolved = resolveTooltipPosition(change.connectionPair);
 					if (resolved) {
-						compRef.instance.setProps(
-							null,
-							resolved,
-							this._config.tooltipContentClasses,
-							this._config.arrowClasses(resolved),
-							this._config.svgClasses,
-						);
+						this._applyContentProps(compRef.instance, resolved, null);
 					}
 				});
 		}
@@ -276,6 +271,23 @@ export class BrnTooltip {
 			});
 		});
 		this.show.emit();
+	}
+
+	/** Apply text + position (and the position-derived classes) to the content, recording the position as
+	 *  active. Pass `text = null` for a position-only update that keeps the content's existing text. */
+	private _applyContentProps(
+		content: BrnTooltipContent,
+		position: BrnTooltipPosition,
+		text: BrnTooltipType = this._tooltipText(),
+	): void {
+		this._activePosition = position;
+		content.setProps(
+			text,
+			position,
+			this._config.tooltipContentClasses,
+			this._config.arrowClasses(position),
+			this._config.svgClasses,
+		);
 	}
 
 	private _hide(): void {

--- a/libs/brain/tooltip/src/lib/brn-tooltip.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip.ts
@@ -29,6 +29,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { Directionality } from '@angular/cdk/bidi';
+import { waitForElementAnimations } from '@spartan-ng/brain/core';
 import { of, Subject, Subscription, timer } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { BrnTooltipContent } from './brn-tooltip-content';
@@ -66,6 +67,8 @@ export class BrnTooltip {
 	private _overlayRef: OverlayRef | undefined = undefined;
 	private _ariaEffectRef: ReturnType<typeof effect> | undefined = undefined;
 	private _positionChangeSub: Subscription | undefined = undefined;
+	/** Bumped on every close/show so a pending exit-animation teardown can detect it was superseded. */
+	private _closeGeneration = 0;
 
 	public readonly tooltipDisabled = input<boolean, boolean>(false, { transform: booleanAttribute });
 	public readonly mutableTooltipDisabled = linkedSignal(this.tooltipDisabled);
@@ -211,7 +214,18 @@ export class BrnTooltip {
 	}
 
 	private _show(): void {
-		if (this._componentRef || !this._tooltipText() || this.mutableTooltipDisabled()) {
+		if (!this._tooltipText() || this.mutableTooltipDisabled()) {
+			return;
+		}
+
+		// Already attached: revive only if it is mid-close (exit animation playing). Cancel the
+		// pending teardown and flip it back open instead of letting it fade out and detach.
+		if (this._componentRef) {
+			if (this._componentRef.instance.state() === 'closed') {
+				this._closeGeneration++;
+				this._componentRef.instance.state.set('open');
+				this.show.emit();
+			}
 			return;
 		}
 
@@ -220,7 +234,7 @@ export class BrnTooltip {
 		this._componentRef?.onDestroy(() => {
 			this._componentRef = undefined;
 		});
-		this._componentRef?.instance.state.set('opened');
+		this._componentRef?.instance.state.set('open');
 		this._componentRef?.instance.setProps(
 			this._tooltipText(),
 			this.position(),
@@ -266,13 +280,35 @@ export class BrnTooltip {
 
 	private _hide(): void {
 		if (!this._componentRef || this._tooltipHovered) return;
+		// Already closing (exit animation in flight): nothing to do.
+		if (this._componentRef.instance.state() === 'closed') return;
+		this._componentRef.instance.state.set('closed');
+		this.hide.emit();
+		this._scheduleDetach(this._componentRef);
+	}
+
+	/**
+	 * Keep the content mounted until its `data-[state=closed]` exit animation finishes, then tear it
+	 * down. A re-show (revive) bumps `_closeGeneration`, which cancels the pending detach.
+	 */
+	private _scheduleDetach(componentRef: ComponentRef<BrnTooltipContent>): void {
+		const generation = ++this._closeGeneration;
+		const content = componentRef.location.nativeElement as HTMLElement;
+		afterNextRender(
+			() => {
+				void waitForElementAnimations(content).then(() => {
+					if (generation === this._closeGeneration) this._detach();
+				});
+			},
+			{ injector: this._injector },
+		);
+	}
+
+	private _detach(): void {
 		this._clearAriaDescribedBy();
 		this._positionChangeSub?.unsubscribe();
 		this._positionChangeSub = undefined;
-
 		this._renderer.removeAttribute(this._elementRef.nativeElement, 'aria-describedby');
-		this._componentRef.instance.state.set('closed');
-		this.hide.emit();
 		this._overlayRef?.detach();
 	}
 

--- a/libs/cli/src/generators/ui/libs/tooltip/files/lib/hlm-tooltip.ts.template
+++ b/libs/cli/src/generators/ui/libs/tooltip/files/lib/hlm-tooltip.ts.template
@@ -7,7 +7,7 @@ export const DEFAULT_TOOLTIP_SVG_CLASS =
 	'bg-foreground fill-foreground z-50 block size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px]';
 
 export const DEFAULT_TOOLTIP_CONTENT_CLASSES = hlm(
-	'spartan-tooltip-content bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) text-balance',
+	'spartan-tooltip-content bg-foreground text-background data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) text-balance',
 );
 
 export const tooltipPositionVariants = cva('absolute', {

--- a/libs/helm/tooltip/src/lib/hlm-tooltip-animation.spec.ts
+++ b/libs/helm/tooltip/src/lib/hlm-tooltip-animation.spec.ts
@@ -1,0 +1,93 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
+import { HlmTooltip } from './hlm-tooltip';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const EXIT_MS = 150;
+
+@Component({
+	selector: 'hlm-tooltip-animation-host',
+	imports: [HlmTooltip],
+	providers: [Directionality],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<button hlmTooltip="tip" [showDelay]="0" [hideDelay]="0">trigger</button>
+	`,
+})
+class TooltipAnimationHost {}
+
+const triggerEl = () => screen.getByText('trigger');
+const tooltipEl = () => document.querySelector('[role="tooltip"]');
+const tooltipState = () => tooltipEl()?.getAttribute('data-state');
+
+describe('HlmTooltip animation-aware teardown', () => {
+	let style: HTMLStyleElement;
+
+	beforeEach(() => {
+		// Tailwind's animate-out utilities are not loaded in unit tests, so stand in a real
+		// keyframe on the content's closed state to exercise the exit animation.
+		style = document.createElement('style');
+		style.textContent = `
+			@keyframes brn-test-tooltip-exit { from { opacity: 1; } to { opacity: 0; } }
+			[role='tooltip'][data-state='closed'] { animation: brn-test-tooltip-exit ${EXIT_MS}ms linear; }
+		`;
+		document.head.appendChild(style);
+	});
+
+	afterEach(() => {
+		style.remove();
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	it('keeps the tooltip mounted while the exit animation runs, then disposes it', async () => {
+		await render(TooltipAnimationHost);
+
+		fireEvent.mouseEnter(triggerEl());
+		await waitFor(() => expect(tooltipEl()).toBeTruthy());
+
+		fireEvent.mouseLeave(triggerEl());
+		// Marked closed but still mounted while the exit animation runs.
+		await waitFor(() => expect(tooltipState()).toBe('closed'));
+		expect(tooltipEl()).toBeTruthy();
+
+		// After the animation completes it is detached.
+		await waitFor(() => expect(tooltipEl()).toBeNull(), { timeout: EXIT_MS + 500 });
+	});
+
+	it('revives the tooltip when re-hovered mid-animation', async () => {
+		await render(TooltipAnimationHost);
+
+		fireEvent.mouseEnter(triggerEl());
+		await waitFor(() => expect(tooltipEl()).toBeTruthy());
+
+		fireEvent.mouseLeave(triggerEl());
+		await waitFor(() => expect(tooltipState()).toBe('closed'));
+
+		// Re-hover before the exit animation finishes: it must flip back open...
+		fireEvent.mouseEnter(triggerEl());
+		await waitFor(() => expect(tooltipState()).toBe('open'));
+
+		// ...and survive past the moment the pending teardown would have fired.
+		await wait(EXIT_MS + 120);
+		expect(tooltipEl()).toBeTruthy();
+		expect(tooltipState()).toBe('open');
+	});
+});
+
+describe('HlmTooltip teardown without an exit animation', () => {
+	afterEach(() => {
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	it('detaches promptly when there is no exit animation', async () => {
+		await render(TooltipAnimationHost);
+
+		fireEvent.mouseEnter(triggerEl());
+		await waitFor(() => expect(tooltipEl()).toBeTruthy());
+
+		fireEvent.mouseLeave(triggerEl());
+		await waitFor(() => expect(tooltipEl()).toBeNull());
+	});
+});

--- a/libs/helm/tooltip/src/lib/hlm-tooltip-animation.spec.ts
+++ b/libs/helm/tooltip/src/lib/hlm-tooltip-animation.spec.ts
@@ -12,8 +12,13 @@ const EXIT_MS = 150;
 	imports: [HlmTooltip],
 	providers: [Directionality],
 	changeDetection: ChangeDetectionStrategy.OnPush,
+	// Center the trigger so the overlay never renders under the headless browser's
+	// resting cursor (0,0); otherwise the panel receives a real mouseenter, sets the
+	// directive's hovered flag, and a synthetic mouseleave on the trigger is ignored.
 	template: `
-		<button hlmTooltip="tip" [showDelay]="0" [hideDelay]="0">trigger</button>
+		<div style="position: fixed; inset: 0; display: flex; align-items: center; justify-content: center">
+			<button hlmTooltip="tip" [showDelay]="0" [hideDelay]="0">trigger</button>
+		</div>
 	`,
 })
 class TooltipAnimationHost {}

--- a/libs/helm/tooltip/src/lib/hlm-tooltip-animation.spec.ts
+++ b/libs/helm/tooltip/src/lib/hlm-tooltip-animation.spec.ts
@@ -1,5 +1,5 @@
 import { Directionality } from '@angular/cdk/bidi';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
 import { HlmTooltip } from './hlm-tooltip';
 
@@ -22,6 +22,21 @@ const EXIT_MS = 150;
 	`,
 })
 class TooltipAnimationHost {}
+
+@Component({
+	selector: 'hlm-tooltip-dynamic-host',
+	imports: [HlmTooltip],
+	providers: [Directionality],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div style="position: fixed; inset: 0; display: flex; align-items: center; justify-content: center">
+			<button [hlmTooltip]="tip()" [showDelay]="0" [hideDelay]="0">trigger</button>
+		</div>
+	`,
+})
+class TooltipDynamicHost {
+	public readonly tip = signal('first');
+}
 
 const triggerEl = () => screen.getByText('trigger');
 const tooltipEl = () => document.querySelector('[role="tooltip"]');
@@ -78,6 +93,24 @@ describe('HlmTooltip animation-aware teardown', () => {
 		await wait(EXIT_MS + 120);
 		expect(tooltipEl()).toBeTruthy();
 		expect(tooltipState()).toBe('open');
+	});
+
+	it('reflects a programmatic text change when revived mid-animation', async () => {
+		const { fixture } = await render(TooltipDynamicHost);
+
+		fireEvent.mouseEnter(triggerEl());
+		await waitFor(() => expect(tooltipEl()?.textContent).toContain('first'));
+
+		fireEvent.mouseLeave(triggerEl());
+		await waitFor(() => expect(tooltipState()).toBe('closed'));
+
+		// Mutate the bound text while the exit animation is in flight, then re-hover to revive.
+		fixture.componentInstance.tip.set('second');
+		fixture.detectChanges();
+		fireEvent.mouseEnter(triggerEl());
+
+		await waitFor(() => expect(tooltipState()).toBe('open'));
+		expect(tooltipEl()?.textContent).toContain('second');
 	});
 });
 

--- a/libs/helm/tooltip/src/lib/hlm-tooltip-group.spec.ts
+++ b/libs/helm/tooltip/src/lib/hlm-tooltip-group.spec.ts
@@ -1,0 +1,82 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { provideBrnTooltipGroup } from '@spartan-ng/brain/tooltip';
+import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
+import { HlmTooltip } from './hlm-tooltip';
+
+@Component({
+	selector: 'hlm-tooltip-group-host',
+	imports: [HlmTooltip],
+	providers: [Directionality, provideBrnTooltipGroup({ skipDelayDuration: 1000 })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	// Centered + spaced so neither overlay lands under the headless cursor (0,0).
+	template: `
+		<div style="position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; gap: 200px">
+			<button hlmTooltip="first" [showDelay]="100" [hideDelay]="0">one</button>
+			<button hlmTooltip="second" [showDelay]="100" [hideDelay]="0">two</button>
+		</div>
+	`,
+})
+class TooltipGroupHost {}
+
+// Short skip window so the reset-path test can wait it out quickly. showDelay is 0, so a delayed vs an
+// instant open is distinguishable purely by data-state, not by timing.
+@Component({
+	selector: 'hlm-tooltip-group-short-host',
+	imports: [HlmTooltip],
+	providers: [Directionality, provideBrnTooltipGroup({ skipDelayDuration: 50 })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div style="position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; gap: 200px">
+			<button hlmTooltip="first" [showDelay]="0" [hideDelay]="0">one</button>
+			<button hlmTooltip="second" [showDelay]="0" [hideDelay]="0">two</button>
+		</div>
+	`,
+})
+class TooltipGroupShortWindowHost {}
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const tooltipByText = (text: string) =>
+	Array.from(document.querySelectorAll('[role="tooltip"]')).find((el) => el.textContent?.includes(text));
+
+describe('HlmTooltip skip-delay grouping', () => {
+	afterEach(() => {
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	it('opens the first tooltip delayed, then the next instantly within the skip window', async () => {
+		await render(TooltipGroupHost);
+
+		// First open waits for its delay -> animated "open".
+		fireEvent.mouseEnter(screen.getByText('one'));
+		await waitFor(() => expect(tooltipByText('first')?.getAttribute('data-state')).toBe('open'));
+
+		// Second opens within the window -> "instant-open" (no enter animation).
+		fireEvent.mouseEnter(screen.getByText('two'));
+		await waitFor(() => {
+			const el = tooltipByText('second');
+			expect(el).toBeTruthy();
+			expect(el?.getAttribute('data-state')).toBe('instant-open');
+		});
+	});
+
+	it('restores the delay once the skip window elapses after the group closes', async () => {
+		await render(TooltipGroupShortWindowHost);
+
+		// Open then close the first tooltip - closing starts the window's expiry timer.
+		fireEvent.mouseEnter(screen.getByText('one'));
+		await waitFor(() => expect(tooltipByText('first')).toBeTruthy());
+		fireEvent.mouseLeave(screen.getByText('one'));
+		await waitFor(() => expect(tooltipByText('first')).toBeFalsy());
+
+		// After the window elapses, the next open is delayed again -> animated "open", not "instant-open".
+		await wait(90);
+		fireEvent.mouseEnter(screen.getByText('two'));
+		await waitFor(() => {
+			const el = tooltipByText('second');
+			expect(el).toBeTruthy();
+			expect(el?.getAttribute('data-state')).toBe('open');
+		});
+	});
+});

--- a/libs/helm/tooltip/src/lib/hlm-tooltip.ts
+++ b/libs/helm/tooltip/src/lib/hlm-tooltip.ts
@@ -7,7 +7,7 @@ export const DEFAULT_TOOLTIP_SVG_CLASS =
 	'bg-foreground fill-foreground z-50 block size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px]';
 
 export const DEFAULT_TOOLTIP_CONTENT_CLASSES = hlm(
-	'spartan-tooltip-content bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) text-balance',
+	'spartan-tooltip-content bg-foreground text-background data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) text-balance',
 );
 
 export const tooltipPositionVariants = cva('absolute', {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] tooltip

### Others

- [x] cli

## What is the current behavior?

The tooltip lost its exit animation. On hide, the directive set the content to
`data-state="closed"` and then immediately called `overlayRef.detach()` on the
next line, removing the content from the DOM before the
`data-[state=closed]` fade/zoom-out could paint. The tooltip just blinked out.

Separately, the content emitted `data-state="opened"` — a value no style or
shadcn class targets (every other overlay uses `open`). As a result the
per-style `data-open:`/`data-[state=delayed-open]:` enter-animation classes in
all six style files were dead; the enter animation only ran because the default
helm classes carried an ungated `animate-in`.

## What is the new behavior?

- Teardown is deferred until the content's exit animations finish, reusing
  `waitForElementAnimations` from `@spartan-ng/brain/core` (the same helper the
  dialog/overlay lifecycle split introduced). If there is no exit animation
  (e.g. `prefers-reduced-motion`), it detaches immediately.
- Re-hovering a tooltip mid-close revives it (cancels the pending teardown and
  flips it back open) instead of letting it fade out and detach.
- The content now emits `data-state="open"` to match every other overlay and
  shadcn, which revives the per-style enter-animation classes. The default helm
  classes were switched to the same gated convention (`data-open:` /
  `data-[state=delayed-open]:` / `data-closed:`) the style blocks already use,
  and the CLI tooltip template was kept in sync.
- Added the first tooltip animation specs (teardown, revive, no-animation fast
  path).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The tooltip content's `data-state` changes from `opened` to `open`. This is a
rendered-DOM value only; consumers style via the shipped helm classes, and
`opened` matched no existing selector, so this aligns the value rather than
changing supported behavior.

The `data-[state=delayed-open]` enter classes are now wired but remain dormant
until a follow-up adds skip-delay grouping (the Radix `TooltipProvider`
`delayed-open`/`instant-open` behavior); this PR is the prerequisite rename for
that work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tooltip group support with configurable skip-delay so the next tooltip can open instantly during the group window.
  * Updated tooltip open/close animations and transition selectors for more consistent behavior.
* **Bug Fixes**
  * Tooltip teardown now waits for exit animations to finish, preventing premature detaching.
  * Re-hovering during the exit phase keeps the tooltip mounted and restores the open state; content/position updates remain synchronized.
* **Tests**
  * Added coverage for animated vs non-animated teardown, mid-exit recovery, content updates, skip-delay helper, and tooltip group behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->