### PR TITLE
fix(dropdown-menu): move focus to hovered item to prevent submenu collapse

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/menu/dropdown-menu.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/menu/dropdown-menu.cy.ts
@@ -86,4 +86,44 @@ describe('dropdown-menu', () => {
 			cy.findByText(/open/i).should('have.focus').should('have.attr', 'aria-expanded', 'false');
 		});
 	});
+
+	// Regression for https://github.com/spartan-ng/spartan/issues/1333
+	// Closing a submenu must not collapse the whole dropdown when focus was inside the submenu.
+	describe('submenu (issue #1333)', () => {
+		beforeEach(() => {
+			cy.visit('/iframe.html?id=dropdown-menu--submenu');
+			cy.viewport(1000, 1000);
+		});
+
+		it('hovering from an open submenu to a sibling item closes only the submenu, not the dropdown', () => {
+			cy.findByText(/open/i).realClick().should('have.attr', 'aria-expanded', 'true');
+
+			cy.findByText(/submenu trigger/i).realHover();
+			cy.findAllByRole('menu').should('have.length', 2);
+
+			// move onto a sibling of the sub-trigger: the submenu should close but the dropdown stay open
+			cy.findByText(/bottom item/i).realHover();
+			cy.findAllByRole('menu').should('have.length', 1);
+			cy.findByText(/open/i).should('have.attr', 'aria-expanded', 'true');
+		});
+
+		it('opening a submenu with the keyboard then moving the mouse keeps the dropdown open', () => {
+			cy.findByText(/open/i).realClick().should('have.attr', 'aria-expanded', 'true');
+
+			// open the submenu via the keyboard so focus lands inside the submenu overlay. before the fix,
+			// the next pointer-driven submenu close dropped that focus to <body>, the menu stack reported
+			// no focus, and the entire dropdown collapsed.
+			cy.get('[data-slot="dropdown-menu-sub-trigger"]').focus();
+			cy.realPress('ArrowRight');
+			cy.findAllByRole('menu').should('have.length', 2);
+			// wait until focus has actually settled in the submenu before moving the mouse
+			cy.findByText(/sub item one/i).should('have.focus');
+
+			// moving the mouse onto a parent sibling closes the submenu; focus follows the pointer into the
+			// parent menu, so the dropdown must stay open rather than collapse.
+			cy.findByText(/bottom item/i).realHover();
+			cy.findByText(/open/i).should('have.attr', 'aria-expanded', 'true');
+			cy.findByRole('menu').should('exist');
+		});
+	});
 });

--- a/apps/ui-storybook-e2e/src/integration/menu/dropdown-menu.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/menu/dropdown-menu.cy.ts
@@ -122,8 +122,8 @@ describe('dropdown-menu', () => {
 			// moving the mouse onto a parent sibling closes the submenu; focus follows the pointer into the
 			// parent menu, so the dropdown must stay open rather than collapse.
 			cy.findByText(/bottom item/i).realHover();
+			cy.findAllByRole('menu').should('have.length', 1);
 			cy.findByText(/open/i).should('have.attr', 'aria-expanded', 'true');
-			cy.findByRole('menu').should('exist');
 		});
 	});
 });

--- a/apps/ui-storybook/stories/dropdown-menu.stories.ts
+++ b/apps/ui-storybook/stories/dropdown-menu.stories.ts
@@ -224,3 +224,36 @@ export const Stateful: Story = {
 		template: '<stateful-dropdown-story/>',
 	}),
 };
+
+// Minimal, deterministic submenu layout used by the issue #1333 regression e2e: a sub-trigger with a
+// plain sibling item directly below it, so a test can hover/click the sub-trigger and then move to the
+// sibling to assert the parent dropdown stays open.
+export const Submenu: Story = {
+	render: () => ({
+		moduleMetadata: {
+			imports: [HlmDropdownMenuImports, HlmButton, NgIcon],
+			providers: [provideIcons(lucide)],
+		},
+		template: `
+    <div class='flex w-full justify-center pt-[20%]'>
+      <button hlmBtn variant='outline' [hlmDropdownMenuTrigger]='menu'>Open</button>
+    </div>
+    <ng-template #menu>
+      <hlm-dropdown-menu class='w-56'>
+        <button hlmDropdownMenuItem>Top Item</button>
+        <button hlmDropdownMenuItem [hlmDropdownMenuSubTrigger]='sub' side='right' align='start'>
+          <span>Submenu Trigger</span>
+          <hlm-dropdown-menu-item-sub-indicator />
+        </button>
+        <button hlmDropdownMenuItem>Bottom Item</button>
+      </hlm-dropdown-menu>
+    </ng-template>
+    <ng-template #sub>
+      <hlm-dropdown-menu-sub>
+        <button hlmDropdownMenuItem>Sub Item One</button>
+        <button hlmDropdownMenuItem>Sub Item Two</button>
+      </hlm-dropdown-menu-sub>
+    </ng-template>
+    `,
+	}),
+};

--- a/libs/helm/dropdown-menu/src/index.ts
+++ b/libs/helm/dropdown-menu/src/index.ts
@@ -17,6 +17,7 @@ import { HlmDropdownMenuTrigger } from './lib/hlm-dropdown-menu-trigger';
 export * from './lib/hlm-dropdown-menu';
 export * from './lib/hlm-dropdown-menu-checkbox';
 export * from './lib/hlm-dropdown-menu-checkbox-indicator';
+export * from './lib/hlm-dropdown-menu-focus-on-hover';
 export * from './lib/hlm-dropdown-menu-group';
 export * from './lib/hlm-dropdown-menu-item';
 export * from './lib/hlm-dropdown-menu-item-sub-indicator';

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-checkbox.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-checkbox.ts
@@ -2,6 +2,7 @@ import { type BooleanInput } from '@angular/cdk/coercion';
 import { CdkMenuItem, CdkMenuItemCheckbox, CdkMenuItemSelectable } from '@angular/cdk/menu';
 import { Directive, booleanAttribute, inject, input } from '@angular/core';
 import { classes } from '@spartan-ng/helm/utils';
+import { HlmDropdownMenuFocusOnHover } from './hlm-dropdown-menu-focus-on-hover';
 
 /** @internal. Use HlmDropdownMenuCheckbox instead. */
 @Directive({
@@ -28,6 +29,7 @@ export class HlmDropdownMenuCheckboxCdk extends CdkMenuItemCheckbox {
 			inputs: ['cdkMenuItemDisabled: disabled', 'cdkMenuItemChecked: checked', 'keepOpen'],
 			outputs: ['cdkMenuItemTriggered: triggered'],
 		},
+		HlmDropdownMenuFocusOnHover,
 	],
 	host: {
 		'data-slot': 'dropdown-menu-checkbox-item',

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-focus-on-hover.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-focus-on-hover.ts
@@ -25,6 +25,8 @@ export class HlmDropdownMenuFocusOnHover {
 	private readonly _inputModality = inject(InputModalityDetector);
 
 	protected _focusOnHover(): void {
+		// Only skip synthetic hovers from touch taps; every real hover (mouse, or keyboard-then-hover,
+		// which leaves the modality as 'keyboard') should move focus to keep a single highlight.
 		if (this._inputModality.mostRecentModality === 'touch' || this._cdkMenuItem.disabled) {
 			return;
 		}

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-focus-on-hover.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-focus-on-hover.ts
@@ -1,0 +1,33 @@
+import { InputModalityDetector } from '@angular/cdk/a11y';
+import { CdkMenu, CdkMenuItem } from '@angular/cdk/menu';
+import { Directive, inject } from '@angular/core';
+
+/**
+ * @internal
+ * Moves DOM focus to the hovered menu item. CDK menus only move focus with the keyboard, so on a pointer
+ * the highlight would otherwise stay on the last keyboard-focused item (leaving two rows highlighted) and,
+ * when a submenu closes, focus would fall to <body>, the menu stack would report no focus, and the whole
+ * dropdown would collapse. Following the pointer with focus (Radix/shadcn behaviour) keeps a single
+ * highlight and keeps focus inside the menu stack. setActiveMenuItem also syncs the key manager so keyboard
+ * navigation continues from the hovered item.
+ *
+ * Applied as a host directive on every dropdown item type (item, checkbox, radio, sub-trigger).
+ */
+@Directive({
+	selector: '[hlmDropdownMenuFocusOnHover]',
+	host: {
+		'(mouseenter)': '_focusOnHover()',
+	},
+})
+export class HlmDropdownMenuFocusOnHover {
+	private readonly _cdkMenuItem = inject(CdkMenuItem, { self: true });
+	private readonly _parentMenu = inject(CdkMenu, { optional: true });
+	private readonly _inputModality = inject(InputModalityDetector);
+
+	protected _focusOnHover(): void {
+		if (this._inputModality.mostRecentModality === 'touch' || this._cdkMenuItem.disabled) {
+			return;
+		}
+		this._parentMenu?.setActiveMenuItem(this._cdkMenuItem);
+	}
+}

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-item.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-item.ts
@@ -2,6 +2,7 @@ import { type BooleanInput } from '@angular/cdk/coercion';
 import { CdkMenuItem } from '@angular/cdk/menu';
 import { booleanAttribute, Directive, HOST_TAG_NAME, inject, input } from '@angular/core';
 import { classes } from '@spartan-ng/helm/utils';
+import { HlmDropdownMenuFocusOnHover } from './hlm-dropdown-menu-focus-on-hover';
 
 @Directive({
 	selector: '[hlmDropdownMenuItem],hlm-dropdown-menu-item',
@@ -11,6 +12,7 @@ import { classes } from '@spartan-ng/helm/utils';
 			inputs: ['cdkMenuItemDisabled: disabled'],
 			outputs: ['cdkMenuItemTriggered: triggered'],
 		},
+		HlmDropdownMenuFocusOnHover,
 	],
 	host: {
 		'data-slot': 'dropdown-menu-item',

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-radio.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-radio.ts
@@ -2,6 +2,7 @@ import { type BooleanInput } from '@angular/cdk/coercion';
 import { CdkMenuItem, CdkMenuItemRadio, CdkMenuItemSelectable } from '@angular/cdk/menu';
 import { Directive, booleanAttribute, inject, input } from '@angular/core';
 import { classes } from '@spartan-ng/helm/utils';
+import { HlmDropdownMenuFocusOnHover } from './hlm-dropdown-menu-focus-on-hover';
 
 /** @internal. Use HlmDropdownMenuRadio instead. */
 @Directive({
@@ -28,6 +29,7 @@ export class HlmDropdownMenuRadioCdk extends CdkMenuItemRadio {
 			inputs: ['cdkMenuItemDisabled: disabled', 'cdkMenuItemChecked: checked', 'keepOpen'],
 			outputs: ['cdkMenuItemTriggered: triggered'],
 		},
+		HlmDropdownMenuFocusOnHover,
 	],
 	host: {
 		'data-slot': 'dropdown-menu-radio-item',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] dropdown-menu

## What is the current behavior?

Closes #1333

The dropdown menu wraps the Angular CDK Menu. The CDK only moves DOM focus with the
keyboard — on a pointer, focus stays on the last keyboard-focused item. This caused two
problems:

1. **Submenu close collapses the whole dropdown.** When a submenu is opened by click or
   keyboard, CDK focuses the first submenu item. When that submenu then closes via a
   pointer interaction (hovering to a sibling, or clicking the trigger to close), CDK
   closes it without returning focus to the parent menu. Focus falls to `document.body`,
   the root menu stack reports `hasFocus = false`, and the root trigger calls `closeAll()`
   — collapsing the entire dropdown. The CDK menubar example does not show this because its
   root is an inline `cdkMenuBar`, not an overlay-rooted `cdkMenuTrigger`, so it never runs
   the "close everything when focus leaves" path.
2. **Two items highlighted at once.** Because focus never follows the pointer, the
   keyboard-focused row stayed lit (`focus:bg-accent`) while the hovered row also lit up
   (`hover:bg-accent`).

## What is the new behavior?

Menu items now move focus to the hovered item (the behaviour Radix/shadcn already use, and
that the existing `hover:`/`focus:` styles were reaching for). This is implemented as a
small shared host directive (`HlmDropdownMenuFocusOnHover`) applied to the item, checkbox
and radio directives; it calls `CdkMenu.setActiveMenuItem`, which both focuses the item and
keeps the key manager in sync so keyboard navigation continues from the hovered row.

As a result:

- Closing a submenu (hover-away or click) no longer collapses the dropdown — focus stays
  inside the menu stack on the hovered item.
- Only one row is highlighted at a time (the highlight follows the pointer).
- Keyboard navigation, Escape, and disabled-item handling are unchanged (covered by the
  existing e2e specs, which still pass).

Added a `Submenu` story and e2e specs covering both the hover and keyboard paths.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented dropdown menus from collapsing when closing a submenu while focus remains within the submenu.
  * Improved dropdown item interactions by enabling focus-on-hover so hovered items stay in sync with keyboard navigation.
* **Tests**
  * Added an end-to-end regression suite covering submenu open/close behavior across mouse and keyboard interactions.
* **Documentation / Demos**
  * Added a Storybook submenu example to demonstrate the corrected submenu behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->