### PR TITLE
fix(navigation-menu): keep keyboard focus within the menu when tabbing

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/navigation-menu/navigation-menu.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/navigation-menu/navigation-menu.cy.ts
@@ -1,0 +1,123 @@
+// cypress-real-events sends keyboard input as CDP `rawKeyDown`, which is dropped when the spec runs
+// without window focus. Our navigation-menu moves focus imperatively from its Tab/Arrow handlers
+// (preventDefault + .focus()), so dispatching a native KeyboardEvent on the focused element
+// exercises the real behaviour reliably. A native event (not jQuery's .trigger) is required so
+// Angular's `keydown.arrowDown` host binding sees the right `event.key`.
+const TAB: KeyboardEventInit = { key: 'Tab' };
+const pressKey = (init: KeyboardEventInit) =>
+	cy.focused().then(($el) => {
+		$el[0].dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+	});
+
+describe('navigation-menu', () => {
+	const checkA11y = () =>
+		cy.checkA11y('#storybook-root', {
+			rules: {
+				'page-has-heading-one': { enabled: false },
+				'landmark-one-main': { enabled: false },
+			},
+		});
+
+	const openHome = () => {
+		cy.findByRole('button', { name: /home/i }).realHover();
+		cy.findByRole('button', { name: /home/i }).should('have.attr', 'aria-expanded', 'true');
+	};
+
+	describe('default (open on hover)', () => {
+		beforeEach(() => {
+			cy.visit('/iframe.html?id=navigation-menu--default');
+			cy.injectAxe();
+			cy.viewport(1000, 1000);
+		});
+
+		it('has no a11y violations and wires aria-expanded/controls only while open', () => {
+			checkA11y();
+
+			cy.findByRole('button', { name: /home/i })
+				.should('have.attr', 'aria-expanded', 'false')
+				.and('not.have.attr', 'aria-controls');
+
+			openHome();
+			cy.findByRole('link', { name: /introduction/i }).should('be.visible');
+			cy.findByRole('button', { name: /home/i }).should('have.attr', 'aria-controls');
+		});
+
+		it('renders a single chevron per trigger', () => {
+			cy.findByRole('button', { name: /home/i }).find('ng-icon').should('have.length', 1);
+		});
+
+		it('enters the panel with ArrowDown', () => {
+			openHome();
+
+			cy.findByRole('button', { name: /home/i }).focus();
+			pressKey({ key: 'ArrowDown' });
+			cy.findByRole('link', { name: /spartan\.ng/i }).should('be.focused');
+		});
+
+		it('enters the panel when tabbing from the trigger', () => {
+			openHome();
+
+			cy.findByRole('button', { name: /home/i }).focus();
+			pressKey(TAB);
+			cy.findByRole('link', { name: /spartan\.ng/i }).should('be.focused');
+		});
+
+		it('walks through the panel items with Tab / Shift+Tab', () => {
+			openHome();
+
+			cy.findByRole('link', { name: /spartan\.ng/i }).focus();
+			pressKey(TAB);
+			cy.findByRole('link', { name: /introduction/i }).should('be.focused');
+
+			pressKey({ ...TAB, shiftKey: true });
+			cy.findByRole('link', { name: /spartan\.ng/i }).should('be.focused');
+		});
+
+		it('keeps focus in the menu when tabbing past the last item (issue #1484)', () => {
+			openHome();
+
+			// Tab once more after the final dropdown link - this used to drop focus out of the nav.
+			cy.findByRole('link', { name: /typography/i }).focus();
+			pressKey(TAB);
+
+			cy.findByRole('button', { name: /components/i }).should('be.focused');
+			cy.findByRole('button', { name: /home/i }).should('have.attr', 'aria-expanded', 'false');
+		});
+
+		it('returns focus to the trigger on Shift+Tab from the first item', () => {
+			openHome();
+
+			cy.findByRole('link', { name: /spartan\.ng/i }).focus();
+			pressKey({ ...TAB, shiftKey: true });
+			cy.findByRole('button', { name: /home/i }).should('be.focused');
+		});
+
+		it('closes on Escape and restores focus to the trigger', () => {
+			openHome();
+
+			cy.findByRole('link', { name: /introduction/i }).focus();
+			pressKey({ key: 'Escape' });
+
+			cy.findByRole('button', { name: /home/i }).should('be.focused').and('have.attr', 'aria-expanded', 'false');
+		});
+	});
+
+	describe('click to open', () => {
+		beforeEach(() => {
+			cy.visit('/iframe.html?id=navigation-menu--click-to-open');
+			cy.injectAxe();
+			cy.viewport(1000, 1000);
+		});
+
+		it('opens on click and toggles closed on a second click', () => {
+			cy.findByRole('button', { name: /home/i }).should('have.attr', 'aria-expanded', 'false');
+
+			cy.findByRole('button', { name: /home/i }).click();
+			cy.findByRole('button', { name: /home/i }).should('have.attr', 'aria-expanded', 'true');
+			cy.findByRole('link', { name: /introduction/i }).should('be.visible');
+
+			cy.findByRole('button', { name: /home/i }).click();
+			cy.findByRole('button', { name: /home/i }).should('have.attr', 'aria-expanded', 'false');
+		});
+	});
+});

--- a/apps/ui-storybook/stories/navigation-menu.stories.ts
+++ b/apps/ui-storybook/stories/navigation-menu.stories.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { lucideChevronDown, lucideCircle, lucideCircleCheck, lucideCircleHelp, lucideLink } from '@ng-icons/lucide';
+import { lucideCircle, lucideCircleCheck, lucideCircleHelp, lucideLink } from '@ng-icons/lucide';
 
 import { HlmNavigationMenuImports } from '@spartan-ng/helm/navigation-menu';
 import type { Meta, StoryObj } from '@storybook/angular';
@@ -9,18 +9,12 @@ import { moduleMetadata } from '@storybook/angular';
 @Component({
 	selector: 'navigation-menu-example',
 	imports: [HlmNavigationMenuImports, NgIcon],
-	providers: [provideIcons({ lucideChevronDown, lucideLink, lucideCircle, lucideCircleHelp, lucideCircleCheck })],
+	providers: [provideIcons({ lucideLink, lucideCircle, lucideCircleHelp, lucideCircleCheck })],
 	template: `
 		<nav hlmNavigationMenu>
 			<ul hlmNavigationMenuList class="flex-wrap">
 				<li hlmNavigationMenuItem>
-					<button hlmNavigationMenuTrigger>
-						Home
-						<ng-icon
-							name="lucideChevronDown"
-							class="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
-						/>
-					</button>
+					<button hlmNavigationMenuTrigger>Home</button>
 					<hlm-navigation-menu-content *hlmNavigationMenuPortal>
 						<ul class="grid gap-2 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
 							<li class="row-span-3">
@@ -66,13 +60,7 @@ import { moduleMetadata } from '@storybook/angular';
 
 				<!-- Components Menu -->
 				<li hlmNavigationMenuItem>
-					<button hlmNavigationMenuTrigger>
-						Components
-						<ng-icon
-							name="lucideChevronDown"
-							class="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
-						/>
-					</button>
+					<button hlmNavigationMenuTrigger>Components</button>
 					<hlm-navigation-menu-content *hlmNavigationMenuPortal>
 						<ul class="grid gap-2 sm:w-[400px] md:w-[500px] md:grid-cols-2 lg:w-[600px]">
 							@for (component of components; track $index) {
@@ -94,13 +82,7 @@ import { moduleMetadata } from '@storybook/angular';
 				</li>
 
 				<li hlmNavigationMenuItem class="hidden md:block">
-					<button hlmNavigationMenuTrigger>
-						List
-						<ng-icon
-							name="lucideChevronDown"
-							class="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
-						/>
-					</button>
+					<button hlmNavigationMenuTrigger>List</button>
 					<hlm-navigation-menu-content *hlmNavigationMenuPortal>
 						<ul class="grid w-[300px] gap-4">
 							<li>
@@ -122,13 +104,7 @@ import { moduleMetadata } from '@storybook/angular';
 				</li>
 
 				<li hlmNavigationMenuItem class="hidden md:block">
-					<button hlmNavigationMenuTrigger>
-						Simple
-						<ng-icon
-							name="lucideChevronDown"
-							class="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
-						/>
-					</button>
+					<button hlmNavigationMenuTrigger>Simple</button>
 					<hlm-navigation-menu-content *hlmNavigationMenuPortal>
 						<ul class="grid w-[200px] gap-4">
 							<li>
@@ -141,13 +117,7 @@ import { moduleMetadata } from '@storybook/angular';
 				</li>
 
 				<li hlmNavigationMenuItem class="hidden md:block">
-					<button hlmNavigationMenuTrigger>
-						With Icon
-						<ng-icon
-							name="lucideChevronDown"
-							class="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
-						/>
-					</button>
+					<button hlmNavigationMenuTrigger>With Icon</button>
 					<hlm-navigation-menu-content *hlmNavigationMenuPortal>
 						<ul class="grid w-[200px] gap-4">
 							<li>
@@ -209,18 +179,12 @@ class NavigationMenuExample {
 @Component({
 	selector: 'navigation-menu-click-to-open-example',
 	imports: [HlmNavigationMenuImports],
-	providers: [provideIcons({ lucideChevronDown, lucideLink, lucideCircle, lucideCircleHelp, lucideCircleCheck })],
+	providers: [provideIcons({ lucideLink, lucideCircle, lucideCircleHelp, lucideCircleCheck })],
 	template: `
 		<nav hlmNavigationMenu openOn="click">
 			<ul hlmNavigationMenuList class="flex-wrap">
 				<li hlmNavigationMenuItem>
-					<button hlmNavigationMenuTrigger>
-						Home
-						<ng-icon
-							name="lucideChevronDown"
-							class="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
-						/>
-					</button>
+					<button hlmNavigationMenuTrigger>Home</button>
 					<hlm-navigation-menu-content *hlmNavigationMenuPortal>
 						<ul class="grid gap-2 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
 							<li class="row-span-3">
@@ -266,13 +230,7 @@ class NavigationMenuExample {
 
 				<!-- Components Menu -->
 				<li hlmNavigationMenuItem>
-					<button hlmNavigationMenuTrigger>
-						Components
-						<ng-icon
-							name="lucideChevronDown"
-							class="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
-						/>
-					</button>
+					<button hlmNavigationMenuTrigger>Components</button>
 					<hlm-navigation-menu-content *hlmNavigationMenuPortal>
 						<ul class="grid gap-2 sm:w-[400px] md:w-[500px] md:grid-cols-2 lg:w-[600px]">
 							@for (component of components; track $index) {
@@ -294,13 +252,7 @@ class NavigationMenuExample {
 				</li>
 
 				<li hlmNavigationMenuItem class="hidden md:block">
-					<button hlmNavigationMenuTrigger>
-						List
-						<ng-icon
-							name="lucideChevronDown"
-							class="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
-						/>
-					</button>
+					<button hlmNavigationMenuTrigger>List</button>
 					<hlm-navigation-menu-content *hlmNavigationMenuPortal>
 						<ul class="grid w-[300px] gap-4">
 							<li>
@@ -322,13 +274,7 @@ class NavigationMenuExample {
 				</li>
 
 				<li hlmNavigationMenuItem class="hidden md:block">
-					<button hlmNavigationMenuTrigger>
-						Simple
-						<ng-icon
-							name="lucideChevronDown"
-							class="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
-						/>
-					</button>
+					<button hlmNavigationMenuTrigger>Simple</button>
 					<hlm-navigation-menu-content *hlmNavigationMenuPortal>
 						<ul class="grid w-[200px] gap-4">
 							<li>
@@ -341,13 +287,7 @@ class NavigationMenuExample {
 				</li>
 
 				<li hlmNavigationMenuItem class="hidden md:block">
-					<button hlmNavigationMenuTrigger>
-						With Icon
-						<ng-icon
-							name="lucideChevronDown"
-							class="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
-						/>
-					</button>
+					<button hlmNavigationMenuTrigger>With Icon</button>
 					<hlm-navigation-menu-content *hlmNavigationMenuPortal>
 						<ul class="grid w-[200px] gap-4">
 							<li>

--- a/libs/brain/navigation-menu/src/lib/brn-navigation-menu-content.service.ts
+++ b/libs/brain/navigation-menu/src/lib/brn-navigation-menu-content.service.ts
@@ -85,7 +85,7 @@ export class BrnNavigationMenuContentService {
 
 	private readonly _overlayHoveredObservables$ = new BehaviorSubject<Observable<boolean> | undefined>(undefined);
 
-	private readonly _overlayShiftTabObservables$ = new BehaviorSubject<Observable<KeyboardEvent> | undefined>(undefined);
+	private readonly _overlayTabObservables$ = new BehaviorSubject<Observable<KeyboardEvent> | undefined>(undefined);
 
 	private readonly _overlayEscapeObservables$ = new BehaviorSubject<Observable<KeyboardEvent> | undefined>(undefined);
 
@@ -94,22 +94,14 @@ export class BrnNavigationMenuContentService {
 		share(),
 	);
 
-	private readonly _shiftTabPressed$ = this._overlayShiftTabObservables$.pipe(
-		switchMap((contentFocused$) => (contentFocused$ !== undefined ? contentFocused$ : of())),
+	/** Emits `Tab`/`Shift+Tab` keydowns bubbling up the content panel so the trigger can manage focus. */
+	public readonly tabPressed$ = this._overlayTabObservables$.pipe(
+		switchMap((tab$) => (tab$ !== undefined ? tab$ : of())),
 	);
 
 	public readonly escapePressed$ = this._overlayEscapeObservables$.pipe(
 		switchMap((contentFocused$) => (contentFocused$ !== undefined ? contentFocused$ : of())),
 	);
-
-	constructor() {
-		this._shiftTabPressed$.pipe(takeUntil(this._destroyed$)).subscribe((e) => {
-			if (this._config.attachTo?.nativeElement) {
-				e.preventDefault();
-				this._config.attachTo.nativeElement.focus();
-			}
-		});
-	}
 
 	public setConfig(config: BrnNavigationMenuContentOptions) {
 		this._config = config;
@@ -197,9 +189,10 @@ export class BrnNavigationMenuContentService {
 			createHoverObservable(this._overlayRef.hostElement, this._zone, this._destroyed$).pipe(map((e) => e.hover)),
 		);
 
-		this._overlayShiftTabObservables$.next(
+		this._overlayTabObservables$.next(
 			fromEvent<KeyboardEvent>(contentEl, 'keydown').pipe(
-				switchMap((e) => (e.key === 'Tab' && e.shiftKey && e.target === this.contentEl() ? of(e) : of())),
+				// Forward Tab/Shift+Tab without meta modifiers; the trigger decides how to keep focus in the menu
+				switchMap((e) => (e.key === 'Tab' && !e.altKey && !e.ctrlKey && !e.metaKey ? of(e) : of())),
 				takeUntil(this._destroyed$),
 			),
 		);

--- a/libs/brain/navigation-menu/src/lib/brn-navigation-menu-tabbable.ts
+++ b/libs/brain/navigation-menu/src/lib/brn-navigation-menu-tabbable.ts
@@ -1,0 +1,26 @@
+/** Returns the tabbable elements inside `container`, in DOM order. Ported from Radix's navigation menu. */
+export function getTabbableCandidates(container: HTMLElement): HTMLElement[] {
+	const nodes: HTMLElement[] = [];
+	// `.tabIndex` reflects the runtime's view of tabbability, so it covers links/buttons/[tabindex] alike.
+	const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, {
+		acceptNode: (node: unknown) => {
+			const el = node as HTMLElement & { type?: string; disabled?: boolean };
+			const isHiddenInput = el.tagName === 'INPUT' && el.type === 'hidden';
+			if (el.disabled || el.hidden || isHiddenInput) return NodeFilter.FILTER_SKIP;
+			return el.tabIndex >= 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+		},
+	});
+	while (walker.nextNode()) nodes.push(walker.currentNode as HTMLElement);
+	return nodes;
+}
+
+/** Focuses the first candidate that can take focus; returns whether focus landed on a candidate. */
+export function focusFirst(candidates: HTMLElement[]): boolean {
+	const previouslyFocused = document.activeElement;
+	return candidates.some((candidate) => {
+		// already where we want to be - stop walking
+		if (candidate === previouslyFocused) return true;
+		candidate.focus();
+		return document.activeElement !== previouslyFocused;
+	});
+}

--- a/libs/brain/navigation-menu/src/lib/brn-navigation-menu-trigger.ts
+++ b/libs/brain/navigation-menu/src/lib/brn-navigation-menu-trigger.ts
@@ -263,6 +263,9 @@ export class BrnNavigationMenuTrigger implements OnInit, OnDestroy, FocusableOpt
 		if (orientation === 'vertical' && dir && this._dir() !== dir) return;
 
 		e.preventDefault();
+		// Stop the event from reaching the nav's CDK key manager, which would otherwise
+		// read event.keyCode and move focus to the next trigger, overriding the entry.
+		e.stopPropagation();
 		this._focusFirstContent();
 	}
 

--- a/libs/brain/navigation-menu/src/lib/brn-navigation-menu-trigger.ts
+++ b/libs/brain/navigation-menu/src/lib/brn-navigation-menu-trigger.ts
@@ -34,6 +34,7 @@ import { BrnNavigationMenuContentService } from './brn-navigation-menu-content.s
 import { BrnNavigationMenuItem } from './brn-navigation-menu-item';
 import { provideBrnNavigationMenuFocusable } from './brn-navigation-menu-item-focusable.token';
 import { injectBrnNavigationMenuItem } from './brn-navigation-menu-item.token';
+import { focusFirst, getTabbableCandidates } from './brn-navigation-menu-tabbable';
 import { injectBrnNavigationMenu } from './brn-navigation-menu.token';
 
 interface TriggerEvent {
@@ -54,11 +55,14 @@ interface TriggerEvent {
 	host: {
 		'(keydown.escape)': 'onEscape($event)',
 		'(keydown.tab)': 'onTab($event)',
+		'(keydown.arrowDown)': 'onEntryKey($event, "horizontal")',
+		'(keydown.arrowRight)': 'onEntryKey($event, "vertical", "ltr")',
+		'(keydown.arrowLeft)': 'onEntryKey($event, "vertical", "rtl")',
 		'(focus)': 'handleFocus()',
 		'[id]': '_id',
 		'[attr.data-state]': '_state()',
 		'[attr.aria-expanded]': '_isActive()',
-		'[attr.aria-controls]': '_contentId',
+		'[attr.aria-controls]': '_ariaControls()',
 		'data-slot': 'navigation-menu-trigger',
 	},
 })
@@ -81,6 +85,9 @@ export class BrnNavigationMenuTrigger implements OnInit, OnDestroy, FocusableOpt
 	private readonly _parentNavMenu = this._navigationMenu.parentNavMenu;
 
 	protected readonly _isActive = this._navigationMenuItem.isActive;
+
+	// Only reference the content panel while it is open, matching Radix's aria-controls behaviour.
+	protected readonly _ariaControls = computed(() => (this._isActive() ? this._contentId : null));
 
 	protected readonly _contentId = this._contentService.id;
 
@@ -221,6 +228,8 @@ export class BrnNavigationMenuTrigger implements OnInit, OnDestroy, FocusableOpt
 			this._el.nativeElement.focus();
 			this._deactivate();
 		});
+
+		this._contentService.tabPressed$.pipe(takeUntil(this._destroy$)).subscribe((e) => this._handleContentTab(e));
 	}
 
 	public ngOnDestroy() {
@@ -243,12 +252,68 @@ export class BrnNavigationMenuTrigger implements OnInit, OnDestroy, FocusableOpt
 
 		if (contentEl && !hasModifierKey(e as KeyboardEvent)) {
 			e.preventDefault();
-			contentEl.focus();
+			this._focusFirstContent();
 		}
+	}
+
+	/** Arrow-key entry into the open content: ArrowDown (horizontal) or ArrowRight/Left (vertical, dir-aware). */
+	protected onEntryKey(e: Event, orientation: 'horizontal' | 'vertical', dir?: 'ltr' | 'rtl') {
+		if (!this._navigationMenuItem.isActive()) return;
+		if (this._orientation() !== orientation) return;
+		if (orientation === 'vertical' && dir && this._dir() !== dir) return;
+
+		e.preventDefault();
+		this._focusFirstContent();
 	}
 
 	protected onEscape(e: Event) {
 		e.preventDefault();
+		this._deactivate();
+	}
+
+	private _focusFirstContent() {
+		const contentEl = this._contentService.contentEl();
+		if (!contentEl) return;
+
+		const candidates = getTabbableCandidates(contentEl);
+		if (candidates.length) {
+			focusFirst(candidates);
+		} else {
+			contentEl.focus();
+		}
+	}
+
+	/** Keeps keyboard focus inside the menu when tabbing across the content edges (issue #1484). */
+	private _handleContentTab(event: KeyboardEvent) {
+		const contentEl = this._contentService.contentEl();
+		if (!contentEl) return;
+
+		const candidates = getTabbableCandidates(contentEl);
+		const focused = document.activeElement as HTMLElement | null;
+		const index = focused ? candidates.indexOf(focused) : -1;
+
+		if (event.shiftKey) {
+			const previous = index > 0 ? candidates.slice(0, index).reverse() : [];
+			if (previous.length && focusFirst(previous)) {
+				event.preventDefault();
+				return;
+			}
+			// at the first item or on the content container - return to the trigger, keep content open
+			event.preventDefault();
+			this._el.nativeElement.focus();
+			return;
+		}
+
+		const next = index >= 0 ? candidates.slice(index + 1) : candidates;
+		if (next.length && focusFirst(next)) {
+			event.preventDefault();
+			return;
+		}
+
+		// past the last item - hand focus to the next top-level item and close the panel
+		if (this._navigationMenu.focusSibling(this, 1)) {
+			event.preventDefault();
+		}
 		this._deactivate();
 	}
 

--- a/libs/brain/navigation-menu/src/lib/brn-navigation-menu.spec.ts
+++ b/libs/brain/navigation-menu/src/lib/brn-navigation-menu.spec.ts
@@ -1,0 +1,319 @@
+import { ChangeDetectionStrategy, Component, signal, viewChild } from '@angular/core';
+import { render, type RenderResult, screen, waitFor } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { BrnNavigationMenu } from './brn-navigation-menu';
+import { BrnNavigationMenuContent } from './brn-navigation-menu-content';
+import { BrnNavigationMenuItem } from './brn-navigation-menu-item';
+import { BrnNavigationMenuLink } from './brn-navigation-menu-link';
+import { BrnNavigationMenuList } from './brn-navigation-menu-list';
+import { BrnNavigationMenuTrigger } from './brn-navigation-menu-trigger';
+
+const BrnNavigationMenuImports = [
+	BrnNavigationMenu,
+	BrnNavigationMenuItem,
+	BrnNavigationMenuList,
+	BrnNavigationMenuTrigger,
+	BrnNavigationMenuContent,
+	BrnNavigationMenuLink,
+] as const;
+
+@Component({
+	selector: 'brn-navigation-menu-spec',
+	imports: [BrnNavigationMenuImports],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<nav brnNavigationMenu [orientation]="orientation()">
+			<ul brnNavigationMenuList>
+				<li brnNavigationMenuItem id="item1">
+					<button brnNavigationMenuTrigger data-testid="trigger1">One</button>
+					<div *brnNavigationMenuContent data-testid="content1">
+						<a brnNavigationMenuLink href="#" data-testid="c1-link1">C1 L1</a>
+						<a brnNavigationMenuLink href="#" data-testid="c1-link2">C1 L2</a>
+						<a brnNavigationMenuLink href="#" data-testid="c1-link3">C1 L3</a>
+					</div>
+				</li>
+				<li brnNavigationMenuItem id="item2">
+					<button brnNavigationMenuTrigger data-testid="trigger2" [disabled]="disabledTwo()">Two</button>
+					<div *brnNavigationMenuContent data-testid="content2">
+						<a brnNavigationMenuLink href="#" data-testid="c2-link1">C2 L1</a>
+						<a brnNavigationMenuLink href="#" data-testid="c2-link2">C2 L2</a>
+					</div>
+				</li>
+				<li brnNavigationMenuItem id="item3">
+					<a brnNavigationMenuLink href="#" data-testid="link3">Three</a>
+				</li>
+			</ul>
+		</nav>
+	`,
+})
+class NavigationMenuSpec {
+	public readonly orientation = signal<'horizontal' | 'vertical'>('horizontal');
+	public readonly disabledTwo = signal(false);
+	public readonly nav = viewChild.required(BrnNavigationMenu);
+}
+
+@Component({
+	selector: 'brn-nested-navigation-menu-spec',
+	imports: [BrnNavigationMenuImports],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<nav brnNavigationMenu>
+			<ul brnNavigationMenuList>
+				<li brnNavigationMenuItem id="root1">
+					<button brnNavigationMenuTrigger data-testid="root-trigger">Root</button>
+					<div *brnNavigationMenuContent data-testid="root-content">
+						<nav brnNavigationMenu orientation="vertical">
+							<ul brnNavigationMenuList>
+								<li brnNavigationMenuItem id="sub1">
+									<button brnNavigationMenuTrigger data-testid="sub-trigger1">Sub One</button>
+									<div *brnNavigationMenuContent data-testid="sub-content1">
+										<a brnNavigationMenuLink href="#" data-testid="s1-link1">S1 L1</a>
+										<a brnNavigationMenuLink href="#" data-testid="s1-link2">S1 L2</a>
+									</div>
+								</li>
+								<li brnNavigationMenuItem id="sub2">
+									<button brnNavigationMenuTrigger data-testid="sub-trigger2">Sub Two</button>
+									<div *brnNavigationMenuContent data-testid="sub-content2">
+										<a brnNavigationMenuLink href="#" data-testid="s2-link1">S2 L1</a>
+									</div>
+								</li>
+							</ul>
+						</nav>
+					</div>
+				</li>
+			</ul>
+		</nav>
+	`,
+})
+class NestedNavigationMenuSpec {}
+
+function key(target: HTMLElement, init: Partial<KeyboardEventInit> & { key: string }) {
+	target.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+}
+
+describe('BrnNavigationMenu', () => {
+	let view: RenderResult<NavigationMenuSpec>;
+
+	const setup = async (orientation: 'horizontal' | 'vertical' = 'horizontal') => {
+		view = await render(NavigationMenuSpec);
+		if (orientation !== 'horizontal') {
+			view.fixture.componentInstance.orientation.set(orientation);
+			view.detectChanges();
+		}
+		return view;
+	};
+
+	// Opens an item by driving the controlled value, then waits for the portaled content to attach.
+	const open = async (itemId: string, contentTestId: string) => {
+		view.fixture.componentInstance.nav().value.set(itemId);
+		view.detectChanges();
+		return screen.findByTestId(contentTestId);
+	};
+
+	afterEach(() => {
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	describe('aria wiring', () => {
+		it('does not reference a content panel while closed', async () => {
+			await setup();
+			const trigger = screen.getByTestId('trigger1');
+
+			expect(screen.queryByTestId('content1')).not.toBeInTheDocument();
+			expect(trigger).toHaveAttribute('aria-expanded', 'false');
+			expect(trigger).not.toHaveAttribute('aria-controls');
+		});
+
+		it('references the rendered content while open and labels it by the trigger', async () => {
+			await setup();
+			const trigger = screen.getByTestId('trigger1');
+			const content = await open('item1', 'content1');
+
+			expect(trigger).toHaveAttribute('aria-expanded', 'true');
+			expect(trigger).toHaveAttribute('aria-controls', content.id);
+			expect(content).toHaveAttribute('aria-labelledby', trigger.id);
+		});
+
+		it('exposes orientation and a navigation label on the root', async () => {
+			await setup();
+			const nav = screen.getByRole('navigation');
+			expect(nav).toHaveAttribute('aria-label', 'Main');
+			expect(nav).toHaveAttribute('data-orientation', 'horizontal');
+		});
+	});
+
+	describe('open / close', () => {
+		it('toggles the panel on trigger click', async () => {
+			const user = userEvent.setup();
+			await setup();
+			const trigger = screen.getByTestId('trigger1');
+
+			await user.click(trigger);
+			expect(await screen.findByTestId('content1')).toBeInTheDocument();
+
+			await user.click(trigger);
+			await waitFor(() => expect(trigger).toHaveAttribute('aria-expanded', 'false'));
+		});
+
+		it('closes on Escape and returns focus to the trigger', async () => {
+			await setup();
+			const trigger = screen.getByTestId('trigger1');
+			await open('item1', 'content1');
+
+			const firstLink = screen.getByTestId('c1-link1');
+			firstLink.focus();
+			key(firstLink, { key: 'Escape' });
+			view.detectChanges();
+
+			expect(document.activeElement).toBe(trigger);
+			expect(trigger).toHaveAttribute('aria-expanded', 'false');
+		});
+	});
+
+	describe('keyboard entry into content', () => {
+		it('moves focus into the panel when tabbing from the trigger', async () => {
+			await setup();
+			const trigger = screen.getByTestId('trigger1');
+			await open('item1', 'content1');
+
+			trigger.focus();
+			key(trigger, { key: 'Tab' });
+
+			expect(document.activeElement).toBe(screen.getByTestId('c1-link1'));
+		});
+
+		it('enters the panel with ArrowDown in a horizontal menu', async () => {
+			await setup('horizontal');
+			const trigger = screen.getByTestId('trigger1');
+			await open('item1', 'content1');
+
+			trigger.focus();
+			key(trigger, { key: 'ArrowDown' });
+
+			expect(document.activeElement).toBe(screen.getByTestId('c1-link1'));
+		});
+
+		it('enters the panel with ArrowRight in a vertical menu', async () => {
+			await setup('vertical');
+			const trigger = screen.getByTestId('trigger1');
+			await open('item1', 'content1');
+
+			trigger.focus();
+			key(trigger, { key: 'ArrowRight' });
+
+			expect(document.activeElement).toBe(screen.getByTestId('c1-link1'));
+		});
+	});
+
+	describe('tabbing within content', () => {
+		it('walks forward to the next item', async () => {
+			await setup();
+			await open('item1', 'content1');
+
+			const first = screen.getByTestId('c1-link1');
+			first.focus();
+			key(first, { key: 'Tab' });
+
+			expect(document.activeElement).toBe(screen.getByTestId('c1-link2'));
+		});
+
+		it('walks backward to the previous item', async () => {
+			await setup();
+			await open('item1', 'content1');
+
+			const second = screen.getByTestId('c1-link2');
+			second.focus();
+			key(second, { key: 'Tab', shiftKey: true });
+
+			expect(document.activeElement).toBe(screen.getByTestId('c1-link1'));
+		});
+
+		it('returns focus to the trigger on Shift+Tab from the first item', async () => {
+			await setup();
+			const trigger = screen.getByTestId('trigger1');
+			await open('item1', 'content1');
+
+			const first = screen.getByTestId('c1-link1');
+			first.focus();
+			key(first, { key: 'Tab', shiftKey: true });
+
+			expect(document.activeElement).toBe(trigger);
+		});
+	});
+
+	describe('tabbing out of content (issue #1484)', () => {
+		it('moves focus to the next top-level trigger after the last item', async () => {
+			await setup();
+			await open('item1', 'content1');
+
+			const last = screen.getByTestId('c1-link3');
+			last.focus();
+			key(last, { key: 'Tab' });
+			view.detectChanges();
+
+			// Focus stays in the menu flow on the next trigger instead of escaping to the page.
+			expect(document.activeElement).toBe(screen.getByTestId('trigger2'));
+			expect(screen.getByTestId('trigger1')).toHaveAttribute('aria-expanded', 'false');
+		});
+
+		it('skips a disabled sibling when tabbing out', async () => {
+			await setup();
+			view.fixture.componentInstance.disabledTwo.set(true);
+			view.detectChanges();
+			await open('item1', 'content1');
+
+			const last = screen.getByTestId('c1-link3');
+			last.focus();
+			key(last, { key: 'Tab' });
+			view.detectChanges();
+
+			expect(document.activeElement).toBe(screen.getByTestId('link3'));
+		});
+	});
+});
+
+describe('BrnNavigationMenu (nested)', () => {
+	let nestedView: RenderResult<NestedNavigationMenuSpec>;
+
+	// Native click() toggles the panel deterministically without the pointer/hover side effects of userEvent.
+	const click = async (triggerTestId: string, contentTestId: string) => {
+		screen.getByTestId(triggerTestId).click();
+		return screen.findByTestId(contentTestId);
+	};
+
+	afterEach(() => {
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	it('reveals the nested menu when the root panel opens', async () => {
+		nestedView = await render(NestedNavigationMenuSpec);
+
+		await click('root-trigger', 'root-content');
+		expect(screen.getByTestId('sub-trigger1')).toBeInTheDocument();
+		expect(screen.getByTestId('sub-trigger2')).toBeInTheDocument();
+	});
+
+	it('opens a nested panel and keeps the root panel open', async () => {
+		nestedView = await render(NestedNavigationMenuSpec);
+
+		await click('root-trigger', 'root-content');
+		await click('sub-trigger1', 'sub-content1');
+
+		expect(screen.getByTestId('root-content')).toBeInTheDocument();
+		expect(screen.getByTestId('sub-trigger1')).toHaveAttribute('aria-expanded', 'true');
+	});
+
+	it('tabs out of a nested panel to the next nested trigger (issue #1484)', async () => {
+		nestedView = await render(NestedNavigationMenuSpec);
+
+		await click('root-trigger', 'root-content');
+		await click('sub-trigger1', 'sub-content1');
+
+		const last = screen.getByTestId('s1-link2');
+		last.focus();
+		key(last, { key: 'Tab' });
+		nestedView.detectChanges();
+
+		expect(document.activeElement).toBe(screen.getByTestId('sub-trigger2'));
+	});
+});

--- a/libs/brain/navigation-menu/src/lib/brn-navigation-menu.spec.ts
+++ b/libs/brain/navigation-menu/src/lib/brn-navigation-menu.spec.ts
@@ -88,7 +88,13 @@ class NavigationMenuSpec {
 class NestedNavigationMenuSpec {}
 
 function key(target: HTMLElement, init: Partial<KeyboardEventInit> & { key: string }) {
-	target.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+	const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init });
+	// Browsers ignore `keyCode` from the constructor, but the CDK key manager reads it; pin it
+	// explicitly so a test can exercise the path a real keypress would take.
+	if (init.keyCode !== undefined) {
+		Object.defineProperty(event, 'keyCode', { value: init.keyCode });
+	}
+	target.dispatchEvent(event);
 }
 
 describe('BrnNavigationMenu', () => {
@@ -200,6 +206,31 @@ describe('BrnNavigationMenu', () => {
 
 			trigger.focus();
 			key(trigger, { key: 'ArrowRight' });
+
+			expect(document.activeElement).toBe(screen.getByTestId('c1-link1'));
+		});
+
+		// Regression: a real keypress carries a keyCode that the nav's CDK key manager reads to move
+		// to the next trigger. Entry into the content must stop propagation so it does not get
+		// overridden (synthetic events default keyCode to 0, hiding the conflict).
+		it('does not fall through to the key manager when ArrowDown carries a keyCode', async () => {
+			await setup('horizontal');
+			const trigger = screen.getByTestId('trigger1');
+			await open('item1', 'content1');
+
+			trigger.focus();
+			key(trigger, { key: 'ArrowDown', keyCode: 40 });
+
+			expect(document.activeElement).toBe(screen.getByTestId('c1-link1'));
+		});
+
+		it('does not fall through to the key manager when ArrowRight carries a keyCode (vertical)', async () => {
+			await setup('vertical');
+			const trigger = screen.getByTestId('trigger1');
+			await open('item1', 'content1');
+
+			trigger.focus();
+			key(trigger, { key: 'ArrowRight', keyCode: 39 });
 
 			expect(document.activeElement).toBe(screen.getByTestId('c1-link1'));
 		});

--- a/libs/brain/navigation-menu/src/lib/brn-navigation-menu.ts
+++ b/libs/brain/navigation-menu/src/lib/brn-navigation-menu.ts
@@ -169,6 +169,22 @@ export class BrnNavigationMenu implements OnDestroy {
 		this._keyManager().setActiveItem(item);
 	}
 
+	/** Focuses the sibling trigger/link `delta` steps from `current`, skipping disabled ones. @internal */
+	public focusSibling(current: FocusableOption, delta: 1 | -1): boolean {
+		const items = this._triggersAndLinks();
+		const idx = items.indexOf(current);
+		if (idx === -1) return false;
+
+		for (let i = idx + delta; i >= 0 && i < items.length; i += delta) {
+			const candidate = items[i];
+			if (!candidate.disabled) {
+				this._keyManager().setActiveItem(candidate);
+				return true;
+			}
+		}
+		return false;
+	}
+
 	protected handleKeydown(event: KeyboardEvent) {
 		this._keyManager().onKeydown(event);
 	}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [x] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1484

Tabbing forward past the last item of an open navigation-menu dropdown dropped
focus out of the navigation entirely. The dropdown content lives in a CDK
overlay portaled to the end of `<body>`, and nothing handled the content edges,
so Tab from the last item escaped the menu.

## What is the new behavior?

Edge handling now mirrors Radix:

- Tab/Shift+Tab walks to the next/previous tabbable inside the open content.
- Tabbing past the last item hands focus to the next top-level trigger/link
  (and closes the panel); Shift+Tab before the first item returns to the
  trigger.
- Arrow keys can enter the open panel.
- `aria-controls` is only exposed while the panel is open, matching Radix.

Adds unit coverage (including nested menus) and a Storybook e2e spec, and drops
the duplicate chevron the stories rendered on top of the trigger's own icon.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated navigation-menu keyboard behavior: improved Tab/Shift+Tab traversal, arrow-key entry into open content, and Escape-based closing with focus restoration.
  * Refined accessibility: ARIA `aria-controls` is now only set while the trigger is active/open.
  * Added internal focus helpers to reliably target tabbable elements.
* **Tests**
  * Added comprehensive unit and Cypress end-to-end coverage for keyboard navigation, focus management, and accessibility checks.
* **Documentation**
  * Updated Storybook navigation menu examples to remove the dropdown chevron icon from trigger buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->