### PR TITLE
fix: fade overlay blur in sync and align dialog, alert-dialog and sheet

### DIFF
--- a/libs/cli/src/generators/ui/libs/sheet/files/lib/hlm-sheet-overlay.ts.template
+++ b/libs/cli/src/generators/ui/libs/sheet/files/lib/hlm-sheet-overlay.ts.template
@@ -11,12 +11,7 @@ import type { ClassValue } from 'clsx';
 export class HlmSheetOverlay {
 	private readonly _classSettable = injectCustomClassSettable({ optional: true, host: true });
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() =>
-		hlm(
-			'spartan-sheet-overlay transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0',
-			this.userClass(),
-		),
-	);
+	protected readonly _computedClass = computed(() => hlm('spartan-sheet-overlay', this.userClass()));
 
 	constructor() {
 		effect(() => {

--- a/libs/helm/sheet/src/lib/hlm-sheet-overlay.ts
+++ b/libs/helm/sheet/src/lib/hlm-sheet-overlay.ts
@@ -11,12 +11,7 @@ import type { ClassValue } from 'clsx';
 export class HlmSheetOverlay {
 	private readonly _classSettable = injectCustomClassSettable({ optional: true, host: true });
 	public readonly userClass = input<ClassValue>('', { alias: 'class' });
-	protected readonly _computedClass = computed(() =>
-		hlm(
-			'spartan-sheet-overlay transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0',
-			this.userClass(),
-		),
-	);
+	protected readonly _computedClass = computed(() => hlm('spartan-sheet-overlay', this.userClass()));
 
 	constructor() {
 		effect(() => {

--- a/libs/registry/src/styles/style-luma.css
+++ b/libs/registry/src/styles/style-luma.css
@@ -454,7 +454,7 @@
 
 	/* MARK: Alert Dialog */
 	.spartan-alert-dialog-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/30 duration-100 supports-backdrop-filter:backdrop-blur-sm;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/30 duration-100 supports-backdrop-filter:backdrop-blur-sm;
 	}
 
 	.spartan-alert-dialog-content {
@@ -665,7 +665,7 @@
 
 	/* MARK: Dialog */
 	.spartan-dialog-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/30 duration-100 supports-backdrop-filter:backdrop-blur-sm;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/30 duration-100 supports-backdrop-filter:backdrop-blur-sm;
 	}
 
 	.spartan-dialog-content {
@@ -1073,7 +1073,7 @@
 
 	/* MARK: Sheet */
 	.spartan-sheet-overlay {
-		@apply bg-black/30 supports-backdrop-filter:backdrop-blur-sm;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/30 duration-100 supports-backdrop-filter:backdrop-blur-sm;
 	}
 
 	.spartan-sheet-content {

--- a/libs/registry/src/styles/style-lyra.css
+++ b/libs/registry/src/styles/style-lyra.css
@@ -50,7 +50,7 @@
 
 	/* MARK: Alert Dialog */
 	.spartan-alert-dialog-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-alert-dialog-content {
@@ -419,7 +419,7 @@
 
 	/* MARK: Dialog */
 	.spartan-dialog-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-dialog-content {
@@ -898,7 +898,7 @@
 
 	/* MARK: Sheet */
 	.spartan-sheet-overlay {
-		@apply bg-black/10 text-xs/relaxed supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/10 text-xs/relaxed duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-sheet-content {

--- a/libs/registry/src/styles/style-maia.css
+++ b/libs/registry/src/styles/style-maia.css
@@ -26,7 +26,7 @@
 
 	/* MARK: Alert Dialog */
 	.spartan-alert-dialog-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-alert-dialog-content {
@@ -437,7 +437,7 @@
 
 	/* MARK: Dialog */
 	.spartan-dialog-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-dialog-content {
@@ -920,7 +920,7 @@
 
 	/* MARK: Sheet */
 	.spartan-sheet-overlay {
-		@apply bg-black/80 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-sheet-content {

--- a/libs/registry/src/styles/style-mira.css
+++ b/libs/registry/src/styles/style-mira.css
@@ -26,7 +26,7 @@
 
 	/* MARK: Alert Dialog */
 	.spartan-alert-dialog-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-alert-dialog-content {
@@ -437,7 +437,7 @@
 
 	/* MARK: Dialog */
 	.spartan-dialog-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-dialog-content {
@@ -920,7 +920,7 @@
 
 	/* MARK: Sheet */
 	.spartan-sheet-overlay {
-		@apply bg-black/80 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-sheet-content {

--- a/libs/registry/src/styles/style-nova.css
+++ b/libs/registry/src/styles/style-nova.css
@@ -77,7 +77,7 @@
 
 	/* MARK: Alert Dialog */
 	.spartan-alert-dialog-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-alert-dialog-content {
@@ -467,7 +467,7 @@
 
 	/* MARK: Dialog */
 	.spartan-dialog-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-dialog-content {
@@ -950,7 +950,7 @@
 
 	/* MARK: Sheet */
 	.spartan-sheet-overlay {
-		@apply bg-black/10 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-sheet-content {

--- a/libs/registry/src/styles/style-vega.css
+++ b/libs/registry/src/styles/style-vega.css
@@ -22,7 +22,7 @@
 
 	/* MARK: Alert Dialog */
 	.spartan-alert-dialog-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-alert-dialog-content {
@@ -487,7 +487,7 @@
 
 	/* MARK: Dialog */
 	.spartan-dialog-overlay {
-		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-dialog-content {
@@ -1050,7 +1050,7 @@
 
 	/* MARK: Sheet */
 	.spartan-sheet-overlay {
-		@apply bg-black/10 supports-backdrop-filter:backdrop-blur-xs;
+		@apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 isolate bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs;
 	}
 
 	.spartan-sheet-content {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [x] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [x] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [x] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [x] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Two related inconsistencies in the modal overlays:

1. On the dialog/alert-dialog overlays, the backdrop fades via opacity while
   `backdrop-filter` sits on the same element. Browsers defer rasterizing the
   blur until the opacity animation settles, so the blur "snaps" in a beat after
   the fade instead of ramping with it.
2. The sheet overlay had no entrance animation at all (just `bg` + blur, so it
   popped in), and its helm component carried inert Base-UI classes
   (`transition-opacity` + `data-starting-style`/`data-ending-style`) that brn
   never triggers — whose unlayered `duration-150` would also override the
   registry duration.

## What is the new behavior?

`isolation: isolate` is added to the dialog/alert-dialog overlays so each gets
its own compositing group with a stable backing store; the backdrop-filter is
then rasterized every frame and the blur fades in together with the tint
(matching shadcn, which isolates its dialog overlay for the same reason).

The sheet overlay now uses the same keyframe `fade` + `isolate` recipe as the
dialog across all six styles, so dialog, alert-dialog, and sheet behave
identically. The dead Base-UI classes are dropped from the helm sheet overlay
component and the cli generator template. Drawer is intentionally left alone
(vaul-driven, separate animation).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Verified on the live dev server (nova) that the dialog/sheet blur now fades in
sync; rolled the same recipe across vega, lyra, maia, mira, and luma.
