### PR TITLE
fix: tolerate @angular/cdk < 21.2 in menu trigger transform-origin

### DIFF
--- a/libs/cli/src/generators/ui/libs/context-menu/files/lib/hlm-context-menu-trigger.ts.template
+++ b/libs/cli/src/generators/ui/libs/context-menu/files/lib/hlm-context-menu-trigger.ts.template
@@ -37,8 +37,10 @@ export class HlmContextMenuTrigger {
 
 	constructor() {
 		// CDK sets transform-origin on the menu content (a shared hlm-dropdown-menu) from the resolved
-		// position; the content reads it to animate from the anchored corner and to derive its data-side
-		this._cdkTrigger.transformOriginSelector = '[data-slot="dropdown-menu"]';
+		// position; the content reads it to animate from the anchored corner and to derive its data-side.
+		// Cast tolerates @angular/cdk < 21.2 (we still support >=21.0), where the property is absent and
+		// the assignment is a harmless no-op.
+		(this._cdkTrigger as { transformOriginSelector?: string }).transformOriginSelector = '[data-slot="dropdown-menu"]';
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();

--- a/libs/cli/src/generators/ui/libs/dropdown-menu/files/lib/hlm-dropdown-menu-sub-trigger.ts.template
+++ b/libs/cli/src/generators/ui/libs/dropdown-menu/files/lib/hlm-dropdown-menu-sub-trigger.ts.template
@@ -27,8 +27,10 @@ export class HlmDropdownMenuSubTrigger {
 
 	constructor() {
 		// CDK sets transform-origin on the submenu content from the resolved position; the content reads it
-		// to animate from the anchored corner and to derive its data-side
-		this._cdkTrigger.transformOriginSelector = '[data-slot="dropdown-menu-sub"]';
+		// to animate from the anchored corner and to derive its data-side. Cast tolerates @angular/cdk < 21.2
+		// (we still support >=21.0), where the property is absent and the assignment is a harmless no-op.
+		(this._cdkTrigger as { transformOriginSelector?: string }).transformOriginSelector =
+			'[data-slot="dropdown-menu-sub"]';
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();

--- a/libs/cli/src/generators/ui/libs/dropdown-menu/files/lib/hlm-dropdown-menu-trigger.ts.template
+++ b/libs/cli/src/generators/ui/libs/dropdown-menu/files/lib/hlm-dropdown-menu-trigger.ts.template
@@ -26,8 +26,9 @@ export class HlmDropdownMenuTrigger {
 
 	constructor() {
 		// CDK sets transform-origin on the menu content from the resolved position; the content reads it to
-		// animate from the anchored corner and to derive its data-side
-		this._cdkTrigger.transformOriginSelector = '[data-slot="dropdown-menu"]';
+		// animate from the anchored corner and to derive its data-side. Cast tolerates @angular/cdk < 21.2
+		// (we still support >=21.0), where the property is absent and the assignment is a harmless no-op.
+		(this._cdkTrigger as { transformOriginSelector?: string }).transformOriginSelector = '[data-slot="dropdown-menu"]';
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();

--- a/libs/cli/src/generators/ui/libs/menubar/files/lib/hlm-menubar-trigger.ts.template
+++ b/libs/cli/src/generators/ui/libs/menubar/files/lib/hlm-menubar-trigger.ts.template
@@ -38,8 +38,10 @@ export class HlmMenubarTrigger {
 
 	constructor() {
 		// CDK sets transform-origin on the menu content (a shared hlm-dropdown-menu) from the resolved
-		// position; the content reads it to animate from the anchored corner and to derive its data-side
-		this._cdkTrigger.transformOriginSelector = '[data-slot="dropdown-menu"]';
+		// position; the content reads it to animate from the anchored corner and to derive its data-side.
+		// Cast tolerates @angular/cdk < 21.2 (we still support >=21.0), where the property is absent and
+		// the assignment is a harmless no-op.
+		(this._cdkTrigger as { transformOriginSelector?: string }).transformOriginSelector = '[data-slot="dropdown-menu"]';
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();

--- a/libs/helm/context-menu/src/lib/hlm-context-menu-trigger.ts
+++ b/libs/helm/context-menu/src/lib/hlm-context-menu-trigger.ts
@@ -37,8 +37,10 @@ export class HlmContextMenuTrigger {
 
 	constructor() {
 		// CDK sets transform-origin on the menu content (a shared hlm-dropdown-menu) from the resolved
-		// position; the content reads it to animate from the anchored corner and to derive its data-side
-		this._cdkTrigger.transformOriginSelector = '[data-slot="dropdown-menu"]';
+		// position; the content reads it to animate from the anchored corner and to derive its data-side.
+		// Cast tolerates @angular/cdk < 21.2 (we still support >=21.0), where the property is absent and
+		// the assignment is a harmless no-op.
+		(this._cdkTrigger as { transformOriginSelector?: string }).transformOriginSelector = '[data-slot="dropdown-menu"]';
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-sub-trigger.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-sub-trigger.ts
@@ -27,8 +27,10 @@ export class HlmDropdownMenuSubTrigger {
 
 	constructor() {
 		// CDK sets transform-origin on the submenu content from the resolved position; the content reads it
-		// to animate from the anchored corner and to derive its data-side
-		this._cdkTrigger.transformOriginSelector = '[data-slot="dropdown-menu-sub"]';
+		// to animate from the anchored corner and to derive its data-side. Cast tolerates @angular/cdk < 21.2
+		// (we still support >=21.0), where the property is absent and the assignment is a harmless no-op.
+		(this._cdkTrigger as { transformOriginSelector?: string }).transformOriginSelector =
+			'[data-slot="dropdown-menu-sub"]';
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();

--- a/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-trigger.ts
+++ b/libs/helm/dropdown-menu/src/lib/hlm-dropdown-menu-trigger.ts
@@ -26,8 +26,9 @@ export class HlmDropdownMenuTrigger {
 
 	constructor() {
 		// CDK sets transform-origin on the menu content from the resolved position; the content reads it to
-		// animate from the anchored corner and to derive its data-side
-		this._cdkTrigger.transformOriginSelector = '[data-slot="dropdown-menu"]';
+		// animate from the anchored corner and to derive its data-side. Cast tolerates @angular/cdk < 21.2
+		// (we still support >=21.0), where the property is absent and the assignment is a harmless no-op.
+		(this._cdkTrigger as { transformOriginSelector?: string }).transformOriginSelector = '[data-slot="dropdown-menu"]';
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();

--- a/libs/helm/menubar/src/lib/hlm-menubar-trigger.ts
+++ b/libs/helm/menubar/src/lib/hlm-menubar-trigger.ts
@@ -38,8 +38,10 @@ export class HlmMenubarTrigger {
 
 	constructor() {
 		// CDK sets transform-origin on the menu content (a shared hlm-dropdown-menu) from the resolved
-		// position; the content reads it to animate from the anchored corner and to derive its data-side
-		this._cdkTrigger.transformOriginSelector = '[data-slot="dropdown-menu"]';
+		// position; the content reads it to animate from the anchored corner and to derive its data-side.
+		// Cast tolerates @angular/cdk < 21.2 (we still support >=21.0), where the property is absent and
+		// the assignment is a harmless no-op.
+		(this._cdkTrigger as { transformOriginSelector?: string }).transformOriginSelector = '[data-slot="dropdown-menu"]';
 
 		effect(() => {
 			this._cdkTrigger.menuPosition = this._menuPosition();


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## Which package are you modifying?

### Primitives

- [x] context-menu
- [x] dropdown-menu
- [x] menubar

### Others

- [x] cli

## What is the current behavior?

The menu triggers set `CdkMenuTrigger.transformOriginSelector` (added in #1547 for corner-anchored
open animations). That property only exists in `@angular/cdk` >= 21.2, but brain declares a
`>=21.0.0` peer and the CLI scaffolds consumers onto a 21.0.x CDK. A generated app on CDK 21.0/21.1
therefore fails to compile with `TS2339: Property 'transformOriginSelector' does not exist on type
'CdkMenuTrigger'`. The cli-smoke `all-components` cell caught this once it ran in the release verify
gate.

## What is the new behavior?

Assign `transformOriginSelector` through a structural cast (`{ transformOriginSelector?: string }`)
in the dropdown-menu, dropdown-menu-sub, context-menu and menubar triggers. On CDK >= 21.2 it sets
the selector as before; on older CDK the property is absent and the assignment is a harmless no-op
(the corner-scale animation simply doesn't apply). Regenerate the CLI templates from the patched
helm sources. Keeps the `>=21.0.0` compatibility floor intact.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Verified the patched helm libs build; the cast removes any reference to the typed property, so the
generated components now compile on any supported CDK (>=21.0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved compatibility of menu components (context-menu, dropdown-menu, and menubar) with older Angular CDK versions to ensure stable, reliable operation across different CDK releases. These updates enhance overall robustness and resilience while maintaining full backward compatibility and preserving all existing behavior, features, and end-user experience throughout the application ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->