### PR TITLE
fix(field): render field errors outside fieldset to avoid Chrome collapse

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(field)/field.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(field)/field.page.ts
@@ -325,6 +325,19 @@ export const routeMeta: RouteMeta = {
 					<code class="${hlmCode} mr-0.5">FieldContent</code>
 					to keep error messages aligned with the field.
 				</li>
+				<li class="mt-2">
+					For checkbox or radio groups wrapped in a
+					<code class="${hlmCode} mr-0.5">fieldset</code>
+					, render
+					<code class="${hlmCode} mr-0.5">FieldError</code>
+					as a sibling of the
+					<code class="${hlmCode} mr-0.5">fieldset</code>
+					, not inside it. Because
+					<code class="${hlmCode} mr-0.5">FieldGroup</code>
+					is a container-query context, an error nested in the
+					<code class="${hlmCode} mr-0.5">fieldset</code>
+					triggers a Chrome layout bug that collapses the controls on toggle.
+				</li>
 			</ul>
 			<spartan-code [code]="_validationAndErrorCode" />
 

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/styles.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/styles.page.ts
@@ -154,6 +154,35 @@ export const routeMeta: RouteMeta = {
 				) — this follows the spacing scale.
 			</p>
 
+			<spartan-section-sub-heading id="field-error-placement">Field error placement</spartan-section-sub-heading>
+
+			<p class="${hlmP}">
+				The styles drive field layout with container queries (
+				<code class="${hlmCode}">@container/field-group</code>
+				) and
+				<code class="${hlmCode}">:has()</code>
+				selectors on
+				<code class="${hlmCode}">HlmFieldSet</code>
+				. Chrome has a layout bug with this combination: rendering
+				<code class="${hlmCode}">HlmFieldError</code>
+				<em>inside</em>
+				a
+				<code class="${hlmCode}">fieldset</code>
+				collapses the checkboxes or radios to zero size when the error toggles. Render the error as a sibling of the
+				<code class="${hlmCode}">fieldset</code>
+				instead.
+			</p>
+
+			<div class="mt-6" hlmAlert>
+				<div hlmAlertDescription>
+					<p>
+						See
+						<a class="font-medium underline" href="/components/field">Field → Validation and Errors</a>
+						for the correct structure.
+					</p>
+				</div>
+			</div>
+
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="dark-mode" label="Dark Mode" />
 				<spartan-page-bottom-nav-link direction="previous" href="theming" label="Theming" />

--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/styles.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/styles.page.ts
@@ -177,7 +177,7 @@ export const routeMeta: RouteMeta = {
 				<div hlmAlertDescription>
 					<p>
 						See
-						<a class="font-medium underline" href="/components/field">Field → Validation and Errors</a>
+						<a class="font-medium underline" routerLink="/components/field">Field → Validation and Errors</a>
 						for the correct structure.
 					</p>
 				</div>

--- a/apps/app/src/app/pages/(forms)/forms/(reactive-forms)/reactive-forms--radio-group.demo.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(reactive-forms)/reactive-forms--radio-group.demo.ts
@@ -37,10 +37,10 @@ import { HlmRadioGroupImports } from '@spartan-ng/helm/radio-group';
 									</label>
 								}
 							</hlm-radio-group>
-							@if (form.controls.plan.invalid && form.controls.plan.touched) {
-								<hlm-field-error>You must select a subscription plan to continue.</hlm-field-error>
-							}
 						</fieldset>
+						@if (form.controls.plan.invalid && form.controls.plan.touched) {
+							<hlm-field-error>You must select a subscription plan to continue.</hlm-field-error>
+						}
 					</hlm-field-group>
 				</form>
 			</div>
@@ -128,10 +128,10 @@ import { HlmRadioGroupImports } from '@spartan-ng/helm/radio-group';
 									</label>
 								}
 							</hlm-radio-group>
-							@if (form.controls.plan.invalid && form.controls.plan.touched) {
-								<hlm-field-error>You must select a subscription plan to continue.</hlm-field-error>
-							}
 						</fieldset>
+						@if (form.controls.plan.invalid && form.controls.plan.touched) {
+							<hlm-field-error>You must select a subscription plan to continue.</hlm-field-error>
+						}
 					</hlm-field-group>
 				</form>
 			</div>

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms--checkbox.demo.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms--checkbox.demo.ts
@@ -54,12 +54,12 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 										</hlm-field>
 									}
 								</hlm-field-group>
-								@if (form.tasks().invalid() && form.tasks().touched()) {
-									@for (error of form.tasks().errors(); track error) {
-										<hlm-field-error>{{ error.message }}</hlm-field-error>
-									}
-								}
 							</fieldset>
+							@if (form.tasks().invalid() && form.tasks().touched()) {
+								@for (error of form.tasks().errors(); track error) {
+									<hlm-field-error>{{ error.message }}</hlm-field-error>
+								}
+							}
 						</hlm-field-group>
 					</hlm-field-group>
 				</form>
@@ -185,12 +185,12 @@ import { HlmFieldImports } from '@spartan-ng/helm/field';
 										</hlm-field>
 									}
 								</hlm-field-group>
-								@if (form.tasks().invalid() && form.tasks().touched()) {
-									@for (error of form.tasks().errors(); track error) {
-										<hlm-field-error>{{ error.message }}</hlm-field-error>
-									}
-								}
 							</fieldset>
+							@if (form.tasks().invalid() && form.tasks().touched()) {
+								@for (error of form.tasks().errors(); track error) {
+									<hlm-field-error>{{ error.message }}</hlm-field-error>
+								}
+							}
 						</hlm-field-group>
 					</hlm-field-group>
 				</form>

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms--complex.demo.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms--complex.demo.ts
@@ -99,12 +99,12 @@ import { HlmSwitchImports } from '@spartan-ng/helm/switch';
 									</hlm-field>
 								}
 							</hlm-field-group>
-							@if (form.addons().invalid() && form.addons().touched()) {
-								@for (error of form.addons().errors(); track error) {
-									<hlm-field-error>{{ error.message }}</hlm-field-error>
-								}
-							}
 						</fieldset>
+						@if (form.addons().invalid() && form.addons().touched()) {
+							@for (error of form.addons().errors(); track error) {
+								<hlm-field-error>{{ error.message }}</hlm-field-error>
+							}
+						}
 						<hlm-field-separator />
 						<hlm-field orientation="horizontal">
 							<hlm-field-content>
@@ -320,12 +320,12 @@ import { HlmSwitchImports } from '@spartan-ng/helm/switch';
 									</hlm-field>
 								}
 							</hlm-field-group>
-							@if (form.addons().invalid() && form.addons().touched()) {
-								@for (error of form.addons().errors(); track error) {
-									<hlm-field-error>{{ error.message }}</hlm-field-error>
-								}
-							}
 						</fieldset>
+						@if (form.addons().invalid() && form.addons().touched()) {
+							@for (error of form.addons().errors(); track error) {
+								<hlm-field-error>{{ error.message }}</hlm-field-error>
+							}
+						}
 						<hlm-field-separator />
 						<hlm-field orientation="horizontal">
 							<hlm-field-content>


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (browser-layout bug in demos; not unit-testable)
- [x] Docs have been added / updated

## PR Type

- [x] Bugfix
- [x] Documentation content changes

## Which package are you modifying?

- [x] field
- [x] checkbox
- [x] radio-group

## What is the current behavior?

In Chrome, toggling checkboxes (or radios) in the signal-forms / reactive-forms demos makes the
controls **vanish** — they collapse to `0×0` the moment the group becomes invalid. Firefox and
Safari are unaffected.

Root cause is a Chrome layout bug at the intersection of **container queries** and **`:has()`**:

- `HlmFieldGroup` establishes a container-query context (`@container/field-group` →
  `container-type: inline-size`).
- `HlmFieldSet` carries `:has(>[data-slot=checkbox-group])` / `:has(>[data-slot=radio-group])`.
- The demos render `<hlm-field-error>` **inside** the `<fieldset>`. When validation flips, the
  error node is inserted as a child of the `:has()` element **inside the containment root**, and
  Chrome mis-invalidates layout, collapsing the contained `[role=checkbox]` / `[role=radio]`
  buttons to zero size.

shadcn (which spartan's Field is ported from) does not hit this: it renders `FieldError` as a
**sibling of `FieldSet`**, so the error never mutates the `:has()` node.

<details>
<summary>Hypotheses investigated and ruled out (so reviewers don't re-litigate)</summary>

Verified against the real app + shadcn's reference app in Chrome via Playwright/CDP:

- **`display: contents` on the checkbox wrappers** — changed at the source to real boxes; still collapsed.
- **The wrapper elements themselves** — a single shadcn-style button injected into the same container collapsed too.
- **Button `display` (flex vs block/grid), `contain`, `isolation`, `translateZ`, `min-width`, `flex-basis`** — none fixed it.
- **`_errorStateClass` class churn on the button** — removed it; still collapsed.
- **Validation timing** — shadcn forced invalid + toggled does not collapse.
- Only removing `container-type` stopped it (but that breaks `@md/field-group` responsive orientation), confirming the container-query involvement; the real trigger is the error insertion into the `:has()`-bearing fieldset.
</details>

## What is the new behavior?

`<hlm-field-error>` is rendered as a **sibling of `<fieldset>`** (inside the field-group), matching
shadcn. The controls no longer collapse on toggle.

Changed demos:
- `signal-forms--checkbox`
- `signal-forms--complex` (add-ons group)
- `reactive-forms--radio-group`

Unchanged (already correct or not affected):
- `reactive-forms--checkbox` (error was already a fieldset sibling)
- `signal-forms--radio-group` (no `HlmFieldGroup`, so no container-query context)

Docs:
- **Field → Validation and Errors**: added a rule to render `FieldError` as a fieldset sibling for
  checkbox/radio groups.
- **Styles → Field error placement**: added a short "known limitation" caveat explaining the
  Chrome `:has()` × `container-type` interaction, linking to the Field docs.

## Does this PR introduce a breaking change?

- [x] No

## Other information

This is a usage/footgun fix, not a library code change — the safe structure is to keep field errors
outside the fieldset. A future CLI healthcheck/lint rule flagging `hlm-field-error` nested inside a
`fieldset[hlmFieldSet]` would prevent regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/expanded guidance on where to render field validation errors for checkbox/radio groups wrapped in a `fieldset`.
  * Updated the Styles documentation with a “Field error placement” subsection explaining Chrome layout behavior when combining container queries and `:has()`, recommending the error be rendered as a sibling of the `fieldset`.

* **Examples**
  * Updated reactive and signal-form demos to place validation error blocks after the closing `</fieldset>` (including for radio groups, checkbox tasks, and complex add-ons).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->