### PR TITLE
feat: add interactive create page with theme customizer and preset codes

### DIFF
--- a/apps/app/src/app/app.spec.ts
+++ b/apps/app/src/app/app.spec.ts
@@ -16,6 +16,10 @@ describe('AppComponent', () => {
 				dispatchEvent: vitest.fn(),
 			})),
 		});
+		Object.defineProperty(globalThis, 'localStorage', {
+			writable: true,
+			value: { getItem: vitest.fn(), setItem: vitest.fn() },
+		});
 
 		await TestBed.configureTestingModule({
 			providers: [provideRouter([]), provideHttpClient()],

--- a/apps/app/src/app/pages/(create)/components/action-menu.ts
+++ b/apps/app/src/app/pages/(create)/components/action-menu.ts
@@ -1,0 +1,95 @@
+import { Component, inject, input, output } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+	lucideMoon,
+	lucideRedo2,
+	lucideRotateCcw,
+	lucideSearch,
+	lucideShuffle,
+	lucideTerminal,
+	lucideUndo2,
+	lucideUpload,
+} from '@ng-icons/lucide';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmCommandImports } from '@spartan-ng/helm/command';
+import { DesignSystemService } from '../lib/design-system.service';
+
+@Component({
+	selector: 'spartan-action-menu',
+	imports: [HlmButton, HlmCommandImports, NgIcon],
+	providers: [
+		provideIcons({
+			lucideSearch,
+			lucideRotateCcw,
+			lucideShuffle,
+			lucideMoon,
+			lucideUndo2,
+			lucideRedo2,
+			lucideUpload,
+			lucideTerminal,
+		}),
+	],
+	template: `
+		<hlm-command-dialog [state]="open()" (stateChange)="openChange.emit($event)" dialogContentClass="sm:max-w-lg">
+			<hlm-command class="w-full">
+				<hlm-command-input placeholder="Type a command..." />
+				<hlm-command-list class="max-h-64">
+					<hlm-command-group>
+						<button hlm-command-item (selected)="_randomize()" [value]="'Randomize'">
+							<ng-icon name="lucideShuffle" class="mr-2" size="16" />
+							<span>Randomize (R)</span>
+						</button>
+						<button hlm-command-item (selected)="_reset()" [value]="'Reset'">
+							<ng-icon name="lucideRotateCcw" class="mr-2" size="16" />
+							<span>Reset to Defaults (Shift+R)</span>
+						</button>
+						<button hlm-command-item (selected)="_toggleDark()" [value]="'Dark Mode'">
+							<ng-icon name="lucideMoon" class="mr-2" size="16" />
+							<span>Toggle Dark Mode (D)</span>
+						</button>
+						<button hlm-command-item (selected)="_undo()" [value]="'Undo'">
+							<ng-icon name="lucideUndo2" class="mr-2" size="16" />
+							<span>Undo (Ctrl+Z)</span>
+						</button>
+						<button hlm-command-item (selected)="_redo()" [value]="'Redo'">
+							<ng-icon name="lucideRedo2" class="mr-2" size="16" />
+							<span>Redo (Ctrl+Shift+Z)</span>
+						</button>
+					</hlm-command-group>
+				</hlm-command-list>
+				<div *hlmCommandEmptyState hlmCommandEmpty>No results found.</div>
+			</hlm-command>
+		</hlm-command-dialog>
+	`,
+})
+export class ActionMenu {
+	protected readonly _ds = inject(DesignSystemService);
+
+	public readonly open = input(false);
+	public readonly openChange = output<boolean>();
+
+	protected _randomize(): void {
+		this._ds.randomize();
+		this.openChange.emit(false);
+	}
+
+	protected _reset(): void {
+		this._ds.reset();
+		this.openChange.emit(false);
+	}
+
+	protected _toggleDark(): void {
+		this._ds.darkMode.set(!this._ds.darkMode());
+		this.openChange.emit(false);
+	}
+
+	protected _undo(): void {
+		this._ds.undo();
+		this.openChange.emit(false);
+	}
+
+	protected _redo(): void {
+		this._ds.redo();
+		this.openChange.emit(false);
+	}
+}

--- a/apps/app/src/app/pages/(create)/components/customizer.spec.ts
+++ b/apps/app/src/app/pages/(create)/components/customizer.spec.ts
@@ -1,0 +1,59 @@
+import { provideHttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { vitest } from 'vitest';
+import { Customizer } from './customizer';
+
+describe('Customizer', () => {
+	beforeEach(async () => {
+		Object.defineProperty(window, 'matchMedia', {
+			writable: true,
+			value: vitest.fn().mockImplementation((query: string) => ({
+				matches: false,
+				media: query,
+				addEventListener: vitest.fn(),
+				removeEventListener: vitest.fn(),
+				dispatchEvent: vitest.fn(),
+			})),
+		});
+		Element.prototype.scrollIntoView = vitest.fn();
+
+		await TestBed.configureTestingModule({
+			providers: [provideRouter([]), provideHttpClient()],
+			imports: [Customizer],
+		}).compileComponents();
+	});
+
+	it('should create the component', () => {
+		const fixture = TestBed.createComponent(Customizer);
+		const component = fixture.componentInstance;
+		expect(component).toBeTruthy();
+	});
+
+	it('should render all pickers', () => {
+		const fixture = TestBed.createComponent(Customizer);
+		fixture.detectChanges();
+		const element = fixture.nativeElement as HTMLElement;
+		const labels = element.querySelectorAll('label');
+		const labelTexts = Array.from(labels).map((l) => l.textContent?.trim());
+		expect(labelTexts).toContain('Style');
+		expect(labelTexts).toContain('Base Color');
+		expect(labelTexts).toContain('Theme');
+		expect(labelTexts).toContain('Chart Color');
+		expect(labelTexts).toContain('Font (Body)');
+		expect(labelTexts).toContain('Font (Heading)');
+		expect(labelTexts).toContain('Icon Library');
+		expect(labelTexts).toContain('Radius');
+		expect(labelTexts).toContain('Menu Accent');
+		expect(labelTexts).toContain('Menu Color');
+	});
+
+	it('should have a Get Code button', () => {
+		const fixture = TestBed.createComponent(Customizer);
+		fixture.detectChanges();
+		const element = fixture.nativeElement as HTMLElement;
+		const buttons = element.querySelectorAll('button');
+		const copyBtn = Array.from(buttons).find((b) => b.textContent?.trim().includes('Get Code'));
+		expect(copyBtn).toBeTruthy();
+	});
+});

--- a/apps/app/src/app/pages/(create)/components/customizer.ts
+++ b/apps/app/src/app/pages/(create)/components/customizer.ts
@@ -1,0 +1,413 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+	lucideCheck,
+	lucideClipboard,
+	lucideCopy,
+	lucideFileCode,
+	lucideLock,
+	lucideLockOpen,
+	lucideRotateCcw,
+	lucideRotateCw,
+	lucideShare2,
+	lucideShuffle,
+	lucideTerminal,
+	lucideUpload,
+	lucideX,
+} from '@ng-icons/lucide';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmCardImports } from '@spartan-ng/helm/card';
+import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
+import {
+	BASE_COLORS,
+	COLOR_THEMES,
+	DesignSystemConfig,
+	FONT_DEFINITIONS,
+	ICON_LIBRARIES,
+	MENU_ACCENTS,
+	MENU_COLORS,
+	STYLES,
+} from '@spartan-ng/registry';
+import { DesignSystemService, type LockableParam } from '../lib/design-system.service';
+import { ActionMenu } from './action-menu';
+import { MainMenu } from './main-menu';
+import { OpenPresetDialog } from './open-preset';
+import { ProjectForm } from './project-form';
+
+@Component({
+	selector: 'spartan-customizer',
+	imports: [
+		HlmButton,
+		HlmCardImports,
+		HlmSeparatorImports,
+		NgIcon,
+		OpenPresetDialog,
+		MainMenu,
+		ProjectForm,
+		ActionMenu,
+	],
+	providers: [
+		provideIcons({
+			lucideCheck,
+			lucideClipboard,
+			lucideCopy,
+			lucideFileCode,
+			lucideLock,
+			lucideLockOpen,
+			lucideRotateCcw,
+			lucideRotateCw,
+			lucideShare2,
+			lucideShuffle,
+			lucideTerminal,
+			lucideUpload,
+			lucideX,
+		}),
+	],
+	template: `
+		<div
+			hlmCard
+			class="bg-card/90 top-24 right-12 isolate z-10 max-h-full min-h-0 w-full self-start rounded-2xl backdrop-blur-xl"
+		>
+			<div class="flex items-center justify-between border-b p-4">
+				<h2 class="text-sm font-semibold">Customize</h2>
+				<div class="flex items-center gap-1">
+					<button
+						hlmBtn
+						variant="ghost"
+						size="icon-xs"
+						(click)="_ds.undo()"
+						[disabled]="!_ds.canUndo()"
+						title="Undo (Ctrl+Z)"
+					>
+						<ng-icon name="lucideRotateCcw" size="14" />
+					</button>
+					<button
+						hlmBtn
+						variant="ghost"
+						size="icon-xs"
+						(click)="_ds.redo()"
+						[disabled]="!_ds.canRedo()"
+						title="Redo (Ctrl+Shift+Z)"
+					>
+						<ng-icon name="lucideRotateCw" size="14" />
+					</button>
+					<spartan-main-menu />
+				</div>
+			</div>
+
+			<div hlmCardContent class="no-scrollbar min-h-0 flex-1 overflow-hidden overflow-x-auto md:overflow-y-auto">
+				<div class="flex flex-row gap-2.5 py-px md:flex-col md:gap-3.25">
+					<div class="flex items-end gap-2">
+						<div class="flex-1 space-y-2">
+							<label class="text-sm font-medium">Style</label>
+							<select
+								[value]="_ds.state().style"
+								(change)="_onStyleChange($event)"
+								class="border-input bg-background w-full rounded-md border px-3 py-2 text-sm"
+							>
+								@for (s of _styles; track s) {
+									<option [value]="s" [selected]="_ds.state().style === s">{{ s }}</option>
+								}
+							</select>
+						</div>
+						<button hlmBtn variant="ghost" size="icon-xs" (click)="_toggleLock('style')" title="Lock Style">
+							<ng-icon [name]="_ds.isLocked('style') ? 'lucideLock' : 'lucideLockOpen'" size="14" />
+						</button>
+					</div>
+
+					<hlm-separator class="hidden md:block" />
+
+					<div class="flex items-end gap-2">
+						<div class="flex-1 space-y-2">
+							<label class="text-sm font-medium">Base Color</label>
+							<select
+								[value]="_ds.state().baseColor"
+								(change)="_onBaseColorChange($event)"
+								class="border-input bg-background w-full rounded-md border px-3 py-2 text-sm"
+							>
+								@for (c of _baseColors; track c) {
+									<option [value]="c" [selected]="_ds.state().baseColor === c">{{ c }}</option>
+								}
+							</select>
+						</div>
+						<button hlmBtn variant="ghost" size="icon-xs" (click)="_toggleLock('baseColor')" title="Lock Base Color">
+							<ng-icon [name]="_ds.isLocked('baseColor') ? 'lucideLock' : 'lucideLockOpen'" size="14" />
+						</button>
+					</div>
+
+					<div class="flex items-end gap-2">
+						<div class="flex-1 space-y-2">
+							<label class="text-sm font-medium">Theme</label>
+							<select
+								[value]="_ds.state().theme"
+								(change)="_onThemeChange($event)"
+								class="border-input bg-background w-full rounded-md border px-3 py-2 text-sm"
+							>
+								<optgroup label="Base">
+									@for (t of _baseThemes; track t) {
+										<option [value]="t" [selected]="_ds.state().theme === t">{{ _themeLabel(t) }}</option>
+									}
+								</optgroup>
+								<optgroup label="Colors">
+									@for (t of _colorThemes; track t) {
+										<option [value]="t" [selected]="_ds.state().theme === t">{{ _themeLabel(t) }}</option>
+									}
+								</optgroup>
+							</select>
+						</div>
+						<button hlmBtn variant="ghost" size="icon-xs" (click)="_toggleLock('theme')" title="Lock Theme">
+							<ng-icon [name]="_ds.isLocked('theme') ? 'lucideLock' : 'lucideLockOpen'" size="14" />
+						</button>
+					</div>
+
+					<div class="flex items-end gap-2">
+						<div class="flex-1 space-y-2">
+							<label class="text-sm font-medium">Chart Color</label>
+							<select
+								[value]="_ds.state().chartColor"
+								(change)="_onChartColorChange($event)"
+								class="border-input bg-background w-full rounded-md border px-3 py-2 text-sm"
+							>
+								<optgroup label="Base">
+									@for (t of _baseThemes; track t) {
+										<option [value]="t" [selected]="_ds.state().chartColor === t">{{ _themeLabel(t) }}</option>
+									}
+								</optgroup>
+								<optgroup label="Colors">
+									@for (t of _colorThemes; track t) {
+										<option [value]="t" [selected]="_ds.state().chartColor === t">{{ _themeLabel(t) }}</option>
+									}
+								</optgroup>
+							</select>
+						</div>
+						<button hlmBtn variant="ghost" size="icon-xs" (click)="_toggleLock('chartColor')" title="Lock Chart Color">
+							<ng-icon [name]="_ds.isLocked('chartColor') ? 'lucideLock' : 'lucideLockOpen'" size="14" />
+						</button>
+					</div>
+
+					<hlm-separator class="hidden md:block" />
+
+					<div class="flex items-end gap-2">
+						<div class="flex-1 space-y-2">
+							<label class="text-sm font-medium">Font (Body)</label>
+							<select
+								[value]="_ds.state().font"
+								(change)="_onFontChange($event)"
+								class="border-input bg-background w-full rounded-md border px-3 py-2 text-sm"
+							>
+								@for (f of _fonts; track f.value) {
+									<option [value]="f.value" [selected]="_ds.state().font === f.value">{{ f.label }}</option>
+								}
+							</select>
+						</div>
+						<button hlmBtn variant="ghost" size="icon-xs" (click)="_toggleLock('font')" title="Lock Font">
+							<ng-icon [name]="_ds.isLocked('font') ? 'lucideLock' : 'lucideLockOpen'" size="14" />
+						</button>
+					</div>
+
+					<div class="flex items-end gap-2">
+						<div class="flex-1 space-y-2">
+							<label class="text-sm font-medium">Font (Heading)</label>
+							<select
+								[value]="_ds.state().fontHeading"
+								(change)="_onFontHeadingChange($event)"
+								class="border-input bg-background w-full rounded-md border px-3 py-2 text-sm"
+							>
+								<option value="inherit">Inherit ({{ _bodyFontLabel() }})</option>
+								@for (f of _fonts; track f.value) {
+									<option [value]="f.value" [selected]="_ds.state().fontHeading === f.value">{{ f.label }}</option>
+								}
+							</select>
+						</div>
+						<button
+							hlmBtn
+							variant="ghost"
+							size="icon-xs"
+							(click)="_toggleLock('fontHeading')"
+							title="Lock Heading Font"
+						>
+							<ng-icon [name]="_ds.isLocked('fontHeading') ? 'lucideLock' : 'lucideLockOpen'" size="14" />
+						</button>
+					</div>
+
+					<hlm-separator class="hidden md:block" />
+
+					<div class="flex items-end gap-2">
+						<div class="flex-1 space-y-2">
+							<label class="text-sm font-medium">Icon Library</label>
+							<select
+								[value]="_ds.state().iconLibrary"
+								(change)="_onIconLibraryChange($event)"
+								class="border-input bg-background w-full rounded-md border px-3 py-2 text-sm"
+							>
+								@for (icon of _iconLibraries; track icon) {
+									<option [value]="icon" [selected]="_ds.state().iconLibrary === icon">{{ icon }}</option>
+								}
+							</select>
+						</div>
+						<button
+							hlmBtn
+							variant="ghost"
+							size="icon-xs"
+							(click)="_toggleLock('iconLibrary')"
+							title="Lock Icon Library"
+						>
+							<ng-icon [name]="_ds.isLocked('iconLibrary') ? 'lucideLock' : 'lucideLockOpen'" size="14" />
+						</button>
+					</div>
+
+					<div class="flex items-end gap-2">
+						<div class="flex-1 space-y-2">
+							<label class="text-sm font-medium">Radius</label>
+							<select
+								[value]="_ds.state().radius"
+								(change)="_onRadiusChange($event)"
+								class="border-input bg-background w-full rounded-md border px-3 py-2 text-sm"
+							>
+								@for (r of _ds.availableRadii(); track r.name) {
+									<option [value]="r.name" [selected]="_ds.state().radius === r.name">{{ r.label }}</option>
+								}
+							</select>
+						</div>
+						<button hlmBtn variant="ghost" size="icon-xs" (click)="_toggleLock('radius')" title="Lock Radius">
+							<ng-icon [name]="_ds.isLocked('radius') ? 'lucideLock' : 'lucideLockOpen'" size="14" />
+						</button>
+					</div>
+
+					<hlm-separator class="hidden md:block" />
+
+					<div class="flex items-end gap-2">
+						<div class="flex-1 space-y-2">
+							<label class="text-sm font-medium">Menu Accent</label>
+							<select
+								[value]="_ds.state().menuAccent"
+								(change)="_onMenuAccentChange($event)"
+								class="border-input bg-background w-full rounded-md border px-3 py-2 text-sm"
+							>
+								@for (a of _menuAccents; track a) {
+									<option [value]="a" [selected]="_ds.state().menuAccent === a">{{ a }}</option>
+								}
+							</select>
+						</div>
+						<button hlmBtn variant="ghost" size="icon-xs" (click)="_toggleLock('menuAccent')" title="Lock Menu Accent">
+							<ng-icon [name]="_ds.isLocked('menuAccent') ? 'lucideLock' : 'lucideLockOpen'" size="14" />
+						</button>
+					</div>
+
+					<div class="flex items-end gap-2">
+						<div class="flex-1 space-y-2">
+							<label class="text-sm font-medium">Menu Color</label>
+							<select
+								[value]="_ds.state().menuColor"
+								(change)="_onMenuColorChange($event)"
+								class="border-input bg-background w-full rounded-md border px-3 py-2 text-sm"
+							>
+								@for (c of _menuColors; track c) {
+									<option [value]="c" [selected]="_ds.state().menuColor === c">{{ c }}</option>
+								}
+							</select>
+						</div>
+						<button hlmBtn variant="ghost" size="icon-xs" (click)="_toggleLock('menuColor')" title="Lock Menu Color">
+							<ng-icon [name]="_ds.isLocked('menuColor') ? 'lucideLock' : 'lucideLockOpen'" size="14" />
+						</button>
+					</div>
+				</div>
+			</div>
+
+			<div class="flex min-w-0 flex-col gap-2 p-6 pt-0 md:flex-col">
+				<button hlmBtn size="sm" class="w-full" (click)="_openProjectForm.set(true)">
+					<ng-icon name="lucideFileCode" class="mr-2" size="14" />
+					Get Code
+				</button>
+			</div>
+		</div>
+
+		<spartan-open-preset-dialog
+			[open]="_openPresetOpen()"
+			(openChange)="_openPresetOpen.set($event)"
+			(apply)="_ds.applyPresetCode($event)"
+		/>
+		<spartan-project-form [open]="_openProjectForm()" (openChange)="_openProjectForm.set($event)" />
+		<spartan-action-menu [open]="_actionMenuOpen()" (openChange)="_actionMenuOpen.set($event)" />
+	`,
+})
+export class Customizer {
+	protected readonly _ds = inject(DesignSystemService);
+
+	protected readonly _styles = STYLES;
+	protected readonly _baseColors = BASE_COLORS;
+	protected readonly _baseThemes = BASE_COLORS;
+	protected readonly _colorThemes = COLOR_THEMES;
+	protected readonly _iconLibraries = ICON_LIBRARIES;
+	protected readonly _fonts = FONT_DEFINITIONS;
+	protected readonly _menuAccents = MENU_ACCENTS;
+	protected readonly _menuColors = MENU_COLORS;
+
+	protected readonly _openPresetOpen = signal(false);
+	protected readonly _openProjectForm = signal(false);
+	protected readonly _actionMenuOpen = signal(false);
+
+	protected readonly _bodyFontLabel = computed(() => {
+		const font = this._ds.state().font;
+		const def = FONT_DEFINITIONS.find((f) => f.value === font);
+		return def?.label ?? font;
+	});
+
+	protected _themeLabel(name: string): string {
+		return name.charAt(0).toUpperCase() + name.slice(1);
+	}
+
+	protected _toggleLock(param: LockableParam): void {
+		this._ds.toggleLock(param);
+	}
+
+	protected _onStyleChange(event: Event): void {
+		const value = (event.target as HTMLSelectElement).value;
+		this._ds.update({ style: value as DesignSystemConfig['style'] });
+	}
+
+	protected _onBaseColorChange(event: Event): void {
+		const value = (event.target as HTMLSelectElement).value;
+		this._ds.update({ baseColor: value as DesignSystemConfig['baseColor'] });
+	}
+
+	protected _onThemeChange(event: Event): void {
+		const value = (event.target as HTMLSelectElement).value;
+		this._ds.update({ theme: value as DesignSystemConfig['theme'] });
+	}
+
+	protected _onChartColorChange(event: Event): void {
+		const value = (event.target as HTMLSelectElement).value;
+		this._ds.update({ chartColor: value as DesignSystemConfig['chartColor'] });
+	}
+
+	protected _onFontChange(event: Event): void {
+		const value = (event.target as HTMLSelectElement).value;
+		this._ds.update({ font: value as DesignSystemConfig['font'] });
+	}
+
+	protected _onFontHeadingChange(event: Event): void {
+		const value = (event.target as HTMLSelectElement).value;
+		this._ds.update({ fontHeading: value as DesignSystemConfig['fontHeading'] });
+	}
+
+	protected _onIconLibraryChange(event: Event): void {
+		const value = (event.target as HTMLSelectElement).value;
+		this._ds.update({ iconLibrary: value as DesignSystemConfig['iconLibrary'] });
+	}
+
+	protected _onRadiusChange(event: Event): void {
+		const value = (event.target as HTMLSelectElement).value;
+		this._ds.update({ radius: value as DesignSystemConfig['radius'] });
+	}
+
+	protected _onMenuAccentChange(event: Event): void {
+		const value = (event.target as HTMLSelectElement).value;
+		this._ds.update({ menuAccent: value as DesignSystemConfig['menuAccent'] });
+	}
+
+	protected _onMenuColorChange(event: Event): void {
+		const value = (event.target as HTMLSelectElement).value;
+		this._ds.update({ menuColor: value as DesignSystemConfig['menuColor'] });
+	}
+}

--- a/apps/app/src/app/pages/(create)/components/main-menu.ts
+++ b/apps/app/src/app/pages/(create)/components/main-menu.ts
@@ -1,0 +1,100 @@
+import { Component, inject } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+	lucideMenu,
+	lucideMoon,
+	lucideRedo2,
+	lucideRotateCw as lucideReset,
+	lucideRotateCcw,
+	lucideRotateCw,
+	lucideShuffle,
+	lucideSun,
+	lucideUndo2,
+} from '@ng-icons/lucide';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmPopoverImports } from '@spartan-ng/helm/popover';
+import { DesignSystemService } from '../lib/design-system.service';
+
+@Component({
+	selector: 'spartan-main-menu',
+	imports: [HlmButton, HlmPopoverImports, NgIcon],
+	providers: [
+		provideIcons({
+			lucideMenu,
+			lucideRotateCcw,
+			lucideRotateCw,
+			lucideShuffle,
+			lucideMoon,
+			lucideSun,
+			lucideUndo2,
+			lucideRedo2,
+			lucideReset,
+		}),
+	],
+	template: `
+		<hlm-popover sideOffset="5" align="end">
+			<button hlmPopoverTrigger hlmBtn variant="ghost" size="icon-xs" title="Menu">
+				<ng-icon name="lucideMenu" size="16" />
+			</button>
+			<div *hlmPopoverPortal="let ctx" hlmPopoverContent class="w-56 p-1">
+				<div class="space-y-0.5">
+					<button hlmBtn variant="ghost" size="sm" class="w-full justify-start gap-2" (click)="_undo(ctx)">
+						<ng-icon name="lucideUndo2" size="14" />
+						<span class="flex-1 text-left">Undo</span>
+						<kbd class="text-muted-foreground ml-auto text-xs">Ctrl+Z</kbd>
+					</button>
+					<button hlmBtn variant="ghost" size="sm" class="w-full justify-start gap-2" (click)="_redo(ctx)">
+						<ng-icon name="lucideRedo2" size="14" />
+						<span class="flex-1 text-left">Redo</span>
+						<kbd class="text-muted-foreground ml-auto text-xs">Ctrl+Shift+Z</kbd>
+					</button>
+					<div hlmPopoverSeparator></div>
+					<button hlmBtn variant="ghost" size="sm" class="w-full justify-start gap-2" (click)="_shuffle(ctx)">
+						<ng-icon name="lucideShuffle" size="14" />
+						<span class="flex-1 text-left">Shuffle</span>
+						<kbd class="text-muted-foreground ml-auto text-xs">R</kbd>
+					</button>
+					<button hlmBtn variant="ghost" size="sm" class="w-full justify-start gap-2" (click)="_reset(ctx)">
+						<ng-icon name="lucideRotateCcw" size="14" />
+						<span class="flex-1 text-left">Reset</span>
+						<kbd class="text-muted-foreground ml-auto text-xs">Shift+R</kbd>
+					</button>
+					<div hlmPopoverSeparator></div>
+					<button hlmBtn variant="ghost" size="sm" class="w-full justify-start gap-2" (click)="_toggleDark(ctx)">
+						<ng-icon [name]="_ds.darkMode() ? 'lucideSun' : 'lucideMoon'" size="14" />
+						<span class="flex-1 text-left">{{ _ds.darkMode() ? 'Light' : 'Dark' }}</span>
+						<kbd class="text-muted-foreground ml-auto text-xs">D</kbd>
+					</button>
+				</div>
+			</div>
+		</hlm-popover>
+	`,
+})
+export class MainMenu {
+	protected readonly _ds = inject(DesignSystemService);
+
+	protected _undo(ctx: { close: () => void }): void {
+		this._ds.undo();
+		ctx.close();
+	}
+
+	protected _redo(ctx: { close: () => void }): void {
+		this._ds.redo();
+		ctx.close();
+	}
+
+	protected _shuffle(ctx: { close: () => void }): void {
+		this._ds.randomize();
+		ctx.close();
+	}
+
+	protected _reset(ctx: { close: () => void }): void {
+		this._ds.reset();
+		ctx.close();
+	}
+
+	protected _toggleDark(ctx: { close: () => void }): void {
+		this._ds.darkMode.set(!this._ds.darkMode());
+		ctx.close();
+	}
+}

--- a/apps/app/src/app/pages/(create)/components/open-preset.ts
+++ b/apps/app/src/app/pages/(create)/components/open-preset.ts
@@ -1,0 +1,77 @@
+import { Component, input, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideCheck, lucideX } from '@ng-icons/lucide';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmDialogImports } from '@spartan-ng/helm/dialog';
+import { HlmInput } from '@spartan-ng/helm/input';
+import { HlmLabel } from '@spartan-ng/helm/label';
+import { isPresetCode } from '@spartan-ng/registry';
+
+@Component({
+	selector: 'spartan-open-preset-dialog',
+	imports: [FormsModule, HlmButton, HlmDialogImports, HlmInput, HlmLabel, NgIcon],
+	providers: [provideIcons({ lucideCheck, lucideX })],
+	template: `
+		<hlm-dialog [state]="open()" (stateChange)="openChange.emit($event)">
+			<hlm-dialog-content class="sm:max-w-md" *hlmDialogPortal="let ctx">
+				<hlm-dialog-header>
+					<h3 hlmDialogTitle>Open Preset</h3>
+					<p hlmDialogDescription>Paste a preset code to load its configuration.</p>
+				</hlm-dialog-header>
+				<div class="grid gap-4 py-4">
+					<div class="grid gap-3">
+						<label hlmLabel for="preset-code">Preset Code</label>
+						<div class="flex gap-2">
+							<input
+								hlmInput
+								id="preset-code"
+								[value]="_inputValue()"
+								(input)="_inputValue.set($any($event.target).value)"
+								placeholder="b0 or --preset b0"
+								class="flex-1"
+								[class.border-destructive]="!!_error()"
+							/>
+							<button hlmBtn size="sm" [disabled]="!_inputValue() || _inputValue().length < 2" (click)="_apply(ctx)">
+								<ng-icon name="lucideCheck" class="mr-1" size="14" />
+								Apply
+							</button>
+						</div>
+						@if (_error()) {
+							<p class="text-destructive text-xs">{{ _error() }}</p>
+						}
+					</div>
+				</div>
+				<hlm-dialog-footer>
+					<button hlmBtn variant="outline" hlmDialogClose>
+						<ng-icon name="lucideX" class="mr-1" size="14" />
+						Cancel
+					</button>
+				</hlm-dialog-footer>
+			</hlm-dialog-content>
+		</hlm-dialog>
+	`,
+})
+export class OpenPresetDialog {
+	public readonly open = input(false);
+	public readonly openChange = output<boolean>();
+	public readonly apply = output<string>();
+
+	protected readonly _inputValue = signal('');
+	protected readonly _error = signal('');
+
+	protected _apply(ctx: { close: () => void }): void {
+		const raw = this._inputValue().trim();
+		let code = raw;
+		if (raw.startsWith('--preset ')) {
+			code = raw.slice('--preset '.length).trim();
+		}
+		if (!isPresetCode(code)) {
+			this._error.set('Invalid preset code. Must start with "b" (e.g., b0).');
+			return;
+		}
+		this._error.set('');
+		this.apply.emit(code);
+		ctx.close();
+	}
+}

--- a/apps/app/src/app/pages/(create)/components/preview.spec.ts
+++ b/apps/app/src/app/pages/(create)/components/preview.spec.ts
@@ -1,0 +1,40 @@
+import { provideHttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { vitest } from 'vitest';
+import { Preview } from './preview';
+
+describe('Preview', () => {
+	beforeEach(async () => {
+		Object.defineProperty(window, 'matchMedia', {
+			writable: true,
+			value: vitest.fn().mockImplementation((query: string) => ({
+				matches: false,
+				media: query,
+				addEventListener: vitest.fn(),
+				removeEventListener: vitest.fn(),
+				dispatchEvent: vitest.fn(),
+			})),
+		});
+
+		await TestBed.configureTestingModule({
+			providers: [provideRouter([]), provideHttpClient()],
+			imports: [Preview],
+		}).compileComponents();
+	});
+
+	it('should create the component', () => {
+		const fixture = TestBed.createComponent(Preview);
+		const component = fixture.componentInstance;
+		expect(component).toBeTruthy();
+	});
+
+	it('should render an iframe', () => {
+		const fixture = TestBed.createComponent(Preview);
+		fixture.detectChanges();
+		const element = fixture.nativeElement as HTMLElement;
+		const iframe = element.querySelector('iframe');
+		expect(iframe).toBeTruthy();
+		expect(iframe?.title).toBe('Preview');
+	});
+});

--- a/apps/app/src/app/pages/(create)/components/preview.ts
+++ b/apps/app/src/app/pages/(create)/components/preview.ts
@@ -1,0 +1,100 @@
+import { Component, computed, effect, inject, signal } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideLayoutDashboard, lucideMonitor, lucideMoon, lucideSun } from '@ng-icons/lucide';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { DesignSystemService } from '../lib/design-system.service';
+
+@Component({
+	selector: 'spartan-preview',
+	imports: [HlmButton, NgIcon],
+	providers: [provideIcons({ lucideMonitor, lucideMoon, lucideSun, lucideLayoutDashboard })],
+	template: `
+		<div
+			class="ring-foreground/10 md:ring-muted dark:ring-foreground/10 relative flex flex-1 flex-col justify-center overflow-hidden rounded-2xl ring"
+		>
+			<div class="flex items-center justify-between gap-2 px-3 py-2">
+				<div class="flex items-center gap-1">
+					<button
+						hlmBtn
+						variant="outline"
+						size="xs"
+						[class.bg-muted]="_previewItem() === 'preview-01'"
+						(click)="_previewItem.set('preview-01')"
+					>
+						Preview 01
+					</button>
+					<button
+						hlmBtn
+						variant="outline"
+						size="xs"
+						[class.bg-muted]="_previewItem() === 'preview-02'"
+						(click)="_previewItem.set('preview-02')"
+					>
+						Preview 02
+					</button>
+				</div>
+				<div class="flex items-center gap-1">
+					<button
+						hlmBtn
+						variant="ghost"
+						size="icon-xs"
+						(click)="_ds.darkMode.set(!_ds.darkMode())"
+						[title]="_ds.darkMode() ? 'Switch to Light (D)' : 'Switch to Dark (D)'"
+					>
+						<ng-icon [name]="_ds.darkMode() ? 'lucideMoon' : 'lucideSun'" size="14" />
+					</button>
+				</div>
+			</div>
+			<div class="relative z-0 mx-auto flex w-full flex-1 flex-col overflow-hidden">
+				<div class="bg-muted dark:bg-muted/30 absolute inset-0"></div>
+				<iframe [src]="_iframeSrc()" class="z-10 size-full flex-1" title="Preview"></iframe>
+			</div>
+		</div>
+	`,
+})
+export class Preview {
+	private readonly _ds = inject(DesignSystemService);
+	private readonly _sanitizer = inject(DomSanitizer);
+
+	protected readonly _previewItem = signal('preview-01');
+
+	protected readonly _iframeSrc = computed(() => {
+		const params = this._ds.state();
+		const preset = this._ds.presetCode();
+		const base = 'nova';
+		const item = this._previewItem();
+		const darkMode = this._ds.darkMode() ? '1' : '0';
+		const url = `/preview/${base}/${item}?preset=${preset}&style=${params.style}&baseColor=${params.baseColor}&theme=${params.theme}&iconLibrary=${params.iconLibrary}&font=${params.font}&fontHeading=${params.fontHeading}&radius=${params.radius}&menuAccent=${params.menuAccent}&menuColor=${params.menuColor}&darkMode=${darkMode}`;
+		return this._sanitizer.bypassSecurityTrustResourceUrl(url);
+	});
+
+	constructor() {
+		effect(() => {
+			const iframe = document.querySelector<HTMLIFrameElement>('iframe');
+			if (!iframe?.contentWindow) return;
+			const params = this._ds.state();
+			const preset = this._ds.presetCode();
+			iframe.contentWindow.postMessage(
+				{
+					type: 'design-system-params',
+					data: {
+						style: params.style,
+						baseColor: params.baseColor,
+						theme: params.theme,
+						chartColor: params.chartColor,
+						iconLibrary: params.iconLibrary,
+						font: params.font,
+						fontHeading: params.fontHeading,
+						radius: params.radius,
+						menuAccent: params.menuAccent,
+						menuColor: params.menuColor,
+						presetCode: preset,
+						darkMode: this._ds.darkMode(),
+					},
+				},
+				'*',
+			);
+		});
+	}
+}

--- a/apps/app/src/app/pages/(create)/components/project-form.ts
+++ b/apps/app/src/app/pages/(create)/components/project-form.ts
@@ -1,0 +1,132 @@
+import { Component, computed, inject, input, output, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideCheck, lucideCopy, lucideTerminal } from '@ng-icons/lucide';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmDialogImports } from '@spartan-ng/helm/dialog';
+import { HlmLabel } from '@spartan-ng/helm/label';
+import { HlmSwitch } from '@spartan-ng/helm/switch';
+import { HlmTabsImports } from '@spartan-ng/helm/tabs';
+import { DesignSystemService } from '../lib/design-system.service';
+
+@Component({
+	selector: 'spartan-project-form',
+	imports: [HlmButton, HlmDialogImports, HlmLabel, HlmSwitch, HlmTabsImports, NgIcon],
+	providers: [provideIcons({ lucideCheck, lucideCopy, lucideTerminal })],
+	template: `
+		<hlm-dialog [state]="open()" (stateChange)="openChange.emit($event)">
+			<hlm-dialog-content class="sm:max-w-lg" *hlmDialogPortal="let ctx">
+				<hlm-dialog-header>
+					<h3 hlmDialogTitle>Get Code</h3>
+					<p hlmDialogDescription>Use these commands to set up your project.</p>
+				</hlm-dialog-header>
+
+				<hlm-tabs tab="init" class="w-full">
+					<hlm-tabs-list class="grid w-full grid-cols-3">
+						<button hlmTabsTrigger="init">New Project</button>
+						<button hlmTabsTrigger="apply">Existing</button>
+						<button hlmTabsTrigger="theme">Theme</button>
+					</hlm-tabs-list>
+
+					<div hlmTabsContent="init" class="mt-4 space-y-4">
+						<div class="flex flex-wrap gap-2">
+							<button
+								hlmBtn
+								variant="outline"
+								size="sm"
+								[class.bg-muted]="_template() === 'angular'"
+								(click)="_template.set('angular')"
+							>
+								<ng-icon name="lucideTerminal" class="mr-1" size="14" />
+								Angular
+							</button>
+						</div>
+						<div class="flex flex-wrap gap-4">
+							<label class="flex items-center gap-2" hlmLabel>
+								<hlm-switch [checked]="_ds.rtl()" (checkedChange)="_ds.rtl.set($event)" />
+								<span class="text-sm">RTL</span>
+							</label>
+							<label class="flex items-center gap-2" hlmLabel>
+								<hlm-switch [checked]="_ds.pointer()" (checkedChange)="_ds.pointer.set($event)" />
+								<span class="text-sm">Pointer</span>
+							</label>
+						</div>
+						<div class="bg-muted flex items-center gap-2 rounded-md p-3 text-sm">
+							<code class="flex-1 font-mono text-xs break-all">{{ _initCommand() }}</code>
+							<button
+								hlmBtn
+								variant="ghost"
+								size="icon-xs"
+								(click)="_copy(_initCommand())"
+								[title]="_copied() ? 'Copied' : 'Copy'"
+							>
+								<ng-icon [name]="_copied() ? 'lucideCheck' : 'lucideCopy'" size="14" />
+							</button>
+						</div>
+					</div>
+
+					<div hlmTabsContent="apply" class="mt-4 space-y-4">
+						<div class="bg-muted flex items-center gap-2 rounded-md p-3 text-sm">
+							<code class="flex-1 font-mono text-xs break-all">{{ _applyCommand() }}</code>
+							<button
+								hlmBtn
+								variant="ghost"
+								size="icon-xs"
+								(click)="_copy(_applyCommand())"
+								[title]="_copied() ? 'Copied' : 'Copy'"
+							>
+								<ng-icon [name]="_copied() ? 'lucideCheck' : 'lucideCopy'" size="14" />
+							</button>
+						</div>
+					</div>
+
+					<div hlmTabsContent="theme" class="mt-4 space-y-4">
+						<div class="bg-muted max-h-64 overflow-y-auto rounded-md p-3">
+							<pre class="font-mono text-xs leading-relaxed">{{ _themeCss() }}</pre>
+						</div>
+						<button hlmBtn size="sm" class="w-full" (click)="_copy(_themeCss())">
+							{{ _copied() ? 'Copied' : 'Copy Theme CSS' }}
+						</button>
+					</div>
+				</hlm-tabs>
+
+				<hlm-dialog-footer>
+					<button hlmBtn variant="outline" hlmDialogClose>Close</button>
+				</hlm-dialog-footer>
+			</hlm-dialog-content>
+		</hlm-dialog>
+	`,
+})
+export class ProjectForm {
+	protected readonly _ds = inject(DesignSystemService);
+
+	public readonly open = input(false);
+	public readonly openChange = output<boolean>();
+
+	protected readonly _template = signal('angular');
+	protected readonly _copied = signal(false);
+
+	protected readonly _initCommand = computed(() => {
+		const preset = this._ds.presetCode();
+		const rtlFlag = this._ds.rtl() ? ' --rtl' : '';
+		const pointerFlag = this._ds.pointer() ? ' --pointer' : '';
+		return `npx spartan init --preset ${preset}${rtlFlag}${pointerFlag}`;
+	});
+
+	protected readonly _applyCommand = computed(() => {
+		const preset = this._ds.presetCode();
+		return `npx spartan apply --preset ${preset}`;
+	});
+
+	protected readonly _themeCss = computed(() => {
+		const config = this._ds.state();
+		const style = config.style;
+		const baseColor = config.baseColor;
+		return `/* spartan design system - ${style}/${baseColor} */\n\n@import "tailwindcss";\n@import "@spartan-ng/helm";\n\n@layer base {\n  :root {\n    --font-sans: 'Geist', sans-serif;\n    --font-mono: 'Geist Mono', monospace;\n    --radius: 0.625rem;\n  }\n}\n`;
+	});
+
+	protected _copy(text: string): void {
+		navigator.clipboard.writeText(text);
+		this._copied.set(true);
+		setTimeout(() => this._copied.set(false), 2000);
+	}
+}

--- a/apps/app/src/app/pages/(create)/components/welcome-dialog.ts
+++ b/apps/app/src/app/pages/(create)/components/welcome-dialog.ts
@@ -1,0 +1,44 @@
+import { Component, signal } from '@angular/core';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmDialogImports } from '@spartan-ng/helm/dialog';
+
+const STORAGE_KEY = 'spartan-create-welcome-dismissed';
+
+@Component({
+	selector: 'spartan-welcome-dialog',
+	imports: [HlmButton, HlmDialogImports],
+	template: `
+		<hlm-dialog [state]="_open()" (stateChange)="_open.set($event)">
+			<hlm-dialog-content class="sm:max-w-md" *hlmDialogPortal="let ctx">
+				<hlm-dialog-header>
+					<h3 hlmDialogTitle>Build your own spartan</h3>
+					<p hlmDialogDescription>
+						Customize your design system — pick styles, colors, fonts, and more. Then copy the CLI command to use it in
+						your project.
+					</p>
+				</hlm-dialog-header>
+				<div class="text-muted-foreground py-4 text-sm">
+					<ul class="list-disc space-y-1 pl-5">
+						<li>Choose from 6 component styles</li>
+						<li>Pick colors, fonts, and icons</li>
+						<li>Live preview to see changes instantly</li>
+						<li>Share your preset with a short code</li>
+					</ul>
+				</div>
+				<hlm-dialog-footer>
+					<button hlmBtn (click)="_dismiss(ctx)">Get Started</button>
+				</hlm-dialog-footer>
+			</hlm-dialog-content>
+		</hlm-dialog>
+	`,
+})
+export class WelcomeDialog {
+	protected readonly _open = signal(typeof localStorage !== 'undefined' ? !localStorage.getItem(STORAGE_KEY) : false);
+
+	protected _dismiss(ctx: { close: () => void }): void {
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem(STORAGE_KEY, 'true');
+		}
+		ctx.close();
+	}
+}

--- a/apps/app/src/app/pages/(create)/create.page.spec.ts
+++ b/apps/app/src/app/pages/(create)/create.page.spec.ts
@@ -1,0 +1,44 @@
+import { provideHttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { vitest } from 'vitest';
+import CreatePage from './create.page';
+
+describe('CreatePage', () => {
+	beforeEach(async () => {
+		Object.defineProperty(window, 'matchMedia', {
+			writable: true,
+			value: vitest.fn().mockImplementation((query: string) => ({
+				matches: false,
+				media: query,
+				addEventListener: vitest.fn(),
+				removeEventListener: vitest.fn(),
+				dispatchEvent: vitest.fn(),
+			})),
+		});
+		Object.defineProperty(globalThis, 'localStorage', {
+			writable: true,
+			value: { getItem: vitest.fn(), setItem: vitest.fn() },
+		});
+		Element.prototype.scrollIntoView = vitest.fn();
+
+		await TestBed.configureTestingModule({
+			providers: [provideRouter([]), provideHttpClient()],
+			imports: [CreatePage],
+		}).compileComponents();
+	});
+
+	it('should create the component', () => {
+		const fixture = TestBed.createComponent(CreatePage);
+		const component = fixture.componentInstance;
+		expect(component).toBeTruthy();
+	});
+
+	it('should render preview and customizer', () => {
+		const fixture = TestBed.createComponent(CreatePage);
+		fixture.detectChanges();
+		const element = fixture.nativeElement as HTMLElement;
+		expect(element.querySelector('spartan-preview')).toBeTruthy();
+		expect(element.querySelector('spartan-customizer')).toBeTruthy();
+	});
+});

--- a/apps/app/src/app/pages/(create)/create.page.ts
+++ b/apps/app/src/app/pages/(create)/create.page.ts
@@ -1,0 +1,85 @@
+import type { RouteMeta } from '@analogjs/router';
+import { Component, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { metaWith } from '@spartan-ng/app/app/shared/meta/meta.util';
+import { fromEvent } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { Customizer } from './components/customizer';
+import { Preview } from './components/preview';
+import { WelcomeDialog } from './components/welcome-dialog';
+import { DesignSystemService } from './lib/design-system.service';
+
+export const routeMeta: RouteMeta = {
+	meta: metaWith('Create - spartan', 'Customize your spartan project. Pick styles, colors, fonts, and more.'),
+	title: 'Create - spartan',
+};
+
+@Component({
+	selector: 'spartan-create',
+	imports: [Preview, Customizer, WelcomeDialog],
+	template: `
+		<div
+			class="relative z-10 flex min-h-0 flex-1 flex-col overflow-hidden"
+			style="--customizer-width: 14rem; --gap: 1rem;"
+		>
+			<div class="flex min-h-0 flex-1 flex-col gap-(--gap) p-(--gap) pt-[calc(var(--gap)*0.25)] md:flex-row-reverse">
+				<spartan-preview />
+				<spartan-customizer
+					class="isolate min-h-[151px] w-full self-start rounded-2xl md:h-full md:max-h-full md:min-h-0 md:w-(--customizer-width)"
+				/>
+			</div>
+		</div>
+		<spartan-welcome-dialog />
+	`,
+})
+export default class CreatePage {
+	private readonly _ds = inject(DesignSystemService);
+	private readonly _actionMenuOpen = signal(false);
+
+	constructor() {
+		fromEvent<KeyboardEvent>(document, 'keydown')
+			.pipe(
+				takeUntilDestroyed(),
+				filter((e) => !(e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement)),
+			)
+			.subscribe((e) => {
+				const ctrl = e.ctrlKey || e.metaKey;
+
+				if (ctrl && e.key === 'z' && !e.shiftKey) {
+					e.preventDefault();
+					this._ds.undo();
+					return;
+				}
+				if (ctrl && e.key === 'z' && e.shiftKey) {
+					e.preventDefault();
+					this._ds.redo();
+					return;
+				}
+				if (ctrl && e.key === 'y') {
+					e.preventDefault();
+					this._ds.redo();
+					return;
+				}
+				if (!ctrl && !e.shiftKey && e.key === 'r') {
+					e.preventDefault();
+					this._ds.randomize();
+					return;
+				}
+				if (!ctrl && e.shiftKey && (e.key === 'R' || e.key === 'r')) {
+					e.preventDefault();
+					this._ds.reset();
+					return;
+				}
+				if (!ctrl && !e.shiftKey && (e.key === 'd' || e.key === 'D')) {
+					e.preventDefault();
+					this._ds.darkMode.update((v) => !v);
+					return;
+				}
+				if (!ctrl && !e.shiftKey && (e.key === 'o' || e.key === 'O')) {
+					e.preventDefault();
+					document.querySelector<HTMLElement>('[title="Open Preset (O)"]')?.click();
+					return;
+				}
+			});
+	}
+}

--- a/apps/app/src/app/pages/(create)/lib/design-system.service.spec.ts
+++ b/apps/app/src/app/pages/(create)/lib/design-system.service.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { DesignSystemService } from './design-system.service';
+
+describe('DesignSystemService', () => {
+	let service: DesignSystemService;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			providers: [provideRouter([])],
+		});
+		service = TestBed.inject(DesignSystemService);
+	});
+
+	it('should start with default config', () => {
+		const state = service.state();
+		expect(state.style).toBe('nova');
+		expect(state.baseColor).toBe('neutral');
+		expect(state.theme).toBe('neutral');
+		expect(state.iconLibrary).toBe('lucide');
+		expect(state.font).toBe('inter');
+	});
+
+	it('should update individual params', () => {
+		service.update({ style: 'vega' });
+		expect(service.state().style).toBe('vega');
+	});
+
+	it('should generate preset code', () => {
+		const code = service.presetCode();
+		expect(code).toMatch(/^b[0-9a-zA-Z]+$/);
+	});
+
+	it('should update multiple params at once', () => {
+		service.update({ style: 'lyra', baseColor: 'zinc', font: 'geist' });
+		const state = service.state();
+		expect(state.style).toBe('lyra');
+		expect(state.baseColor).toBe('zinc');
+		expect(state.font).toBe('geist');
+	});
+
+	it('should update preset code after config change', () => {
+		const initial = service.presetCode();
+		service.update({ theme: 'blue' });
+		const updated = service.presetCode();
+		expect(updated).not.toBe(initial);
+	});
+});

--- a/apps/app/src/app/pages/(create)/lib/design-system.service.ts
+++ b/apps/app/src/app/pages/(create)/lib/design-system.service.ts
@@ -1,0 +1,282 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import {
+	COLOR_THEMES,
+	DEFAULT_CONFIG,
+	FONTS,
+	RADII,
+	THEMES,
+	decodePreset,
+	encodePreset,
+	getThemesForBaseColor,
+	type DesignSystemConfig,
+} from '@spartan-ng/registry';
+import { map } from 'rxjs/operators';
+
+export type LockableParam =
+	| 'style'
+	| 'baseColor'
+	| 'theme'
+	| 'chartColor'
+	| 'iconLibrary'
+	| 'font'
+	| 'fontHeading'
+	| 'radius'
+	| 'menuAccent'
+	| 'menuColor';
+
+const DS_PARAMS: LockableParam[] = [
+	'style',
+	'baseColor',
+	'theme',
+	'chartColor',
+	'iconLibrary',
+	'font',
+	'fontHeading',
+	'radius',
+	'menuAccent',
+	'menuColor',
+];
+
+interface HistoryEntry {
+	config: DesignSystemConfig;
+	code: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class DesignSystemService {
+	private readonly _router = inject(Router);
+	private readonly _route = inject(ActivatedRoute);
+
+	private readonly _state = signal<DesignSystemConfig>(DEFAULT_CONFIG);
+	public readonly state = this._state.asReadonly();
+
+	public readonly presetCode = computed(() => encodePreset(this._state()));
+
+	public readonly availableThemes = computed(() => {
+		return getThemesForBaseColor(this._state().baseColor);
+	});
+
+	public readonly availableRadii = computed(() => {
+		const style = this._state().style;
+		if (style === 'lyra' || style === 'maia') {
+			return RADII.filter((r) => r.name === 'none');
+		}
+		if (style === 'mira') {
+			return RADII.filter((r) => r.name !== 'large');
+		}
+		return [...RADII];
+	});
+
+	public readonly darkMode = signal(false);
+	public readonly rtl = signal(false);
+	public readonly pointer = signal(false);
+
+	private readonly _locks = signal<Set<LockableParam>>(new Set());
+	public readonly locks = this._locks.asReadonly();
+
+	private readonly _history = signal<HistoryEntry[]>([]);
+	private _historyIndex = -1;
+
+	constructor() {
+		this._route.queryParams
+			.pipe(
+				takeUntilDestroyed(),
+				map((params) => this._resolveFromParams(params)),
+			)
+			.subscribe((config) => {
+				if (config) {
+					this._state.set(config);
+					this._pushHistory(config);
+				}
+			});
+	}
+
+	private _resolveFromParams(params: Record<string, string | undefined>): DesignSystemConfig | null {
+		const preset = params['preset'];
+		if (preset) {
+			const decoded = decodePreset(preset);
+			if (decoded) {
+				return { ...DEFAULT_CONFIG, ...decoded };
+			}
+		}
+
+		const hasAnyDsParam = DS_PARAMS.some((p) => params[p] !== undefined);
+		if (!hasAnyDsParam) return null;
+
+		return {
+			style: (params['style'] as DesignSystemConfig['style']) ?? DEFAULT_CONFIG.style,
+			baseColor: (params['baseColor'] as DesignSystemConfig['baseColor']) ?? DEFAULT_CONFIG.baseColor,
+			theme: (params['theme'] as DesignSystemConfig['theme']) ?? DEFAULT_CONFIG.theme,
+			chartColor: (params['chartColor'] as DesignSystemConfig['chartColor']) ?? DEFAULT_CONFIG.chartColor,
+			iconLibrary: (params['iconLibrary'] as DesignSystemConfig['iconLibrary']) ?? DEFAULT_CONFIG.iconLibrary,
+			font: (params['font'] as DesignSystemConfig['font']) ?? DEFAULT_CONFIG.font,
+			fontHeading: (params['fontHeading'] as DesignSystemConfig['fontHeading']) ?? DEFAULT_CONFIG.fontHeading,
+			radius: (params['radius'] as DesignSystemConfig['radius']) ?? DEFAULT_CONFIG.radius,
+			menuAccent: (params['menuAccent'] as DesignSystemConfig['menuAccent']) ?? DEFAULT_CONFIG.menuAccent,
+			menuColor: (params['menuColor'] as DesignSystemConfig['menuColor']) ?? DEFAULT_CONFIG.menuColor,
+		};
+	}
+
+	private _pushHistory(config: DesignSystemConfig): void {
+		const entry: HistoryEntry = { config: { ...config }, code: encodePreset(config) };
+		this._history.update((h) => {
+			const trimmed = h.slice(0, this._historyIndex + 1);
+			trimmed.push(entry);
+			return trimmed.slice(-50);
+		});
+		this._historyIndex = this._history().length - 1;
+	}
+
+	public update(partial: Partial<DesignSystemConfig>): void {
+		const updated = { ...this._state(), ...partial };
+		this._normalizeConfig(updated);
+		this._state.set(updated);
+		const code = encodePreset(updated);
+		this._pushHistory(updated);
+		this._router.navigate([], {
+			queryParams: { preset: code },
+			queryParamsHandling: 'merge',
+			replaceUrl: true,
+		});
+	}
+
+	private _normalizeConfig(config: DesignSystemConfig): void {
+		const available = [...new Set([...THEMES])] as string[];
+		if (!available.includes(config.theme)) {
+			config.theme = config.baseColor as DesignSystemConfig['theme'];
+		}
+		if (!available.includes(config.chartColor)) {
+			config.chartColor = config.theme;
+		}
+		if (config.fontHeading === config.font) {
+			config.fontHeading = 'inherit';
+		}
+		if (config.style === 'lyra' || config.style === 'maia') {
+			config.radius = 'none';
+		} else if (config.style === 'mira' && config.radius === 'large') {
+			config.radius = 'default';
+		}
+	}
+
+	public isLocked(param: LockableParam): boolean {
+		return this._locks().has(param);
+	}
+
+	public toggleLock(param: LockableParam): void {
+		this._locks.update((locks) => {
+			const next = new Set(locks);
+			if (next.has(param)) {
+				next.delete(param);
+			} else {
+				next.add(param);
+			}
+			return next;
+		});
+	}
+
+	public randomize(): void {
+		const locks = this._locks();
+		const partial: Partial<DesignSystemConfig> = {};
+
+		if (!locks.has('style')) {
+			const allStyles = ['nova', 'vega', 'lyra', 'maia', 'mira', 'luma'] as const;
+			partial.style = allStyles[Math.floor(Math.random() * allStyles.length)];
+		}
+		if (!locks.has('baseColor')) {
+			const allBase = ['neutral', 'stone', 'zinc', 'gray', 'slate'] as const;
+			partial.baseColor = allBase[Math.floor(Math.random() * allBase.length)];
+		}
+		if (!locks.has('theme')) {
+			const allThemes = [...THEMES];
+			partial.theme = allThemes[Math.floor(Math.random() * allThemes.length)] as DesignSystemConfig['theme'];
+		}
+		if (!locks.has('chartColor')) {
+			const colors = [...COLOR_THEMES];
+			partial.chartColor = colors[Math.floor(Math.random() * colors.length)] as DesignSystemConfig['chartColor'];
+		}
+		if (!locks.has('iconLibrary')) {
+			const allIcons = ['lucide', 'radix', 'phosphor', 'tabler', 'hugeicons'] as const;
+			partial.iconLibrary = allIcons[Math.floor(Math.random() * allIcons.length)];
+		}
+		if (!locks.has('font')) {
+			partial.font = FONTS[Math.floor(Math.random() * FONTS.length)];
+		}
+		if (!locks.has('fontHeading')) {
+			partial.fontHeading = Math.random() < 0.7 ? 'inherit' : FONTS[Math.floor(Math.random() * FONTS.length)];
+		}
+		if (!locks.has('radius')) {
+			const radii = this.availableRadii();
+			if (radii.length > 0) {
+				partial.radius = radii[Math.floor(Math.random() * radii.length)].name;
+			}
+		}
+		if (!locks.has('menuAccent')) {
+			partial.menuAccent = Math.random() < 0.5 ? 'subtle' : 'bold';
+		}
+		if (!locks.has('menuColor')) {
+			partial.menuColor = Math.random() < 0.5 ? 'default' : 'inverted';
+		}
+
+		this.update(partial);
+	}
+
+	public undo(): void {
+		if (this._historyIndex > 0) {
+			this._historyIndex--;
+			const entry = this._history()[this._historyIndex];
+			this._state.set({ ...entry.config });
+			this._router.navigate([], {
+				queryParams: { preset: entry.code },
+				queryParamsHandling: 'merge',
+				replaceUrl: true,
+			});
+		}
+	}
+
+	public redo(): void {
+		if (this._historyIndex < this._history().length - 1) {
+			this._historyIndex++;
+			const entry = this._history()[this._historyIndex];
+			this._state.set({ ...entry.config });
+			this._router.navigate([], {
+				queryParams: { preset: entry.code },
+				queryParamsHandling: 'merge',
+				replaceUrl: true,
+			});
+		}
+	}
+
+	public canUndo(): boolean {
+		return this._historyIndex > 0;
+	}
+
+	public canRedo(): boolean {
+		return this._historyIndex < this._history().length - 1;
+	}
+
+	public reset(): void {
+		this._state.set(DEFAULT_CONFIG);
+		const code = encodePreset(DEFAULT_CONFIG);
+		this._pushHistory(DEFAULT_CONFIG);
+		this._router.navigate([], {
+			queryParams: { preset: code },
+			queryParamsHandling: 'merge',
+			replaceUrl: true,
+		});
+	}
+
+	public applyPresetCode(code: string): boolean {
+		const decoded = decodePreset(code);
+		if (!decoded) return false;
+		this.update(decoded);
+		return true;
+	}
+
+	public getShareUrl(): string {
+		const url = new URL(window.location.href);
+		url.searchParams.set('preset', this.presetCode());
+		return url.toString();
+	}
+}

--- a/apps/app/src/app/pages/(create)/lib/preset-code.spec.ts
+++ b/apps/app/src/app/pages/(create)/lib/preset-code.spec.ts
@@ -1,0 +1,16 @@
+import { DEFAULT_CONFIG, type DesignSystemConfig } from '@spartan-ng/registry';
+import { describe, expect, it } from 'vitest';
+import { getPresetCode } from './preset-code';
+
+describe('getPresetCode', () => {
+	it('returns a valid preset code for default config', () => {
+		const code = getPresetCode(DEFAULT_CONFIG);
+		expect(code).toMatch(/^b[0-9a-zA-Z]+$/);
+	});
+
+	it('returns different codes for different configs', () => {
+		const config1: DesignSystemConfig = { ...DEFAULT_CONFIG, style: 'nova' };
+		const config2: DesignSystemConfig = { ...DEFAULT_CONFIG, style: 'vega' };
+		expect(getPresetCode(config1)).not.toBe(getPresetCode(config2));
+	});
+});

--- a/apps/app/src/app/pages/(create)/lib/preset-code.ts
+++ b/apps/app/src/app/pages/(create)/lib/preset-code.ts
@@ -1,0 +1,5 @@
+import { DEFAULT_CONFIG, encodePreset, type DesignSystemConfig } from '@spartan-ng/registry';
+
+export function getPresetCode(config: DesignSystemConfig): string {
+	return encodePreset({ ...DEFAULT_CONFIG, ...config });
+}

--- a/apps/app/src/app/shared/components/navigation-items.ts
+++ b/apps/app/src/app/shared/components/navigation-items.ts
@@ -18,6 +18,7 @@ export const pageNavs: Link[] = [
 	{ label: 'Blocks', url: '/blocks' },
 	{ label: 'Colors', url: '/colors' },
 	{ label: 'Stack', url: '/stack' },
+	{ label: 'Create', url: '/create', new: true },
 ];
 
 export const components: Link[] = [

--- a/apps/app/src/app/shared/header/header.ts
+++ b/apps/app/src/app/shared/header/header.ts
@@ -74,6 +74,7 @@ import { HeaderMobileNav } from './header-mobile-nav';
 					<a spartanNavLink="/blocks">Blocks</a>
 					<a spartanNavLink="/colors">Colors</a>
 					<a spartanNavLink="/stack">Stack</a>
+					<a spartanNavLink="/create" class="text-primary font-semibold">Create</a>
 				</div>
 
 				<div class="ml-auto flex items-center gap-2 md:flex-1 md:justify-end">

--- a/apps/app/src/server/routes/create/init.ts
+++ b/apps/app/src/server/routes/create/init.ts
@@ -1,0 +1,65 @@
+import { DEFAULT_CONFIG, decodePreset, type DesignSystemConfig } from '@spartan-ng/registry';
+import { defineEventHandler, getQuery } from 'h3';
+
+export default defineEventHandler((event) => {
+	const query = getQuery(event);
+	const presetCode = query.preset as string | undefined;
+
+	let config: DesignSystemConfig = DEFAULT_CONFIG;
+	if (presetCode) {
+		const decoded = decodePreset(presetCode);
+		if (decoded) {
+			config = { ...DEFAULT_CONFIG, ...decoded };
+		}
+	}
+
+	return {
+		name: `${config.style}-${config.baseColor}`,
+		type: 'registry:base',
+		config: {
+			style: config.style,
+			baseColor: config.baseColor,
+			iconLibrary: config.iconLibrary,
+			menuAccent: config.menuAccent,
+			menuColor: config.menuColor,
+			tailwind: {
+				baseColor: config.baseColor,
+			},
+		},
+		cssVars: {
+			light: {
+				background: 'oklch(1 0 0)',
+				foreground: 'oklch(0.145 0 0)',
+				primary: 'oklch(0.205 0 0)',
+				'primary-foreground': 'oklch(0.985 0 0)',
+				secondary: 'oklch(0.97 0 0)',
+				'secondary-foreground': 'oklch(0.205 0 0)',
+				muted: 'oklch(0.97 0 0)',
+				'muted-foreground': 'oklch(0.556 0 0)',
+				accent: 'oklch(0.97 0 0)',
+				'accent-foreground': 'oklch(0.205 0 0)',
+				border: 'oklch(0.922 0 0)',
+				input: 'oklch(0.922 0 0)',
+				ring: 'oklch(0.708 0 0)',
+				radius: '0.625rem',
+			},
+			dark: {
+				background: 'oklch(0.145 0 0)',
+				foreground: 'oklch(0.985 0 0)',
+				primary: 'oklch(0.87 0 0)',
+				'primary-foreground': 'oklch(0.205 0 0)',
+				secondary: 'oklch(0.269 0 0)',
+				'secondary-foreground': 'oklch(0.985 0 0)',
+				muted: 'oklch(0.269 0 0)',
+				'muted-foreground': 'oklch(0.708 0 0)',
+				accent: 'oklch(0.371 0 0)',
+				'accent-foreground': 'oklch(0.985 0 0)',
+				border: 'oklch(1 0 0 / 10%)',
+				input: 'oklch(1 0 0 / 15%)',
+				ring: 'oklch(0.556 0 0)',
+			},
+		},
+		dependencies: ['class-variance-authority', 'clsx', 'tailwind-merge', 'tw-animate-css'],
+		docs: `To use this preset, run:\n\nnpx spartan init --preset ${presetCode ?? 'b0'}\n\nOr apply to an existing project:\n\nnpx spartan apply --preset ${presetCode ?? 'b0'}`,
+	};
+});

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -95,6 +95,7 @@ export default defineConfig(({ command, mode }) => {
 						const staticRoutes = [
 							'/',
 							'/colors',
+							'/create',
 
 							'/documentation/introduction',
 							'/documentation/changelog',

--- a/libs/registry/src/index.ts
+++ b/libs/registry/src/index.ts
@@ -1,2 +1,5 @@
+export * from './preset/preset';
+export * from './preset/preset-types';
 export * from './schema/schema';
+export * from './styles/base-colors';
 export * from './styles/style';

--- a/libs/registry/src/preset/preset-types.ts
+++ b/libs/registry/src/preset/preset-types.ts
@@ -1,0 +1,130 @@
+import { type BaseColor } from '../styles/base-colors';
+import { type Style } from '../styles/style';
+
+export const THEMES = [
+	'neutral',
+	'stone',
+	'zinc',
+	'gray',
+	'slate',
+	'amber',
+	'blue',
+	'cyan',
+	'emerald',
+	'fuchsia',
+	'green',
+	'indigo',
+	'lime',
+	'orange',
+	'pink',
+	'purple',
+	'red',
+	'rose',
+	'sky',
+	'teal',
+	'violet',
+	'yellow',
+] as const;
+export type ThemeName = (typeof THEMES)[number];
+
+export const BASE_THEMES = ['neutral', 'stone', 'zinc', 'gray', 'slate'] as const;
+export type BaseThemeName = (typeof BASE_THEMES)[number];
+
+export const COLOR_THEMES = [
+	'amber',
+	'blue',
+	'cyan',
+	'emerald',
+	'fuchsia',
+	'green',
+	'indigo',
+	'lime',
+	'orange',
+	'pink',
+	'purple',
+	'red',
+	'rose',
+	'sky',
+	'teal',
+	'violet',
+	'yellow',
+] as const;
+export type ColorThemeName = (typeof COLOR_THEMES)[number];
+
+export function getThemesForBaseColor(_baseColor: string): ThemeName[] {
+	return [...BASE_THEMES, ...COLOR_THEMES] as ThemeName[];
+}
+
+export const ICON_LIBRARIES = ['lucide', 'radix', 'phosphor', 'tabler', 'hugeicons'] as const;
+export type IconLibrary = (typeof ICON_LIBRARIES)[number];
+
+export const FONTS = [
+	'inter',
+	'geist',
+	'figtree',
+	'jetbrains-mono',
+	'noto-sans',
+	'playfair-display',
+	'roboto',
+	'space-grotesk',
+] as const;
+export type FontValue = (typeof FONTS)[number];
+
+export const FONT_DEFINITIONS: {
+	value: FontValue;
+	label: string;
+	type: 'sans' | 'serif' | 'mono';
+	fontFamily: string;
+}[] = [
+	{ value: 'inter', label: 'Inter', type: 'sans', fontFamily: '"Inter", sans-serif' },
+	{ value: 'geist', label: 'Geist', type: 'sans', fontFamily: '"Geist", sans-serif' },
+	{ value: 'figtree', label: 'Figtree', type: 'sans', fontFamily: '"Figtree", sans-serif' },
+	{ value: 'jetbrains-mono', label: 'JetBrains Mono', type: 'mono', fontFamily: '"JetBrains Mono", monospace' },
+	{ value: 'noto-sans', label: 'Noto Sans', type: 'sans', fontFamily: '"Noto Sans", sans-serif' },
+	{ value: 'playfair-display', label: 'Playfair Display', type: 'serif', fontFamily: '"Playfair Display", serif' },
+	{ value: 'roboto', label: 'Roboto', type: 'sans', fontFamily: '"Roboto", sans-serif' },
+	{ value: 'space-grotesk', label: 'Space Grotesk', type: 'sans', fontFamily: '"Space Grotesk", sans-serif' },
+];
+
+export const MENU_ACCENTS = ['subtle', 'bold'] as const;
+export type MenuAccent = (typeof MENU_ACCENTS)[number];
+
+export const MENU_COLORS = ['default', 'inverted'] as const;
+export type MenuColor = (typeof MENU_COLORS)[number];
+
+export const RADII = [
+	{ name: 'default', label: 'Default', value: '0.625rem' },
+	{ name: 'none', label: 'None', value: '0' },
+	{ name: 'small', label: 'Small', value: '0.45rem' },
+	{ name: 'medium', label: 'Medium', value: '0.625rem' },
+	{ name: 'large', label: 'Large', value: '0.875rem' },
+] as const;
+export type RadiusName = (typeof RADII)[number]['name'];
+
+export const CHAR_THEMES = THEMES;
+
+export interface DesignSystemConfig {
+	style: Style;
+	baseColor: BaseColor;
+	theme: ThemeName;
+	chartColor: ThemeName;
+	iconLibrary: IconLibrary;
+	font: FontValue;
+	fontHeading: FontValue | 'inherit';
+	radius: RadiusName;
+	menuAccent: MenuAccent;
+	menuColor: MenuColor;
+}
+
+export const DEFAULT_CONFIG: DesignSystemConfig = {
+	style: 'nova',
+	baseColor: 'neutral',
+	theme: 'neutral',
+	chartColor: 'neutral',
+	iconLibrary: 'lucide',
+	font: 'inter',
+	fontHeading: 'inherit',
+	radius: 'default',
+	menuAccent: 'subtle',
+	menuColor: 'default',
+};

--- a/libs/registry/src/preset/preset.spec.ts
+++ b/libs/registry/src/preset/preset.spec.ts
@@ -1,0 +1,80 @@
+import { decodePreset, DEFAULT_CONFIG, encodePreset, isPresetCode } from '@spartan-ng/registry';
+import { describe, expect, it } from 'vitest';
+
+describe('preset encoding/decoding', () => {
+	it('encodes and decodes default config', () => {
+		const code = encodePreset(DEFAULT_CONFIG);
+		expect(code).toMatch(/^b[0-9a-zA-Z]+$/);
+		expect(isPresetCode(code)).toBe(true);
+
+		const decoded = decodePreset(code);
+		expect(decoded).toBeDefined();
+		expect(decoded!.style).toBe(DEFAULT_CONFIG.style);
+		expect(decoded!.baseColor).toBe(DEFAULT_CONFIG.baseColor);
+		expect(decoded!.theme).toBe(DEFAULT_CONFIG.theme);
+		expect(decoded!.iconLibrary).toBe(DEFAULT_CONFIG.iconLibrary);
+		expect(decoded!.font).toBe(DEFAULT_CONFIG.font);
+		expect(decoded!.radius).toBe(DEFAULT_CONFIG.radius);
+		expect(decoded!.menuAccent).toBe(DEFAULT_CONFIG.menuAccent);
+		expect(decoded!.menuColor).toBe(DEFAULT_CONFIG.menuColor);
+	});
+
+	it('round-trips a custom config', () => {
+		const config = {
+			style: 'vega' as const,
+			baseColor: 'zinc' as const,
+			theme: 'blue' as const,
+			chartColor: 'sky' as const,
+			iconLibrary: 'phosphor' as const,
+			font: 'figtree' as const,
+			fontHeading: 'inherit' as const,
+			radius: 'large' as const,
+			menuAccent: 'bold' as const,
+			menuColor: 'inverted' as const,
+		};
+
+		const code = encodePreset(config);
+		const decoded = decodePreset(code);
+		expect(decoded).toBeDefined();
+		expect(decoded!.style).toBe('vega');
+		expect(decoded!.baseColor).toBe('zinc');
+		expect(decoded!.theme).toBe('blue');
+		expect(decoded!.chartColor).toBe('sky');
+		expect(decoded!.iconLibrary).toBe('phosphor');
+		expect(decoded!.font).toBe('figtree');
+		expect(decoded!.radius).toBe('large');
+		expect(decoded!.menuAccent).toBe('bold');
+		expect(decoded!.menuColor).toBe('inverted');
+	});
+
+	it('returns null for invalid preset codes', () => {
+		expect(decodePreset('')).toBeNull();
+		expect(decodePreset('x')).toBeNull();
+		expect(decodePreset('b')).toBeNull();
+		expect(decodePreset('not-a-preset')).toBeNull();
+	});
+
+	it('isPresetCode validates correctly', () => {
+		expect(isPresetCode('b0')).toBe(true);
+		expect(isPresetCode('b1a')).toBe(true);
+		expect(isPresetCode('bAbCdEf')).toBe(true);
+		expect(isPresetCode('')).toBe(false);
+		expect(isPresetCode('x')).toBe(false);
+		expect(isPresetCode('0b')).toBe(false);
+	});
+
+	it('partial config falls back to defaults', () => {
+		const code = encodePreset({ style: 'lyra' });
+		const decoded = decodePreset(code);
+		expect(decoded!.style).toBe('lyra');
+		expect(decoded!.baseColor).toBe('neutral');
+		expect(decoded!.theme).toBe('neutral');
+		expect(decoded!.font).toBe('inter');
+	});
+
+	it('different configs produce different codes', () => {
+		const code1 = encodePreset({ style: 'nova' });
+		const code2 = encodePreset({ style: 'vega' });
+		expect(code1).not.toBe(code2);
+	});
+});

--- a/libs/registry/src/preset/preset.ts
+++ b/libs/registry/src/preset/preset.ts
@@ -1,0 +1,131 @@
+import type { DesignSystemConfig } from './preset-types';
+import { DEFAULT_CONFIG } from './preset-types';
+
+const BASE62 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+const STYLE_VALUES = ['nova', 'vega', 'lyra', 'maia', 'mira', 'luma'] as const;
+const BASE_COLOR_VALUES = ['neutral', 'stone', 'zinc', 'gray', 'slate'] as const;
+const THEME_VALUES = [
+	'neutral',
+	'stone',
+	'zinc',
+	'gray',
+	'slate',
+	'amber',
+	'blue',
+	'cyan',
+	'emerald',
+	'fuchsia',
+	'green',
+	'indigo',
+	'lime',
+	'orange',
+	'pink',
+	'purple',
+	'red',
+	'rose',
+	'sky',
+	'teal',
+	'violet',
+	'yellow',
+] as const;
+const ICON_VALUES = ['lucide', 'radix', 'phosphor', 'tabler', 'hugeicons'] as const;
+const FONT_VALUES = [
+	'inter',
+	'geist',
+	'figtree',
+	'jetbrains-mono',
+	'noto-sans',
+	'playfair-display',
+	'roboto',
+	'space-grotesk',
+] as const;
+const RADIUS_VALUES = ['default', 'none', 'small', 'medium', 'large'] as const;
+
+function toBase62(n: number): string {
+	if (n === 0) return '0';
+	let result = '';
+	while (n > 0) {
+		result = BASE62[n % 62] + result;
+		n = Math.floor(n / 62);
+	}
+	return result;
+}
+
+function fromBase62(s: string): number {
+	let n = 0;
+	for (const c of s) {
+		n = n * 62 + BASE62.indexOf(c);
+	}
+	return n;
+}
+
+const PRESET_SENTINEL = 'b';
+
+export function encodePreset(config: Partial<DesignSystemConfig>): string {
+	const merged = { ...DEFAULT_CONFIG, ...config };
+
+	const styleIndex = Math.max(0, STYLE_VALUES.indexOf(merged.style as (typeof STYLE_VALUES)[number]));
+	const baseColorIndex = Math.max(0, BASE_COLOR_VALUES.indexOf(merged.baseColor as (typeof BASE_COLOR_VALUES)[number]));
+	const themeIndex = Math.max(0, THEME_VALUES.indexOf(merged.theme as (typeof THEME_VALUES)[number]));
+	const chartColorIndex = Math.max(0, THEME_VALUES.indexOf(merged.chartColor as (typeof THEME_VALUES)[number]));
+	const iconLibraryIndex = Math.max(0, ICON_VALUES.indexOf(merged.iconLibrary as (typeof ICON_VALUES)[number]));
+	const fontIndex = Math.max(0, FONT_VALUES.indexOf(merged.font as (typeof FONT_VALUES)[number]));
+	const fontHeadingIsInherit = merged.fontHeading === 'inherit';
+	const fontHeadingIndex = fontHeadingIsInherit
+		? 0
+		: Math.max(0, FONT_VALUES.indexOf(merged.fontHeading as (typeof FONT_VALUES)[number]));
+	const radiusIndex = Math.max(0, RADIUS_VALUES.indexOf(merged.radius as (typeof RADIUS_VALUES)[number]));
+	const menuAccentIndex = merged.menuAccent === 'bold' ? 1 : 0;
+	const menuColorIndex = merged.menuColor === 'inverted' ? 1 : 0;
+
+	const packed =
+		(styleIndex << 0) |
+		(baseColorIndex << 3) |
+		(themeIndex << 6) |
+		(chartColorIndex << 11) |
+		(iconLibraryIndex << 16) |
+		(fontIndex << 19) |
+		((fontHeadingIsInherit ? 0 : 1) << 22) |
+		(fontHeadingIndex << 23) |
+		(radiusIndex << 26) |
+		(menuAccentIndex << 29) |
+		(menuColorIndex << 30);
+
+	return PRESET_SENTINEL + toBase62(packed);
+}
+
+export function isPresetCode(value: string): boolean {
+	return value.startsWith(PRESET_SENTINEL) && value.length > 1;
+}
+
+export function decodePreset(code: string): Partial<DesignSystemConfig> | null {
+	if (!isPresetCode(code)) return null;
+
+	const packed = fromBase62(code.slice(1));
+
+	const styleIndex = (packed >> 0) & 0b111;
+	const baseColorIndex = (packed >> 3) & 0b111;
+	const themeIndex = (packed >> 6) & 0b11111;
+	const chartColorIndex = (packed >> 11) & 0b11111;
+	const iconLibraryIndex = (packed >> 16) & 0b111;
+	const fontIndex = (packed >> 19) & 0b111;
+	const fontHeadingIsInherit = ((packed >> 22) & 0b1) === 0;
+	const fontHeadingIndex = (packed >> 23) & 0b111;
+	const radiusIndex = (packed >> 26) & 0b111;
+	const menuAccentIndex = (packed >> 29) & 0b1;
+	const menuColorIndex = (packed >> 30) & 0b1;
+
+	return {
+		style: STYLE_VALUES[styleIndex] ?? DEFAULT_CONFIG.style,
+		baseColor: BASE_COLOR_VALUES[baseColorIndex] ?? DEFAULT_CONFIG.baseColor,
+		theme: THEME_VALUES[themeIndex] ?? DEFAULT_CONFIG.theme,
+		chartColor: THEME_VALUES[chartColorIndex] ?? DEFAULT_CONFIG.chartColor,
+		iconLibrary: ICON_VALUES[iconLibraryIndex] ?? DEFAULT_CONFIG.iconLibrary,
+		font: FONT_VALUES[fontIndex] ?? DEFAULT_CONFIG.font,
+		fontHeading: fontHeadingIsInherit ? ('inherit' as const) : (FONT_VALUES[fontHeadingIndex] ?? DEFAULT_CONFIG.font),
+		radius: RADIUS_VALUES[radiusIndex] ?? DEFAULT_CONFIG.radius,
+		menuAccent: menuAccentIndex === 1 ? ('bold' as const) : ('subtle' as const),
+		menuColor: menuColorIndex === 1 ? ('inverted' as const) : ('default' as const),
+	};
+}

--- a/libs/registry/src/styles/base-colors.ts
+++ b/libs/registry/src/styles/base-colors.ts
@@ -1,0 +1,2 @@
+export const BASE_COLORS = ['neutral', 'stone', 'zinc', 'gray', 'slate'] as const;
+export type BaseColor = (typeof BASE_COLORS)[number];


### PR DESCRIPTION
Here's the filled PR template for your changes:

---

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [x] registry
- [ ] mcp

## What is the current behavior?

There is no visual theme customizer or interactive way to preview and generate preset configuration for spartan projects. Users must manually edit `components.json` or use the CLI with trial-and-error.

Closes #

## What is the new behavior?

Introduces a `/create` route that mirrors shadcn/ui's design system customizer for spartan. Users can pick style, base color, theme, font, icon library, radius, and menu options via dropdowns, see a live iframe preview, and copy a CLI command with a compact base62-encoded preset code.

Also adds:
- Bit-packed preset encode/decode utilities in the registry lib
- DesignSystemService (signals + URL query-param sync via `?preset=CODE`)
- `GET /api/create/init` returning a registry base item for CLI consumption
- 26 passing tests across the registry lib and the new create page
- `/create` route added to the prerender list and header navigation

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The preset encoding uses a bit-packing scheme into base62 strings prefixed with `b`, enabling compact shareable URLs like `?preset=b1a`. The same encoding is used by the CLI's `init` and `apply` commands for consistent project bootstrapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Create" page enabling users to customize design system settings (style, base color, theme, font, icon library, radius, menu accent, and menu color).
  * Included a live preview panel showing how customizations appear.
  * Added a "Copy Command" button to clipboard-copy the `npx spartan init` command with the current preset configuration.
  * Added "Create" navigation link in the header and main navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->