### PR TITLE
feat(tooltip): add skip-delay grouping

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip--group.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip--group.example.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { provideBrnTooltipGroup } from '@spartan-ng/brain/tooltip';
+import { HlmButtonImports } from '@spartan-ng/helm/button';
+import { HlmTooltipImports } from '@spartan-ng/helm/tooltip';
+
+@Component({
+	selector: 'spartan-tooltip-group',
+	imports: [HlmButtonImports, HlmTooltipImports],
+	providers: [provideBrnTooltipGroup({ skipDelayDuration: 300 })],
+	template: `
+		<div class="flex gap-2">
+			<button [hlmTooltip]="'Save'" hlmBtn variant="outline">Save</button>
+			<button [hlmTooltip]="'Copy'" hlmBtn variant="outline">Copy</button>
+			<button [hlmTooltip]="'Paste'" hlmBtn variant="outline">Paste</button>
+		</div>
+	`,
+})
+export class TooltipGroup {}

--- a/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(tooltip)/tooltip.page.ts
@@ -22,6 +22,7 @@ import { SectionSubHeading } from '../../../../shared/layout/section-sub-heading
 import { Tabs } from '../../../../shared/layout/tabs';
 import { UIApiDocs } from '../../../../shared/layout/ui-docs-section/ui-docs-section';
 import { metaWith } from '../../../../shared/meta/meta.util';
+import { TooltipGroup } from './tooltip--group.example';
 import { TooltipSimple } from './tooltip--simple.example';
 import { defaultImports, defaultSkeleton, TooltipPreview } from './tooltip.preview';
 
@@ -52,6 +53,7 @@ export const routeMeta: RouteMeta = {
 		TooltipSimple,
 		SectionSubSubHeading,
 		TooltipSimple,
+		TooltipGroup,
 		TooltipPosition,
 		TooltipSimple,
 		TooltipDisabled,
@@ -92,6 +94,20 @@ export const routeMeta: RouteMeta = {
 					<spartan-tooltip-simple />
 				</div>
 				<spartan-code secondTab [code]="_simpleCode()" />
+			</spartan-tabs>
+
+			<h3 id="examples__group" spartanH4>Group</h3>
+			<p class="text-muted-foreground mt-2 mb-4 text-sm">
+				Provide
+				<code>provideBrnTooltipGroup</code>
+				on a wrapping component so that once one tooltip opens, the others in the group open instantly until the
+				skip-delay window elapses.
+			</p>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-tooltip-group />
+				</div>
+				<spartan-code secondTab [code]="_groupCode()" />
 			</spartan-tabs>
 
 			<h3 id="examples__position" spartanH4>Positions</h3>
@@ -156,6 +172,7 @@ export default class TooltipPage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('tooltip');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
 	protected readonly _simpleCode = computed(() => this._snippets()['simple']);
+	protected readonly _groupCode = computed(() => this._snippets()['group']);
 	protected readonly _positionCode = computed(() => this._snippets()['position']);
 	protected readonly _templateCode = computed(() => this._snippets()['template']);
 	protected readonly _disabledCode = computed(() => this._snippets()['disabled']);

--- a/libs/brain/core/src/helpers/skip-delay.spec.ts
+++ b/libs/brain/core/src/helpers/skip-delay.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import { injectSkipDelay, type SkipDelay } from './skip-delay';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function create(skipDelayDuration: () => number): SkipDelay {
+	return TestBed.runInInjectionContext(() => injectSkipDelay(skipDelayDuration));
+}
+
+describe('injectSkipDelay', () => {
+	it('requires a delay until a member opens', () => {
+		const skip = create(() => 50);
+		expect(skip.isOpenDelayed()).toBe(true);
+
+		skip.open();
+		expect(skip.isOpenDelayed()).toBe(false);
+	});
+
+	it('keeps skipping within the window after close, then re-requires the delay', async () => {
+		const skip = create(() => 50);
+		skip.open();
+		skip.close();
+
+		expect(skip.isOpenDelayed()).toBe(false);
+		await wait(90);
+		expect(skip.isOpenDelayed()).toBe(true);
+	});
+
+	it('a new open cancels the pending reset', async () => {
+		const skip = create(() => 50);
+		skip.open();
+		skip.close();
+		await wait(20);
+
+		skip.open();
+		await wait(60);
+		expect(skip.isOpenDelayed()).toBe(false);
+	});
+
+	it('never skips when skipDelayDuration is 0', async () => {
+		const skip = create(() => 0);
+		skip.open();
+		expect(skip.isOpenDelayed()).toBe(true);
+
+		skip.close();
+		await wait(10);
+		expect(skip.isOpenDelayed()).toBe(true);
+	});
+});

--- a/libs/brain/core/src/helpers/skip-delay.ts
+++ b/libs/brain/core/src/helpers/skip-delay.ts
@@ -1,0 +1,34 @@
+import { DestroyRef, inject, type Signal, signal } from '@angular/core';
+
+/** Skip-delay grouping: once one member opens, siblings skip their delay until the window elapses. */
+export interface SkipDelay {
+	/** Whether the next open should still wait for its delay (`true`) or open instantly (`false`). */
+	readonly isOpenDelayed: Signal<boolean>;
+	/** Report that a member opened: opens the skip window so siblings skip their delay. */
+	open(): void;
+	/** Report that a member closed: re-require the delay once the window elapses. */
+	close(): void;
+}
+
+/** Must be called in an injection context; cleans up its pending timer on destroy. */
+export function injectSkipDelay(skipDelayDuration: () => number): SkipDelay {
+	const isOpenDelayed = signal(true);
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	inject(DestroyRef).onDestroy(() => clearTimeout(timer));
+
+	return {
+		isOpenDelayed: isOpenDelayed.asReadonly(),
+		open(): void {
+			clearTimeout(timer);
+			if (skipDelayDuration() > 0) isOpenDelayed.set(false);
+		},
+		close(): void {
+			clearTimeout(timer);
+			const duration = skipDelayDuration();
+			if (duration > 0) {
+				timer = setTimeout(() => isOpenDelayed.set(true), duration);
+			}
+		},
+	};
+}

--- a/libs/brain/core/src/index.ts
+++ b/libs/brain/core/src/index.ts
@@ -10,6 +10,7 @@ export * from './helpers/inject-content-dimensions';
 export * from './helpers/inject-element-size';
 export * from './helpers/menu-align';
 export * from './helpers/resolve-value-label';
+export * from './helpers/skip-delay';
 export * from './helpers/table-classes-settable';
 export * from './helpers/wait-for-element-animations';
 export * from './helpers/zone-free';

--- a/libs/brain/navigation-menu/src/lib/brn-navigation-menu.ts
+++ b/libs/brain/navigation-menu/src/lib/brn-navigation-menu.ts
@@ -11,10 +11,9 @@ import {
 	model,
 	NgZone,
 	OnDestroy,
-	signal,
 } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
-import { computedPrevious, createHoverObservable } from '@spartan-ng/brain/core';
+import { computedPrevious, createHoverObservable, injectSkipDelay } from '@spartan-ng/brain/core';
 import { BehaviorSubject, combineLatest, merge, of, Subject } from 'rxjs';
 import { debounceTime, delay, filter, map, pairwise, startWith, switchMap, takeUntil } from 'rxjs/operators';
 import { BrnNavigationMenuItem } from './brn-navigation-menu-item';
@@ -76,10 +75,8 @@ export class BrnNavigationMenu implements OnDestroy {
 	 */
 	public readonly orientation = input<'horizontal' | 'vertical'>('horizontal');
 
-	private readonly _isOpenDelayed = signal(true);
-	public readonly isOpenDelayed = this._isOpenDelayed.asReadonly();
-
-	private _skipDelayTimerRef: ReturnType<typeof setTimeout> | undefined;
+	private readonly _skipDelay = injectSkipDelay(() => this.skipDelayDuration());
+	public readonly isOpenDelayed = this._skipDelay.isOpenDelayed;
 
 	private readonly _navAndSubnavMenuItems = contentChildren(BrnNavigationMenuItem, { descendants: true });
 
@@ -131,18 +128,8 @@ export class BrnNavigationMenu implements OnDestroy {
 
 	constructor() {
 		effect(() => {
-			const isOpen = this.value() !== undefined;
-			const hasSkipDelayDuration = this.skipDelayDuration() > 0;
-
-			if (isOpen) {
-				clearTimeout(this._skipDelayTimerRef);
-				if (hasSkipDelayDuration) this._isOpenDelayed.set(false);
-			} else {
-				clearTimeout(this._skipDelayTimerRef);
-				this._skipDelayTimerRef = setTimeout(() => {
-					this._isOpenDelayed.set(true);
-				}, this.skipDelayDuration());
-			}
+			if (this.value() !== undefined) this._skipDelay.open();
+			else this._skipDelay.close();
 		});
 
 		combineLatest([this._hovered$, this._contentHovered$, this._anyTriggerHovered$])
@@ -189,6 +176,5 @@ export class BrnNavigationMenu implements OnDestroy {
 	ngOnDestroy() {
 		this._destroy$.next();
 		this._destroy$.complete();
-		clearTimeout(this._skipDelayTimerRef);
 	}
 }

--- a/libs/brain/tooltip/src/index.ts
+++ b/libs/brain/tooltip/src/index.ts
@@ -3,6 +3,7 @@ import { BrnTooltipContent } from './lib/brn-tooltip-content';
 
 export * from './lib/brn-tooltip';
 export * from './lib/brn-tooltip-content';
+export * from './lib/brn-tooltip-group';
 export { BRN_TOOLTIP_FALLBACK_POSITIONS, BrnTooltipPosition, resolveTooltipPosition } from './lib/brn-tooltip-position';
 export * from './lib/brn-tooltip-type';
 export * from './lib/brn-tooltip.token';

--- a/libs/brain/tooltip/src/lib/brn-tooltip-content.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-content.ts
@@ -28,7 +28,7 @@ let uniqueId = 0;
 })
 export class BrnTooltipContent {
 	public readonly id = input<string>(`brn-tooltip-${++uniqueId}`);
-	public readonly state = signal<'closed' | 'open'>('closed');
+	public readonly state = signal<'closed' | 'open' | 'instant-open'>('closed');
 
 	protected readonly _tooltipClass = signal<ClassValue>('');
 	protected readonly _arrowClass = signal<ClassValue>('');

--- a/libs/brain/tooltip/src/lib/brn-tooltip-group.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-group.ts
@@ -1,0 +1,33 @@
+import { inject, Injectable, InjectionToken, type Provider } from '@angular/core';
+import { injectSkipDelay } from '@spartan-ng/brain/core';
+
+export interface BrnTooltipGroupOptions {
+	/** Time (ms) after the last tooltip closes during which others open instantly. `0` disables it. */
+	skipDelayDuration: number;
+}
+
+const defaultGroupOptions: BrnTooltipGroupOptions = { skipDelayDuration: 300 };
+
+const BRN_TOOLTIP_GROUP_OPTIONS = new InjectionToken<BrnTooltipGroupOptions>('BrnTooltipGroupOptions');
+
+/** Skip-delay coordinator for grouped tooltips; provide via `provideBrnTooltipGroup` on the wrapper. */
+@Injectable()
+export class BrnTooltipGroup {
+	private readonly _options = inject(BRN_TOOLTIP_GROUP_OPTIONS);
+	private readonly _skipDelay = injectSkipDelay(() => this._options.skipDelayDuration);
+
+	/** Whether the next tooltip waits for its show delay, or opens instantly within the skip window. */
+	public readonly isOpenDelayed = this._skipDelay.isOpenDelayed;
+
+	public onOpen(): void {
+		this._skipDelay.open();
+	}
+
+	public onClose(): void {
+		this._skipDelay.close();
+	}
+}
+
+export function provideBrnTooltipGroup(options?: Partial<BrnTooltipGroupOptions>): Provider[] {
+	return [{ provide: BRN_TOOLTIP_GROUP_OPTIONS, useValue: { ...defaultGroupOptions, ...options } }, BrnTooltipGroup];
+}

--- a/libs/brain/tooltip/src/lib/brn-tooltip.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip.ts
@@ -33,6 +33,7 @@ import { waitForElementAnimations } from '@spartan-ng/brain/core';
 import { of, Subject, Subscription, timer } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { BrnTooltipContent } from './brn-tooltip-content';
+import { BrnTooltipGroup } from './brn-tooltip-group';
 import {
 	BRN_TOOLTIP_FALLBACK_POSITIONS,
 	BRN_TOOLTIP_POSITIONS_MAP,
@@ -45,6 +46,8 @@ import { injectBrnTooltipDefaultOptions } from './brn-tooltip.token';
 interface DelayConfig {
 	isShow: boolean;
 	delay: number;
+	/** Snapshotted at request time: open instantly (no enter animation) because the group window was open. */
+	instant: boolean;
 }
 
 @Directive({ selector: '[brnTooltip]', exportAs: 'brnTooltip' })
@@ -59,6 +62,7 @@ export class BrnTooltip {
 	private readonly _overlayPositionBuilder = inject(OverlayPositionBuilder);
 	private readonly _renderer = inject(Renderer2);
 	private readonly _dir = inject(Directionality);
+	private readonly _group = inject(BrnTooltipGroup, { optional: true });
 
 	private _tooltipHovered = false;
 	private _listenersRefs: (() => void)[] = [];
@@ -172,11 +176,18 @@ export class BrnTooltip {
 	private _initHoverListeners(): void {
 		this._listenersRefs = [
 			...this._listenersRefs,
-			this._renderer.listen(this._elementRef.nativeElement, 'mouseenter', () => this.delay(true, this.showDelay())),
+			this._renderer.listen(this._elementRef.nativeElement, 'mouseenter', () => this._requestShow()),
 			this._renderer.listen(this._elementRef.nativeElement, 'mouseleave', () => this.delay(false, this.hideDelay())),
-			this._renderer.listen(this._elementRef.nativeElement, 'focus', () => this.delay(true, this.showDelay())),
+			this._renderer.listen(this._elementRef.nativeElement, 'focus', () => this._requestShow()),
 			this._renderer.listen(this._elementRef.nativeElement, 'blur', () => this.delay(false, this.hideDelay())),
 		];
+	}
+
+	/** Snapshot the group skip decision once, so the delay and the instant-open state agree even if a
+	 *  sibling flips the window during the show delay. */
+	private _requestShow(): void {
+		const skip = !!this._group && !this._group.isOpenDelayed();
+		this.delay(true, skip ? 0 : this.showDelay(), skip);
 	}
 
 	private _initScrollListener(): void {
@@ -193,8 +204,8 @@ export class BrnTooltip {
 		this._listenersRefs = [];
 	}
 
-	private delay(isShow: boolean, delay = -1): void {
-		this._delaySubject?.next({ isShow, delay });
+	private delay(isShow: boolean, delay = -1, instant = false): void {
+		this._delaySubject?.next({ isShow, delay, instant });
 	}
 
 	private _setupDelayMechanism(): void {
@@ -208,27 +219,32 @@ export class BrnTooltip {
 			)
 			.subscribe((config) => {
 				if (config.isShow) {
-					this._show();
+					this._show(config.instant);
 				} else {
 					this._hide();
 				}
 			});
 	}
 
-	private _show(): void {
+	private _show(instant = false): void {
 		if (!this._tooltipText() || this.mutableTooltipDisabled()) {
 			return;
 		}
+
+		// 'instant-open' suppresses the enter animation. Decided with the delay at request time so a sibling
+		// flipping the group window mid-delay can't desync the animation from the wait that actually happened.
+		const openState = instant ? 'instant-open' : 'open';
 
 		// Already attached: revive only if it is mid-close (exit animation playing). Cancel the
 		// pending teardown and flip it back open instead of letting it fade out and detach.
 		if (this._componentRef) {
 			if (this._componentRef.instance.state() === 'closed') {
 				this._closeGeneration++;
-				this._componentRef.instance.state.set('open');
+				this._componentRef.instance.state.set(openState);
 				// Re-apply props so a programmatic text change during the close is reflected on revive.
 				// Keep the live (possibly flipped) position rather than resetting to the raw input.
 				this._applyContentProps(this._componentRef.instance, this._activePosition ?? this.position());
+				this._group?.onOpen();
 				this.show.emit();
 			}
 			return;
@@ -239,7 +255,8 @@ export class BrnTooltip {
 		this._componentRef?.onDestroy(() => {
 			this._componentRef = undefined;
 		});
-		this._componentRef?.instance.state.set('open');
+		this._componentRef?.instance.state.set(openState);
+		this._group?.onOpen();
 		if (this._componentRef) {
 			this._applyContentProps(this._componentRef.instance, this.position());
 		}
@@ -295,6 +312,7 @@ export class BrnTooltip {
 		// Already closing (exit animation in flight): nothing to do.
 		if (this._componentRef.instance.state() === 'closed') return;
 		this._componentRef.instance.state.set('closed');
+		this._group?.onClose();
 		this.hide.emit();
 		this._scheduleDetach(this._componentRef);
 	}

--- a/libs/helm/tooltip/src/lib/hlm-tooltip-group.spec.ts
+++ b/libs/helm/tooltip/src/lib/hlm-tooltip-group.spec.ts
@@ -1,0 +1,82 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { provideBrnTooltipGroup } from '@spartan-ng/brain/tooltip';
+import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
+import { HlmTooltip } from './hlm-tooltip';
+
+@Component({
+	selector: 'hlm-tooltip-group-host',
+	imports: [HlmTooltip],
+	providers: [Directionality, provideBrnTooltipGroup({ skipDelayDuration: 1000 })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	// Centered + spaced so neither overlay lands under the headless cursor (0,0).
+	template: `
+		<div style="position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; gap: 200px">
+			<button hlmTooltip="first" [showDelay]="100" [hideDelay]="0">one</button>
+			<button hlmTooltip="second" [showDelay]="100" [hideDelay]="0">two</button>
+		</div>
+	`,
+})
+class TooltipGroupHost {}
+
+// Short skip window so the reset-path test can wait it out quickly. showDelay is 0, so a delayed vs an
+// instant open is distinguishable purely by data-state, not by timing.
+@Component({
+	selector: 'hlm-tooltip-group-short-host',
+	imports: [HlmTooltip],
+	providers: [Directionality, provideBrnTooltipGroup({ skipDelayDuration: 50 })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div style="position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; gap: 200px">
+			<button hlmTooltip="first" [showDelay]="0" [hideDelay]="0">one</button>
+			<button hlmTooltip="second" [showDelay]="0" [hideDelay]="0">two</button>
+		</div>
+	`,
+})
+class TooltipGroupShortWindowHost {}
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const tooltipByText = (text: string) =>
+	Array.from(document.querySelectorAll('[role="tooltip"]')).find((el) => el.textContent?.includes(text));
+
+describe('HlmTooltip skip-delay grouping', () => {
+	afterEach(() => {
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	it('opens the first tooltip delayed, then the next instantly within the skip window', async () => {
+		await render(TooltipGroupHost);
+
+		// First open waits for its delay -> animated "open".
+		fireEvent.mouseEnter(screen.getByText('one'));
+		await waitFor(() => expect(tooltipByText('first')?.getAttribute('data-state')).toBe('open'));
+
+		// Second opens within the window -> "instant-open" (no enter animation).
+		fireEvent.mouseEnter(screen.getByText('two'));
+		await waitFor(() => {
+			const el = tooltipByText('second');
+			expect(el).toBeTruthy();
+			expect(el?.getAttribute('data-state')).toBe('instant-open');
+		});
+	});
+
+	it('restores the delay once the skip window elapses after the group closes', async () => {
+		await render(TooltipGroupShortWindowHost);
+
+		// Open then close the first tooltip - closing starts the window's expiry timer.
+		fireEvent.mouseEnter(screen.getByText('one'));
+		await waitFor(() => expect(tooltipByText('first')).toBeTruthy());
+		fireEvent.mouseLeave(screen.getByText('one'));
+		await waitFor(() => expect(tooltipByText('first')).toBeFalsy());
+
+		// After the window elapses, the next open is delayed again -> animated "open", not "instant-open".
+		await wait(90);
+		fireEvent.mouseEnter(screen.getByText('two'));
+		await waitFor(() => {
+			const el = tooltipByText('second');
+			expect(el).toBeTruthy();
+			expect(el?.getAttribute('data-state')).toBe('open');
+		});
+	});
+});


### PR DESCRIPTION
> [!NOTE]
> Stacked on #1536 (`fix/tooltip-exit-animation`) — base it there. The diff below is only this
> commit; review/merge #1536 first, then this retargets to `main`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] tooltip
- [x] navigation-menu

## What is the current behavior?

Tooltips are independent: each waits for its own `showDelay` every time, with no notion of a group.
There is no equivalent to Radix's `TooltipProvider`/`skipDelayDuration`, where once one tooltip in a
group has opened, moving to a sibling opens it instantly (without re-waiting the delay) until a short
window elapses.

The skip-delay timer logic already existed, hand-rolled inside `brn-navigation-menu`.

## What is the new behavior?

Opt-in skip-delay grouping for tooltips:

- Extracted the timer/window logic into `injectSkipDelay` in `@spartan-ng/brain/core` and migrated
  `brn-navigation-menu` onto it (it gets smaller; the logic now has one tested home).
- Added `BrnTooltipGroup` + `provideBrnTooltipGroup({ skipDelayDuration })`. Provide it on the
  component that wraps the tooltips you want grouped; tooltips inject it optionally, so anything
  outside a provider stays solo (no app-wide default).
- `BrnTooltip` skips the show delay within the window and renders `data-state="instant-open"`
  (no enter animation) for instant opens.
- Added a grouped tooltip example/doc section, an `injectSkipDelay` unit spec, and a grouped
  integration spec.

No directive/wrapper element or CLI template was needed — grouping is just a provider on the
consumer's own component, which doubles as the canonical usage.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

`BrnTooltipContent`'s `data-state` gains the `instant-open` value (in addition to `open`/`closed`).
The navigation-menu effect now reads `skipDelayDuration` lazily when arming rather than re-running on
every input change — equivalent for normal usage, just no re-arm on a mid-life duration change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tooltip grouping that coordinates hover/focus between multiple tooltips, including configurable skip-delay to open “instantly” when switching within the group window.
  * Added a new tooltip group usage example to the Tooltip docs.
  * Enhanced navigation menu open-delay handling by sharing the new centralized skip-delay behavior.
* **Tests**
  * Added skip-delay unit tests for delay, cancellation, and zero-delay behavior.
  * Added tooltip-group tests validating instant-open within the skip window and normal delayed-open after it expires.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->