### PR TITLE
fix: render hero spotlight as svg to stop safari overlay flicker

### DIFF
--- a/apps/app/src/app/app.ts
+++ b/apps/app/src/app/app.ts
@@ -10,7 +10,7 @@ import { Header } from './shared/header/header';
 		class: 'bg-background relative z-10 flex min-h-svh flex-col',
 	},
 	template: `
-		<svg class="pointer-events-none fixed inset-0 z-40 h-full w-full" width="100%" height="100%" aria-hidden="true">
+		<svg class="pointer-events-none fixed inset-0 z-40 h-full w-full" aria-hidden="true">
 			<defs>
 				<radialGradient id="spartan-spotlight" cx="0.5502" cy="0.3146" r="0.686">
 					<stop offset="0" stop-color="#d9d9d9" stop-opacity="0.078" />

--- a/apps/app/src/app/app.ts
+++ b/apps/app/src/app/app.ts
@@ -10,9 +10,18 @@ import { Header } from './shared/header/header';
 		class: 'bg-background relative z-10 flex min-h-svh flex-col',
 	},
 	template: `
-		<div
-			class="pointer-events-none fixed top-0 left-0 z-40 h-[1380px] w-[560px] -translate-y-[350px] -rotate-45 bg-radial-(--spotlight-gradient)"
-		></div>
+		<svg class="pointer-events-none fixed inset-0 z-40 h-full w-full" width="100%" height="100%" aria-hidden="true">
+			<defs>
+				<radialGradient id="spartan-spotlight" cx="0.5502" cy="0.3146" r="0.686">
+					<stop offset="0" stop-color="#d9d9d9" stop-opacity="0.078" />
+					<stop offset="0.5" stop-color="#8c8c8c" stop-opacity="0.02" />
+					<stop offset="0.8" stop-color="#737373" stop-opacity="0" />
+				</radialGradient>
+			</defs>
+			<g transform="translate(0 -350) rotate(-45 280 690)">
+				<rect x="0" y="0" width="560" height="1380" fill="url(#spartan-spotlight)" />
+			</g>
+		</svg>
 		<spartan-header id="spartan-header" />
 		<main class="flex flex-1 flex-col" id="spartan-main">
 			<router-outlet />

--- a/apps/app/src/styles.css
+++ b/apps/app/src/styles.css
@@ -50,7 +50,6 @@
 
 	--color-surface: var(--surface);
 	--color-surface-foreground: var(--surface-foreground);
-	--spotlight-gradient: 68.54% 68.72% at 55.02% 31.46%, #d9d9d914 0, #8c8c8c05 50%, #73737300 80%;
 }
 
 :root {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

<!-- This change lives in the docs app (apps/app); no published package is modified. -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1532

On iOS Safari, the dialog/overlay backdrop close animation appears to play twice,
producing a visible flicker (most noticeable on the first couple of consecutive
closes). The docs-app hero "spotlight" is a `position: fixed` div positioned with
a CSS transform (`-rotate-45 -translate-y-[350px]`), which promotes it to its own
GPU compositing layer. When a dialog/overlay backdrop mounts and then unmounts,
Safari drops and repaints that transformed layer one frame late, which reads as
the backdrop animation flashing twice. It does not reproduce on Chromium.
Confirmed on-device: toggling the spotlight's transform off stops the flicker,
while layer hints (`isolation`/`will-change`/`translateZ`) do not.

## What is the new behavior?

The spotlight is rendered as an inline `<svg>` with the rotation baked into SVG
coordinate space (`<g transform>`), so the DOM element carries no CSS transform.
Safari no longer has a transformed layer to re-composite when overlays mount or
unmount, and the flicker is gone. The gradient geometry and colors are reproduced
1:1, so the spotlight looks identical. The now-unused `--spotlight-gradient`
custom property is removed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Verified on a physical iOS Safari device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refreshed the app’s full-screen background spotlight effect by switching to an inline SVG-based rendering for a more consistent visual alignment.
  * Cleaned up the related spotlight styling so the spotlight appearance is driven by the new SVG implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->