### PR TITLE
refactor(drawer): expose direction as the canonical writable signal

### DIFF
--- a/libs/brain/drawer/src/lib/brn-drawer-content.ts
+++ b/libs/brain/drawer/src/lib/brn-drawer-content.ts
@@ -15,5 +15,5 @@ import { BrnDrawer } from './brn-drawer';
 	],
 })
 export class BrnDrawerContent<T extends Record<string, unknown>> extends BrnDialogContent<T> implements ExposesSide {
-	public readonly side = inject(BrnDrawer).directionState;
+	public readonly side = inject(BrnDrawer).direction;
 }

--- a/libs/brain/drawer/src/lib/brn-drawer-handle.ts
+++ b/libs/brain/drawer/src/lib/brn-drawer-handle.ts
@@ -89,7 +89,7 @@ export class BrnDrawerHandle {
 	protected _onPointerDown(event: PointerEvent): void {
 		if (!this._brnDialogRef || !this._brnDrawer || this._isDragging) return;
 
-		this._direction = this._brnDrawer.directionState();
+		this._direction = this._brnDrawer.direction();
 		this._drawerEl = this._element.nativeElement.closest('[data-vaul-drawer-direction]');
 		if (!this._drawerEl) return;
 

--- a/libs/brain/drawer/src/lib/brn-drawer-trigger.ts
+++ b/libs/brain/drawer/src/lib/brn-drawer-trigger.ts
@@ -13,7 +13,7 @@ export class BrnDrawerTrigger extends BrnDialogTrigger {
 	override open() {
 		const direction = this.direction();
 		if (this._drawer && direction) {
-			this._drawer.directionState.set(direction);
+			this._drawer.direction.set(direction);
 		}
 		super.open();
 	}

--- a/libs/brain/drawer/src/lib/brn-drawer.ts
+++ b/libs/brain/drawer/src/lib/brn-drawer.ts
@@ -12,11 +12,11 @@ import { BrnDialog } from '@spartan-ng/brain/dialog';
 	],
 })
 export class BrnDrawer extends BrnDialog {
-	public readonly direction = input<'bottom' | 'top' | 'left' | 'right'>('bottom');
-	public readonly directionState = linkedSignal(() => this.direction());
+	public readonly directionInput = input<'bottom' | 'top' | 'left' | 'right'>('bottom', { alias: 'direction' });
+	public readonly direction = linkedSignal(this.directionInput);
 
 	protected override getPositionStrategy() {
-		switch (this.directionState()) {
+		switch (this.direction()) {
 			case 'bottom':
 				return this._positionBuilder.global().bottom();
 			case 'top':


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: public-signal rename ahead of the v1 freeze (no functional change)

## Which package are you modifying?

### Primitives

- [x] drawer

## What is the current behavior?

`BrnDrawer` exposes the resolved direction as a public `directionState` linkedSignal, while the
`direction` member is the raw input. This split is internal plumbing that would otherwise be frozen
into the v1 public surface, and it is inconsistent with the input convention we want for the upcoming
drawer work (snap points, etc.): `_xInput = input({ alias: 'x' }) → x = linkedSignal(...)`.

## What is the new behavior?

`direction` is now the canonical writable `linkedSignal`, backed by a public
`directionInput = input({ alias: 'direction' })` — the same input + `linkedSignal(this.xInput)` shape
already used by `brn-checkbox`, `brn-slider`, and `brn-input-otp`. `directionState` is removed. The
`[direction]` template binding is unchanged (preserved by the alias), and `direction` remains the
writable signal the trigger drives. Covered by the existing `hlm-drawer.spec.ts` integration suite
(binds `[direction]` and exercises open/close/drag through the full stack).

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Removes the public `BrnDrawer.directionState` signal (internal-only; no known external consumers).
Intentionally landed **before the v1 freeze** so the public surface ships clean.

Migration: replace any `brnDrawer.directionState` read/write with `brnDrawer.direction`
(same value, same writable `Signal`). No change needed for `[direction]` bindings.

## Other information

Part of the drawer → Vaul parity effort; this only locks the input/signal shape ahead of v1. The
behavioral work (the #1483 backdrop-fade fix, snap points, scale-background, nested) lands in follow-up
PRs and is additive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored drawer direction input API: introduced `directionInput` signal with `direction` alias, replacing the previous `directionState` approach. Updated drawer-related components to use the new direction access pattern for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->