### PR TITLE
docs(sheet): add example for opening a sheet from a dropdown menu

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(sheet)/sheet--from-dropdown.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(sheet)/sheet--from-dropdown.preview.ts
@@ -1,0 +1,37 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { HlmButtonImports } from '@spartan-ng/helm/button';
+import { HlmDropdownMenuImports } from '@spartan-ng/helm/dropdown-menu';
+import { HlmSheetImports } from '@spartan-ng/helm/sheet';
+
+@Component({
+	selector: 'spartan-sheet-from-dropdown-preview',
+	imports: [HlmSheetImports, HlmDropdownMenuImports, HlmButtonImports],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<button hlmBtn variant="outline" [hlmDropdownMenuTrigger]="menu">Options</button>
+
+		<!-- Keep the sheet outside the dropdown's ng-template so closing the menu does not destroy it. -->
+		<hlm-sheet #sheet="hlmSheet" side="right">
+			<hlm-sheet-content *hlmSheetPortal="let ctx">
+				<hlm-sheet-header>
+					<h3 hlmSheetTitle>Edit Profile</h3>
+					<p hlmSheetDescription>Make changes to your profile here. Click save when you're done.</p>
+				</hlm-sheet-header>
+				<hlm-sheet-footer>
+					<button hlmBtn type="submit">Save Changes</button>
+					<button hlmSheetClose hlmBtn variant="outline">Close</button>
+				</hlm-sheet-footer>
+			</hlm-sheet-content>
+		</hlm-sheet>
+
+		<ng-template #menu>
+			<hlm-dropdown-menu class="w-40">
+				<button hlmDropdownMenuItem (click)="sheet.open()">Edit Profile</button>
+				<button hlmDropdownMenuItem>Duplicate</button>
+				<hlm-dropdown-menu-separator />
+				<button hlmDropdownMenuItem>Delete</button>
+			</hlm-dropdown-menu>
+		</ng-template>
+	`,
+})
+export class SheetFromDropdownPreview {}

--- a/apps/app/src/app/pages/(components)/components/(sheet)/sheet.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(sheet)/sheet.page.ts
@@ -19,6 +19,7 @@ import { Tabs } from '../../../../shared/layout/tabs';
 import { UIApiDocs } from '../../../../shared/layout/ui-docs-section/ui-docs-section';
 import { metaWith } from '../../../../shared/meta/meta.util';
 import { SheetClosePreview } from './sheet--close.preview';
+import { SheetFromDropdownPreview } from './sheet--from-dropdown.preview';
 import { SheetNoClose } from './sheet--no-close.preview';
 import { SheetRtl } from './sheet--rtl.preview';
 import { SheetSidePreview } from './sheet--side.preview';
@@ -58,6 +59,7 @@ export const routeMeta: RouteMeta = {
 		SheetClosePreview,
 		SheetNoClose,
 		SheetRtl,
+		SheetFromDropdownPreview,
 	],
 	template: `
 		<section spartanMainSection>
@@ -121,6 +123,23 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_closeCode()" />
 			</spartan-tabs>
 
+			<h3 id="examples__from_dropdown" spartanH4>Open From Dropdown</h3>
+			<p class="${hlmP} mb-6">
+				Declare the
+				<code class="${hlmCode}">hlm-sheet</code>
+				outside of the dropdown's
+				<code class="${hlmCode}">ng-template</code>
+				and open it from a menu item with
+				<code class="${hlmCode}">sheet.open()</code>
+				. Nesting the sheet inside the template destroys it when the dropdown closes, which breaks the open animation.
+			</p>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-sheet-from-dropdown-preview />
+				</div>
+				<spartan-code secondTab [code]="_fromDropdownCode()" />
+			</spartan-tabs>
+
 			<spartan-header-rtl />
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanRtlCodePreview firstTab>
@@ -155,6 +174,7 @@ export default class LabelPage {
 	protected readonly _closeCode = computed(() => this._snippets()['close']);
 	protected readonly _sizeCode = computed(() => this._snippets()['size']);
 	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
+	protected readonly _fromDropdownCode = computed(() => this._snippets()['fromDropdown']);
 	protected readonly _defaultSkeleton = defaultSkeleton;
 	protected readonly _defaultImports = defaultImports;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] sheet

## What is the current behavior?

Opening a sheet from a dropdown menu produces a broken animation: the sheet briefly
appears open, closes, and opens again. When `hlm-sheet`, its trigger, and its portal
are declared inside the dropdown's `ng-template`, clicking the menu item closes the
dropdown, which destroys the template and tears down the sheet's portal context
mid-open.

Closes #1349

## What is the new behavior?

Adds an "Open From Dropdown" example to the Sheet docs showing the recommended pattern:
declare `hlm-sheet` outside of the dropdown's `ng-template` and open it from a menu item
with `sheet.open()`. The accompanying note explains why nesting the sheet inside the
template breaks the animation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new example demonstrating how to open a Sheet component from within a dropdown menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->