### PR TITLE
fix(sidebar): guard matchMedia for ssr-like windows without it

### DIFF
--- a/libs/cli/src/generators/ui/libs/sidebar/files/lib/hlm-sidebar.service.ts.template
+++ b/libs/cli/src/generators/ui/libs/sidebar/files/lib/hlm-sidebar.service.ts.template
@@ -40,7 +40,7 @@ export class HlmSidebarService {
 		this.restoreStateFromCookie();
 
 		afterNextRender(() => {
-			if (!this._window) return;
+			if (!this._window || typeof this._window.matchMedia !== 'function') return;
 
 			// Initialize MediaQueryList
 			this._mediaQuery = this._window.matchMedia(`(max-width: ${this._config.mobileBreakpoint})`);

--- a/libs/helm/sidebar/src/lib/hlm-sidebar.service.ts
+++ b/libs/helm/sidebar/src/lib/hlm-sidebar.service.ts
@@ -40,7 +40,7 @@ export class HlmSidebarService {
 		this.restoreStateFromCookie();
 
 		afterNextRender(() => {
-			if (!this._window) return;
+			if (!this._window || typeof this._window.matchMedia !== 'function') return;
 
 			// Initialize MediaQueryList
 			this._mediaQuery = this._window.matchMedia(`(max-width: ${this._config.mobileBreakpoint})`);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [x] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [x] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Under Analog's dev SSR, `HlmSidebarService` crashes the render with
`TypeError: this._window.matchMedia is not a function`. `afterNextRender` runs in
that environment, where `document.defaultView` exists but is a server shim
without `matchMedia` — so the existing `if (!this._window) return` guard passes
and the next line calls a method that isn't there.

## What is the new behavior?

The guard now also requires `matchMedia` to be a function before initializing the
media query and wiring up listeners, so the service no-ops cleanly when the
window shim lacks browser APIs. The same change is mirrored into the cli
generator template so generated code stays in sync.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sidebar service compatibility by strengthening environment detection. The sidebar now properly validates browser capabilities before initializing, preventing errors in environments with limited media-query support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->