### PR TITLE
fix: prevent overlay flicker on animated close

### DIFF
--- a/libs/brain/overlay/src/lib/brn-overlay-ref.ts
+++ b/libs/brain/overlay/src/lib/brn-overlay-ref.ts
@@ -130,6 +130,13 @@ export class BrnOverlayRef<OverlayResult = unknown> {
 		if (generation !== this._closeGeneration || this._phase() !== 'closing') return;
 
 		const exitAnimations = this._getActiveAnimations().filter((animation) => !animationsBeforeClose.has(animation));
+		// Pin each exit animation to its final frame. tw-animate-css uses `animation-fill-mode: none`,
+		// so a finished exit reverts the element to its visible pre-animation state in the gap before
+		// we dispose it - that one-frame snap-back is what flickers.
+		for (const animation of exitAnimations) {
+			const target = (animation.effect as KeyframeEffect | null)?.target;
+			if (target instanceof HTMLElement) target.style.setProperty('animation-fill-mode', 'forwards');
+		}
 		await waitForAnimations(exitAnimations);
 
 		if (generation === this._closeGeneration && this._phase() === 'closing') {

--- a/libs/brain/overlay/src/lib/brn-overlay-ref.ts
+++ b/libs/brain/overlay/src/lib/brn-overlay-ref.ts
@@ -131,11 +131,10 @@ export class BrnOverlayRef<OverlayResult = unknown> {
 
 		const exitAnimations = this._getActiveAnimations().filter((animation) => !animationsBeforeClose.has(animation));
 		// Pin each exit animation to its final frame. tw-animate-css uses `animation-fill-mode: none`,
-		// so a finished exit reverts the element to its visible pre-animation state in the gap before
-		// we dispose it - that one-frame snap-back is what flickers.
+		// so a finished exit reverts the element to its visible state in the gap before we dispose it -
+		// that one-frame snap-back is the flicker. updateTiming pins only the animations we await.
 		for (const animation of exitAnimations) {
-			const target = (animation.effect as KeyframeEffect | null)?.target;
-			if (target instanceof HTMLElement) target.style.setProperty('animation-fill-mode', 'forwards');
+			animation.effect?.updateTiming({ fill: 'forwards' });
 		}
 		await waitForAnimations(exitAnimations);
 

--- a/libs/helm/popover/src/lib/hlm-popover-animation.spec.ts
+++ b/libs/helm/popover/src/lib/hlm-popover-animation.spec.ts
@@ -73,6 +73,31 @@ describe('HlmPopover animation-aware teardown', () => {
 		expect(panel()).toBeNull();
 	});
 
+	it('pins the exit animation to its final frame so it cannot snap back before disposal', async () => {
+		const view = await render(PopoverAnimationHost);
+		const popover = popoverOf(view);
+
+		popover.open();
+		view.detectChanges();
+		await flush();
+
+		popover.close();
+		view.detectChanges();
+		await flush();
+		await flush();
+
+		// The exit animation defaults to fill-mode none; the overlay must hold it forwards.
+		const animations = panel()?.getAnimations() ?? [];
+		expect(animations.length).toBeGreaterThan(0);
+		for (const animation of animations) {
+			expect(animation.effect?.getComputedTiming().fill).toBe('forwards');
+		}
+
+		// Pinned or not, the panel still disposes once the animation completes.
+		await wait(EXIT_MS + 120);
+		expect(panel()).toBeNull();
+	});
+
 	it('cancels the pending teardown when reopened mid-animation', async () => {
 		const view = await render(PopoverAnimationHost);
 		const popover = popoverOf(view);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] date-picker
- [x] popover
- [x] dialog
- [x] select
- [x] dropdown-menu
- [x] tooltip

> The fix lives in the shared `brain/overlay` primitive, so it applies to every
> overlay-based component listed above (and any others built on the overlay).

## What is the current behavior?

A flicker appears when closing an animated overlay. It was reported on the date
range picker "form" example: selecting the end date with
`autoCloseOnEndSelection` enabled triggers a programmatic close, and the popover
visibly flickers right before it disappears.

Root cause: the exit animations from `tw-animate-css` use
`animation-fill-mode: none`, so once the exit animation finishes the element
reverts to its visible, pre-animation state (opacity 1 / scale 1). Because the
overlay disposes **asynchronously** (after `waitForAnimations`), the browser
paints that snapped-back frame in the gap before the element is removed from the
DOM. (`shadcn`/Radix avoid this by unmounting synchronously in the
`animationend` handler.)

This is not date-picker specific — it affects every overlay that animates out
(popover, dialog, select, menu, tooltip, backdrop). The date range picker just
makes it reliably reproducible because the close is programmatic and immediate.

Closes #

## What is the new behavior?

In `BrnOverlayRef`, each active exit animation is pinned to its final frame
(`animation-fill-mode: forwards`) before we await it, so the element stays in its
animated-out state through the disposal gap instead of snapping back to visible.
The flicker is gone, and the exit animation itself is unchanged.

No cleanup of the inline style is needed: on a normal close the element is
removed from the DOM (and a fresh element is created on the next open), and the
only reuse path — reopening while still closing — re-runs the enter animation,
whose held end state is the natural visible look.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Diagnosed via a `MutationObserver` on `data-state` + `cdk-overlay-pane`
add/remove, which showed a single clean open/close per interaction (ruling out a
state/lifecycle race) and a ~70ms gap between `data-state="closed"` and the pane
being removed — the window in which the snapped-back frame is painted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved flickering during overlay/popover close transitions by ensuring exit animations are pinned to their final state before waiting for them to finish, preventing brief visual snap-back.
* **Tests**
  * Added coverage to confirm the exit animation timing is enforced (including final-frame behavior) and that the panel is disposed after the expected exit duration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->