### PR TITLE
feat: make menu open animations scale from the anchored corner

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/menu/dropdown-menu-data-side.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/menu/dropdown-menu-data-side.cy.ts
@@ -1,0 +1,14 @@
+// data-side is derived from the transform-origin CDK sets on the content (no _spartanLastPosition hack).
+// Default story: the root menu opens below (=> "bottom") and the "Invite Users" submenu opens right (=> "right").
+describe('dropdown-menu data-side', () => {
+	it('derives data-side for the root menu and submenu from the resolved position', () => {
+		cy.visit('/iframe.html?id=dropdown-menu--default');
+		cy.viewport(1000, 1000);
+
+		cy.findByText(/open/i).realClick();
+		cy.get('[data-slot="dropdown-menu"]').should('have.attr', 'data-side', 'bottom');
+
+		cy.findByText(/invite users/i).realHover();
+		cy.get('[data-slot="dropdown-menu-sub"]').should('have.attr', 'data-side', 'right');
+	});
+});

--- a/libs/brain/core/src/helpers/menu-align.spec.ts
+++ b/libs/brain/core/src/helpers/menu-align.spec.ts
@@ -1,0 +1,35 @@
+import { deriveMenuSideFromTransformOrigin } from './menu-align';
+
+describe(deriveMenuSideFromTransformOrigin.name, () => {
+	it('reads the vertical token for a vertically placed menu', () => {
+		// anchored at the top => sits below => side "bottom"
+		expect(deriveMenuSideFromTransformOrigin('left top', 'bottom')).toBe('bottom');
+		expect(deriveMenuSideFromTransformOrigin('center bottom', 'top')).toBe('top');
+	});
+
+	it('reflects a CDK flip on the vertical axis', () => {
+		// configured bottom, but no room below => CDK anchors at the bottom => side flips to "top"
+		expect(deriveMenuSideFromTransformOrigin('right bottom', 'bottom')).toBe('top');
+	});
+
+	it('reads the horizontal token for a horizontally placed menu', () => {
+		// anchored at the left => sits to the right => side "right"
+		expect(deriveMenuSideFromTransformOrigin('left top', 'right')).toBe('right');
+		expect(deriveMenuSideFromTransformOrigin('right center', 'left')).toBe('left');
+	});
+
+	it('reflects a CDK flip on the horizontal axis (also covers RTL, which CDK bakes into the origin)', () => {
+		expect(deriveMenuSideFromTransformOrigin('right top', 'right')).toBe('left');
+	});
+
+	it('does not couple the axis to root vs submenu: a horizontally placed root reads the x token', () => {
+		// the old isRoot heuristic read the vertical token here and wrongly returned "bottom"
+		expect(deriveMenuSideFromTransformOrigin('left top', 'right')).toBe('right');
+	});
+
+	it('falls back to the configured side when the origin is missing or centered', () => {
+		expect(deriveMenuSideFromTransformOrigin('', 'bottom')).toBe('bottom');
+		expect(deriveMenuSideFromTransformOrigin('center center', 'top')).toBe('top');
+		expect(deriveMenuSideFromTransformOrigin('center center', 'right')).toBe('right');
+	});
+});

--- a/libs/brain/core/src/helpers/menu-align.ts
+++ b/libs/brain/core/src/helpers/menu-align.ts
@@ -1,16 +1,31 @@
 import type { ConnectedPosition } from '@angular/cdk/overlay';
+import { InjectionToken } from '@angular/core';
 
 export type MenuAlign = 'start' | 'center' | 'end';
 export type MenuSide = 'top' | 'bottom' | 'left' | 'right';
 
 const OPPOSITE_SIDE: Record<string, MenuSide> = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' };
 
+/**
+ * Lets a menu trigger expose its configured `side` to the portaled content. CDK gives the content a
+ * child injector whose parent is the trigger's injector, so the content can resolve this token to
+ * learn which axis to read off the transform-origin.
+ */
+export interface MenuSideProvider {
+	readonly side: () => MenuSide;
+}
+
+export const MENU_SIDE = new InjectionToken<MenuSideProvider>('SpartanMenuSide');
+
 // derive data-side from the transform-origin CDK sets on the content. the anchored corner faces the
-// trigger, so the side is its opposite (root reads the vertical axis, submenu the horizontal). CDK's
-// origin is rtl-aware, so the derived side is too.
-export const deriveMenuSideFromTransformOrigin = (transformOrigin: string, isRoot: boolean): MenuSide => {
+// trigger, so the side is its opposite. the configured `side` tells us which axis carries the anchor
+// (top/bottom -> vertical token, left/right -> horizontal), so a CDK flip is read off the right axis.
+// CDK's origin is rtl-aware, so the derived side is too. falls back to the configured side when the
+// transform-origin is missing or centered (no flip information to apply).
+export const deriveMenuSideFromTransformOrigin = (transformOrigin: string, side: MenuSide): MenuSide => {
 	const [x, y] = transformOrigin.trim().split(/\s+/);
-	return OPPOSITE_SIDE[isRoot ? y : x] ?? (isRoot ? 'bottom' : 'right');
+	const anchor = side === 'top' || side === 'bottom' ? y : x;
+	return OPPOSITE_SIDE[anchor] ?? side;
 };
 
 export const createMenuPosition = (align: MenuAlign, side: MenuSide): ConnectedPosition[] => {

--- a/libs/brain/core/src/helpers/menu-align.ts
+++ b/libs/brain/core/src/helpers/menu-align.ts
@@ -3,6 +3,16 @@ import type { ConnectedPosition } from '@angular/cdk/overlay';
 export type MenuAlign = 'start' | 'center' | 'end';
 export type MenuSide = 'top' | 'bottom' | 'left' | 'right';
 
+const OPPOSITE_SIDE: Record<string, MenuSide> = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' };
+
+// derive data-side from the transform-origin CDK sets on the content. the anchored corner faces the
+// trigger, so the side is its opposite (root reads the vertical axis, submenu the horizontal). CDK's
+// origin is rtl-aware, so the derived side is too.
+export const deriveMenuSideFromTransformOrigin = (transformOrigin: string, isRoot: boolean): MenuSide => {
+	const [x, y] = transformOrigin.trim().split(/\s+/);
+	return OPPOSITE_SIDE[isRoot ? y : x] ?? (isRoot ? 'bottom' : 'right');
+};
+
 export const createMenuPosition = (align: MenuAlign, side: MenuSide): ConnectedPosition[] => {
 	const verticalAlign = align === 'start' ? 'top' : align === 'end' ? 'bottom' : 'center';
 

--- a/libs/helm/context-menu/src/lib/hlm-context-menu-trigger.ts
+++ b/libs/helm/context-menu/src/lib/hlm-context-menu-trigger.ts
@@ -1,7 +1,6 @@
 import { type BooleanInput } from '@angular/cdk/coercion';
 import { CdkContextMenuTrigger } from '@angular/cdk/menu';
 import { booleanAttribute, computed, Directive, effect, inject, input } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { createMenuPosition, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
 import { classes } from '@spartan-ng/helm/utils';
 import { injectHlmContextMenuConfig } from './hlm-context-menu-token';
@@ -36,17 +35,9 @@ export class HlmContextMenuTrigger {
 	private readonly _menuPosition = computed(() => createMenuPosition(this.align(), this.side()));
 
 	constructor() {
-		// once the trigger opens we wait until the next tick and then grab the last position
-		// used to position the menu. we store this in our trigger which the brnMenu directive has
-		// access to through DI
-		this._cdkTrigger.opened.pipe(takeUntilDestroyed()).subscribe(() =>
-			setTimeout(
-				() =>
-					// eslint-disable-next-line
-					((this._cdkTrigger as any)._spartanLastPosition = // eslint-disable-next-line
-						(this._cdkTrigger as any).overlayRef._positionStrategy._lastPosition),
-			),
-		);
+		// CDK sets transform-origin on the menu content (a shared hlm-dropdown-menu) from the resolved
+		// position; the content reads it to animate from the anchored corner and to derive its data-side
+		this._cdkTrigger.transformOriginSelector = '[data-slot="dropdown-menu"]';
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();

--- a/libs/helm/context-menu/src/lib/hlm-context-menu-trigger.ts
+++ b/libs/helm/context-menu/src/lib/hlm-context-menu-trigger.ts
@@ -1,12 +1,13 @@
 import { type BooleanInput } from '@angular/cdk/coercion';
 import { CdkContextMenuTrigger } from '@angular/cdk/menu';
-import { booleanAttribute, computed, Directive, effect, inject, input } from '@angular/core';
-import { createMenuPosition, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
+import { booleanAttribute, computed, Directive, effect, forwardRef, inject, input } from '@angular/core';
+import { createMenuPosition, MENU_SIDE, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
 import { classes } from '@spartan-ng/helm/utils';
 import { injectHlmContextMenuConfig } from './hlm-context-menu-token';
 
 @Directive({
 	selector: '[hlmContextMenuTrigger]',
+	providers: [{ provide: MENU_SIDE, useExisting: forwardRef(() => HlmContextMenuTrigger) }],
 	hostDirectives: [
 		{
 			directive: CdkContextMenuTrigger,

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-sub-trigger.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-sub-trigger.ts
@@ -1,11 +1,12 @@
 import { CdkMenuTrigger } from '@angular/cdk/menu';
-import { computed, Directive, effect, inject, input } from '@angular/core';
-import { createMenuPosition, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
+import { computed, Directive, effect, forwardRef, inject, input } from '@angular/core';
+import { createMenuPosition, MENU_SIDE, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
 import { classes } from '@spartan-ng/helm/utils';
 import { injectHlmDropdownMenuConfig } from './hlm-dropdown-menu-token';
 
 @Directive({
 	selector: '[hlmDropdownMenuSubTrigger]',
+	providers: [{ provide: MENU_SIDE, useExisting: forwardRef(() => HlmDropdownMenuSubTrigger) }],
 	hostDirectives: [
 		{
 			directive: CdkMenuTrigger,

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-sub-trigger.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-sub-trigger.ts
@@ -1,6 +1,5 @@
 import { CdkMenuTrigger } from '@angular/cdk/menu';
 import { computed, Directive, effect, inject, input } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { createMenuPosition, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
 import { classes } from '@spartan-ng/helm/utils';
 import { injectHlmDropdownMenuConfig } from './hlm-dropdown-menu-token';
@@ -26,14 +25,9 @@ export class HlmDropdownMenuSubTrigger {
 	private readonly _menuPosition = computed(() => createMenuPosition(this.align(), this.side()));
 
 	constructor() {
-		this._cdkTrigger.opened.pipe(takeUntilDestroyed()).subscribe(() =>
-			setTimeout(
-				() =>
-					// eslint-disable-next-line
-					((this._cdkTrigger as any)._spartanLastPosition = // eslint-disable-next-line
-						(this._cdkTrigger as any).overlayRef._positionStrategy._lastPosition),
-			),
-		);
+		// CDK sets transform-origin on the submenu content from the resolved position; the content reads it
+		// to animate from the anchored corner and to derive its data-side
+		this._cdkTrigger.transformOriginSelector = '[data-slot="dropdown-menu-sub"]';
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-sub.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-sub.ts
@@ -1,6 +1,7 @@
 import { CdkMenu } from '@angular/cdk/menu';
-import { Directive, inject, signal } from '@angular/core';
+import { Directive, ElementRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { deriveMenuSideFromTransformOrigin } from '@spartan-ng/brain/core';
 import { classes } from '@spartan-ng/helm/utils';
 
 @Directive({
@@ -14,12 +15,13 @@ import { classes } from '@spartan-ng/helm/utils';
 })
 export class HlmDropdownMenuSub {
 	private readonly _host = inject(CdkMenu);
+	private readonly _elementRef = inject(ElementRef<HTMLElement>);
 
 	protected readonly _state = signal('open');
 	protected readonly _side = signal('top');
 
 	constructor() {
-		this.setSideWithDarkMagic();
+		this.setSideFromTransformOrigin();
 		// this is a best effort, but does not seem to work currently
 		// TODO: figure out a way for us to know the host is about to be closed. might not be possible with CDK
 		this._host.closed.pipe(takeUntilDestroyed()).subscribe(() => this._state.set('closed'));
@@ -27,29 +29,15 @@ export class HlmDropdownMenuSub {
 		classes(() => 'spartan-dropdown-menu-sub-content w-auto');
 	}
 
-	private setSideWithDarkMagic() {
-		/**
-		 * This is an ugly workaround to at least figure out the correct side of where a submenu
-		 * will appear and set the attribute to the host accordingly
-		 *
-		 * First of all we take advantage of the menu stack not being aware of the root
-		 * object immediately after it is added. This code executes before the root element is added,
-		 * which means the stack is still empty and the peek method returns undefined.
-		 */
+	private setSideFromTransformOrigin() {
+		// peek() is undefined only before this menu is pushed onto the stack, which tells us root vs submenu
 		const isRoot = this._host.menuStack.peek() === undefined;
+		// CDK sets transform-origin on this element synchronously on attach; read it next tick and derive side
 		setTimeout(() => {
-			// our menu trigger directive leaves the last position used for use immediately after opening
-			// we can access it here and determine the correct side.
-			// eslint-disable-next-line
-			const ps = (this._host as any)._parentTrigger._spartanLastPosition;
-			if (!ps) {
-				// if we have no last position we default to the most likely option
-				// I hate that we have to do this and hope we can revisit soon and improve
-				this._side.set(isRoot ? 'top' : 'left');
-				return;
+			const transformOrigin = this._elementRef.nativeElement.style.transformOrigin;
+			if (transformOrigin) {
+				this._side.set(deriveMenuSideFromTransformOrigin(transformOrigin, isRoot));
 			}
-			const side = isRoot ? ps.originY : ps.originX === 'end' ? 'right' : 'left';
-			this._side.set(side);
 		});
 	}
 }

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-sub.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-sub.ts
@@ -1,7 +1,7 @@
 import { CdkMenu } from '@angular/cdk/menu';
 import { Directive, ElementRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { deriveMenuSideFromTransformOrigin } from '@spartan-ng/brain/core';
+import { deriveMenuSideFromTransformOrigin, MENU_SIDE, type MenuSide } from '@spartan-ng/brain/core';
 import { classes } from '@spartan-ng/helm/utils';
 
 @Directive({
@@ -16,9 +16,11 @@ import { classes } from '@spartan-ng/helm/utils';
 export class HlmDropdownMenuSub {
 	private readonly _host = inject(CdkMenu);
 	private readonly _elementRef = inject(ElementRef<HTMLElement>);
+	// The sub-trigger provides its configured side; CDK parents this content's injector under it.
+	private readonly _menuSide = inject(MENU_SIDE, { optional: true });
 
 	protected readonly _state = signal('open');
-	protected readonly _side = signal('top');
+	protected readonly _side = signal<MenuSide>(this._menuSide?.side() ?? 'right');
 
 	constructor() {
 		this.setSideFromTransformOrigin();
@@ -30,14 +32,10 @@ export class HlmDropdownMenuSub {
 	}
 
 	private setSideFromTransformOrigin() {
-		// peek() is undefined only before this menu is pushed onto the stack, which tells us root vs submenu
-		const isRoot = this._host.menuStack.peek() === undefined;
+		const side = this._menuSide?.side() ?? 'right';
 		// CDK sets transform-origin on this element synchronously on attach; read it next tick and derive side
 		setTimeout(() => {
-			const transformOrigin = this._elementRef.nativeElement.style.transformOrigin;
-			if (transformOrigin) {
-				this._side.set(deriveMenuSideFromTransformOrigin(transformOrigin, isRoot));
-			}
+			this._side.set(deriveMenuSideFromTransformOrigin(this._elementRef.nativeElement.style.transformOrigin, side));
 		});
 	}
 }

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-trigger.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-trigger.ts
@@ -1,6 +1,5 @@
 import { CdkMenuTrigger } from '@angular/cdk/menu';
 import { computed, Directive, effect, inject, input } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { createMenuPosition, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
 import { injectHlmDropdownMenuConfig } from './hlm-dropdown-menu-token';
 
@@ -25,17 +24,9 @@ export class HlmDropdownMenuTrigger {
 	private readonly _menuPosition = computed(() => createMenuPosition(this.align(), this.side()));
 
 	constructor() {
-		// once the trigger opens we wait until the next tick and then grab the last position
-		// used to position the menu. we store this in our trigger which the brnMenu directive has
-		// access to through DI
-		this._cdkTrigger.opened.pipe(takeUntilDestroyed()).subscribe(() =>
-			setTimeout(
-				() =>
-					// eslint-disable-next-line
-					((this._cdkTrigger as any)._spartanLastPosition = // eslint-disable-next-line
-						(this._cdkTrigger as any).overlayRef._positionStrategy._lastPosition),
-			),
-		);
+		// CDK sets transform-origin on the menu content from the resolved position; the content reads it to
+		// animate from the anchored corner and to derive its data-side
+		this._cdkTrigger.transformOriginSelector = '[data-slot="dropdown-menu"]';
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-trigger.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-trigger.ts
@@ -1,10 +1,11 @@
 import { CdkMenuTrigger } from '@angular/cdk/menu';
-import { computed, Directive, effect, inject, input } from '@angular/core';
-import { createMenuPosition, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
+import { computed, Directive, effect, forwardRef, inject, input } from '@angular/core';
+import { createMenuPosition, MENU_SIDE, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
 import { injectHlmDropdownMenuConfig } from './hlm-dropdown-menu-token';
 
 @Directive({
 	selector: '[hlmDropdownMenuTrigger]',
+	providers: [{ provide: MENU_SIDE, useExisting: forwardRef(() => HlmDropdownMenuTrigger) }],
 	hostDirectives: [
 		{
 			directive: CdkMenuTrigger,

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu.spec.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu.spec.ts
@@ -1,0 +1,59 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import type { MenuSide } from '@spartan-ng/brain/core';
+import { render, screen } from '@testing-library/angular';
+import { HlmDropdownMenu } from './hlm-dropdown-menu';
+import { HlmDropdownMenuItem } from './hlm-dropdown-menu-item';
+import { HlmDropdownMenuTrigger } from './hlm-dropdown-menu-trigger';
+
+// CDK sets transform-origin async on attach and the content reads it one tick later.
+const flush = async () => {
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+@Component({
+	selector: 'hlm-dropdown-menu-host',
+	imports: [HlmDropdownMenuTrigger, HlmDropdownMenu, HlmDropdownMenuItem],
+	providers: [Directionality],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<button [hlmDropdownMenuTrigger]="menu" [side]="side()">Open</button>
+		<ng-template #menu>
+			<hlm-dropdown-menu>
+				<button hlmDropdownMenuItem>Item</button>
+			</hlm-dropdown-menu>
+		</ng-template>
+	`,
+})
+class DropdownMenuHost {
+	public readonly side = input<MenuSide>('bottom');
+}
+
+describe('HlmDropdownMenu data-side', () => {
+	const open = async (side: MenuSide) => {
+		await render(DropdownMenuHost, { componentInputs: { side } });
+		screen.getByText('Open').click();
+		await flush();
+		return document.querySelector('[data-slot="dropdown-menu"]');
+	};
+
+	afterEach(() => {
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	it('derives a vertical data-side for a vertically placed menu', async () => {
+		const content = await open('bottom');
+		expect(content).toBeTruthy();
+		expect(['top', 'bottom']).toContain(content?.getAttribute('data-side'));
+	});
+
+	// Proves the configured side reaches the portaled content through DI: a horizontal placement must
+	// produce a horizontal data-side. If the MENU_SIDE wiring broke, the content would fall back to the
+	// vertical default and this would read 'top'/'bottom' instead.
+	it('derives a horizontal data-side from the trigger side', async () => {
+		const content = await open('right');
+		expect(content).toBeTruthy();
+		expect(['left', 'right']).toContain(content?.getAttribute('data-side'));
+	});
+});

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu.ts
@@ -2,7 +2,7 @@ import { type NumberInput } from '@angular/cdk/coercion';
 import { CdkMenu } from '@angular/cdk/menu';
 import { Directive, ElementRef, inject, input, numberAttribute, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { deriveMenuSideFromTransformOrigin } from '@spartan-ng/brain/core';
+import { deriveMenuSideFromTransformOrigin, MENU_SIDE, type MenuSide } from '@spartan-ng/brain/core';
 import { classes } from '@spartan-ng/helm/utils';
 
 @Directive({
@@ -18,9 +18,11 @@ import { classes } from '@spartan-ng/helm/utils';
 export class HlmDropdownMenu {
 	private readonly _host = inject(CdkMenu);
 	private readonly _elementRef = inject(ElementRef<HTMLElement>);
+	// The trigger provides its configured side; CDK parents this content's injector under the trigger's.
+	private readonly _menuSide = inject(MENU_SIDE, { optional: true });
 
 	protected readonly _state = signal('open');
-	protected readonly _side = signal('top');
+	protected readonly _side = signal<MenuSide>(this._menuSide?.side() ?? 'bottom');
 
 	public readonly sideOffset = input<number, NumberInput>(1, { transform: numberAttribute });
 
@@ -37,14 +39,10 @@ export class HlmDropdownMenu {
 	}
 
 	private setSideFromTransformOrigin() {
-		// peek() is undefined only before this menu is pushed onto the stack, which tells us root vs submenu
-		const isRoot = this._host.menuStack.peek() === undefined;
+		const side = this._menuSide?.side() ?? 'bottom';
 		// CDK sets transform-origin on this element synchronously on attach; read it next tick and derive side
 		setTimeout(() => {
-			const transformOrigin = this._elementRef.nativeElement.style.transformOrigin;
-			if (transformOrigin) {
-				this._side.set(deriveMenuSideFromTransformOrigin(transformOrigin, isRoot));
-			}
+			this._side.set(deriveMenuSideFromTransformOrigin(this._elementRef.nativeElement.style.transformOrigin, side));
 		});
 	}
 }

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu.ts
@@ -1,7 +1,8 @@
 import { type NumberInput } from '@angular/cdk/coercion';
 import { CdkMenu } from '@angular/cdk/menu';
-import { Directive, inject, input, numberAttribute, signal } from '@angular/core';
+import { Directive, ElementRef, inject, input, numberAttribute, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { deriveMenuSideFromTransformOrigin } from '@spartan-ng/brain/core';
 import { classes } from '@spartan-ng/helm/utils';
 
 @Directive({
@@ -16,6 +17,7 @@ import { classes } from '@spartan-ng/helm/utils';
 })
 export class HlmDropdownMenu {
 	private readonly _host = inject(CdkMenu);
+	private readonly _elementRef = inject(ElementRef<HTMLElement>);
 
 	protected readonly _state = signal('open');
 	protected readonly _side = signal('top');
@@ -28,35 +30,21 @@ export class HlmDropdownMenu {
 				'spartan-dropdown-menu-content my-[--spacing(var(--side-offset))] overflow-x-hidden overflow-y-auto outline-none',
 		);
 
-		this.setSideWithDarkMagic();
+		this.setSideFromTransformOrigin();
 		// this is a best effort, but does not seem to work currently
 		// TODO: figure out a way for us to know the host is about to be closed. might not be possible with CDK
 		this._host.closed.pipe(takeUntilDestroyed()).subscribe(() => this._state.set('closed'));
 	}
 
-	private setSideWithDarkMagic() {
-		/**
-		 * This is an ugly workaround to at least figure out the correct side of where a submenu
-		 * will appear and set the attribute to the host accordingly
-		 *
-		 * First of all we take advantage of the menu stack not being aware of the root
-		 * object immediately after it is added. This code executes before the root element is added,
-		 * which means the stack is still empty and the peek method returns undefined.
-		 */
+	private setSideFromTransformOrigin() {
+		// peek() is undefined only before this menu is pushed onto the stack, which tells us root vs submenu
 		const isRoot = this._host.menuStack.peek() === undefined;
+		// CDK sets transform-origin on this element synchronously on attach; read it next tick and derive side
 		setTimeout(() => {
-			// our menu trigger directive leaves the last position used for use immediately after opening
-			// we can access it here and determine the correct side.
-			// eslint-disable-next-line
-			const ps = (this._host as any)._parentTrigger._spartanLastPosition;
-			if (!ps) {
-				// if we have no last position we default to the most likely option
-				// I hate that we have to do this and hope we can revisit soon and improve
-				this._side.set(isRoot ? 'top' : 'left');
-				return;
+			const transformOrigin = this._elementRef.nativeElement.style.transformOrigin;
+			if (transformOrigin) {
+				this._side.set(deriveMenuSideFromTransformOrigin(transformOrigin, isRoot));
 			}
-			const side = isRoot ? ps.originY : ps.originX === 'end' ? 'right' : 'left';
-			this._side.set(side);
 		});
 	}
 }

--- a/libs/helm/menubar/src/lib/hlm-menubar-trigger.ts
+++ b/libs/helm/menubar/src/lib/hlm-menubar-trigger.ts
@@ -1,7 +1,6 @@
 import { type BooleanInput } from '@angular/cdk/coercion';
 import { CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
 import { booleanAttribute, computed, Directive, effect, inject, input } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { createMenuPosition, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
 import { classes } from '@spartan-ng/helm/utils';
 import { injectHlmMenubarConfig } from './hlm-menubar-token';
@@ -37,17 +36,9 @@ export class HlmMenubarTrigger {
 	private readonly _menuPosition = computed(() => createMenuPosition(this.align(), this.side()));
 
 	constructor() {
-		// once the trigger opens we wait until the next tick and then grab the last position
-		// used to position the menu. we store this in our trigger which the brnMenu directive has
-		// access to through DI
-		this._cdkTrigger.opened.pipe(takeUntilDestroyed()).subscribe(() =>
-			setTimeout(
-				() =>
-					// eslint-disable-next-line
-					((this._cdkTrigger as any)._spartanLastPosition = // eslint-disable-next-line
-						(this._cdkTrigger as any).overlayRef._positionStrategy._lastPosition),
-			),
-		);
+		// CDK sets transform-origin on the menu content (a shared hlm-dropdown-menu) from the resolved
+		// position; the content reads it to animate from the anchored corner and to derive its data-side
+		this._cdkTrigger.transformOriginSelector = '[data-slot="dropdown-menu"]';
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();

--- a/libs/helm/menubar/src/lib/hlm-menubar-trigger.ts
+++ b/libs/helm/menubar/src/lib/hlm-menubar-trigger.ts
@@ -1,12 +1,13 @@
 import { type BooleanInput } from '@angular/cdk/coercion';
 import { CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
-import { booleanAttribute, computed, Directive, effect, inject, input } from '@angular/core';
-import { createMenuPosition, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
+import { booleanAttribute, computed, Directive, effect, forwardRef, inject, input } from '@angular/core';
+import { createMenuPosition, MENU_SIDE, type MenuAlign, type MenuSide } from '@spartan-ng/brain/core';
 import { classes } from '@spartan-ng/helm/utils';
 import { injectHlmMenubarConfig } from './hlm-menubar-token';
 
 @Directive({
 	selector: 'button[hlmMenubarTrigger]',
+	providers: [{ provide: MENU_SIDE, useExisting: forwardRef(() => HlmMenubarTrigger) }],
 	hostDirectives: [
 		{
 			directive: CdkMenuItem,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] context-menu
- [x] dropdown-menu
- [x] menubar

## What is the current behavior?

The menu primitives (dropdown-menu, context-menu, menubar, and their submenus) never set a
`transform-origin` on their content, so the open `zoom-in` animation scaled from the element's
**center** regardless of where the menu was anchored to its trigger — unlike shadcn/Radix, which
scale out of the anchored corner.

Separately, the content's `data-side` (which drives the slide-in direction) was computed by a
"dark magic" workaround: each trigger stashed `overlayRef._positionStrategy._lastPosition` onto a
private `_spartanLastPosition` field via `setTimeout`, and the content read it back through
`(_host as any)._parentTrigger._spartanLastPosition`. That side detection was also not RTL-aware.

Related to #1046 (origin-aware animations), reimplemented against the CDK-native API for the menu
family.

## What is the new behavior?

- The trigger sets CDK's `transformOriginSelector` to point at its content. CDK then writes
  `transform-origin` from the resolved, direction-aware position, so the open animation scales out
  of the corner anchored to the trigger — matching shadcn/Radix.
- The content derives its `data-side` from that same CDK `transform-origin` (the anchored corner is
  the opposite of the side the menu sits on), so the `_spartanLastPosition` / `setSideWithDarkMagic`
  workaround is **deleted** (net −33 lines).
- Because CDK's `transform-origin` is RTL-aware, the slide-in direction is now correct in RTL too.
- Adds a `data-side` e2e for dropdown root + submenu; the existing menu specs stay green.

Notes:
- CLI generator templates for these components will be synced in a follow-up (running the
  `hlm-to-cli-generator` also pulls in unrelated drift, so it's cleaner on its own).
- Exit animations for CDK menus remain unaddressed (CDK detaches the overlay synchronously on
  close); that's an orthogonal piece of work.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Cypress coverage to validate dropdown root and submenu `data-side` positioning from the resolved placement.
  * Added Jest and Angular specs to confirm `data-side` derivation for both vertical and horizontal menu configurations.

* **Refactor**
  * Improved dropdown, context menu, and menubar placement by deriving menu side from the host element’s `transform-origin` instead of relying on fragile internal overlay state, resulting in more consistent animation alignment and submenu direction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->