### PR TITLE
fix(dialog): pin exit animations forwards to stop close flicker

### DIFF
--- a/libs/brain/dialog/src/lib/brn-dialog-ref.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog-ref.ts
@@ -124,6 +124,12 @@ export class BrnDialogRef<DialogResult = unknown> {
 		if (generation !== this._closeGeneration || this._phase() !== 'closing') return;
 
 		const exitAnimations = this._getActiveAnimations().filter((animation) => !animationsBeforeClose.has(animation));
+		// Pin each exit animation to its final frame. tw-animate-css uses `animation-fill-mode: none`,
+		// so a finished exit reverts the element to its visible state in the gap before we dispose it -
+		// that one-frame snap-back is the flicker. updateTiming pins only the animations we await.
+		for (const animation of exitAnimations) {
+			animation.effect?.updateTiming({ fill: 'forwards' });
+		}
 		await waitForAnimations(exitAnimations);
 
 		if (generation === this._closeGeneration && this._phase() === 'closing') {

--- a/libs/helm/dialog/src/lib/hlm-dialog-animation.spec.ts
+++ b/libs/helm/dialog/src/lib/hlm-dialog-animation.spec.ts
@@ -1,0 +1,122 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { BrnDialog } from '@spartan-ng/brain/dialog';
+import { render } from '@testing-library/angular';
+import { HlmDialog } from './hlm-dialog';
+import { HlmDialogContent } from './hlm-dialog-content';
+import { HlmDialogPortal } from './hlm-dialog-portal';
+import { HlmDialogTrigger } from './hlm-dialog-trigger';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const flush = () => wait(0);
+
+const EXIT_MS = 150;
+
+@Component({
+	selector: 'hlm-dialog-animation-host',
+	imports: [HlmDialog, HlmDialogContent, HlmDialogPortal, HlmDialogTrigger],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<hlm-dialog>
+			<button hlmDialogTrigger>open</button>
+			<hlm-dialog-content *hlmDialogPortal="let ctx">
+				<span data-testid="content">content</span>
+			</hlm-dialog-content>
+		</hlm-dialog>
+	`,
+})
+class DialogAnimationHost {}
+
+const dialogOf = (view: Awaited<ReturnType<typeof render>>) =>
+	view.fixture.debugElement.query(By.directive(HlmDialog)).injector.get(BrnDialog);
+const panel = () => document.querySelector('.cdk-overlay-pane');
+
+describe('HlmDialog animation-aware teardown', () => {
+	let style: HTMLStyleElement;
+
+	beforeEach(() => {
+		// Global style: the overlay pane (which receives data-state) animates out when closing.
+		style = document.createElement('style');
+		style.textContent = `
+			@keyframes brn-test-dialog-exit { from { opacity: 1; } to { opacity: 0; } }
+			.cdk-overlay-pane[data-state='closed'] { animation: brn-test-dialog-exit ${EXIT_MS}ms linear; }
+		`;
+		document.head.appendChild(style);
+	});
+
+	afterEach(() => {
+		style.remove();
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	it('keeps the panel mounted while the exit animation runs, then disposes it', async () => {
+		const view = await render(DialogAnimationHost);
+		const dialog = dialogOf(view);
+
+		dialog.open();
+		view.detectChanges();
+		await flush();
+		expect(panel()).toBeTruthy();
+
+		dialog.close();
+		view.detectChanges();
+		await flush();
+
+		// Still mounted during the exit animation, marked closed.
+		expect(panel()).toBeTruthy();
+		expect(panel()?.getAttribute('data-state')).toBe('closed');
+
+		// After the animation completes it is disposed.
+		await wait(EXIT_MS + 120);
+		expect(panel()).toBeNull();
+	});
+
+	it('pins the exit animation to its final frame so it cannot snap back before disposal', async () => {
+		const view = await render(DialogAnimationHost);
+		const dialog = dialogOf(view);
+
+		dialog.open();
+		view.detectChanges();
+		await flush();
+
+		dialog.close();
+		view.detectChanges();
+		await flush();
+		await flush();
+
+		// The exit animation defaults to fill-mode none; the dialog must hold it forwards so the
+		// element stays hidden through the async disposal gap instead of snapping back to visible.
+		const animations = panel()?.getAnimations() ?? [];
+		expect(animations.length).toBeGreaterThan(0);
+		for (const animation of animations) {
+			expect(animation.effect?.getComputedTiming().fill).toBe('forwards');
+		}
+
+		// Pinned or not, the panel still disposes once the animation completes.
+		await wait(EXIT_MS + 120);
+		expect(panel()).toBeNull();
+	});
+});
+
+describe('HlmDialog teardown without an exit animation', () => {
+	afterEach(() => {
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	it('disposes the panel promptly when there is no exit animation', async () => {
+		const view = await render(DialogAnimationHost);
+		const dialog = dialogOf(view);
+
+		dialog.open();
+		view.detectChanges();
+		await flush();
+		expect(panel()).toBeTruthy();
+
+		dialog.close();
+		view.detectChanges();
+		await flush();
+		await flush();
+
+		expect(panel()).toBeNull();
+	});
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] dialog
- [x] sheet

### Others

_None_

## What is the current behavior?

Closing a dialog or sheet flickers: the panel snaps back to its fully-visible
open position for one frame before it disappears.

This is the same root cause fixed for overlays in #1546. That fix pinned exit
animations to their final frame in `BrnOverlayRef`, but dialog and sheet render
through `BrnDialogRef` — a separate close path that was never patched. The
tw-animate-css exit animations use `animation-fill-mode: none`, so a finished
exit reverts the element to its visible state in the async gap before disposal.
Confirmed in the browser: the sheet's `exit` animation reported
`fill: "none"` throughout the close.

## What is the new behavior?

`BrnDialogRef._finishClose` now pins each awaited exit animation to
`fill: 'forwards'` (via `updateTiming`) before disposal, mirroring the
`BrnOverlayRef` fix. The panel stays hidden through the disposal gap, so the
flicker is gone for both dialog and sheet.

Adds the first dialog animation spec (`hlm-dialog-animation.spec.ts`) asserting
the exit animation is held forwards — the dialog close path previously had no
animation coverage, which is why #1546 missed it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dialog exit animations now complete properly without visual glitches, ensuring smooth animation transitions before dialog dismissal

* **Tests**
  * Added comprehensive test coverage verifying dialog teardown behavior with and without exit animations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->