### PR TITLE
ci: publish releases on push to main/beta/alpha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,14 @@ name: release
 # next version on any branch without publishing anything.
 
 on:
-  # TODO(v1 cutover): re-enable after the first manual 1.0.0 release is verified, so every merge to
-  # a release branch publishes automatically. Kept off for now so merging this PR does not auto-fire
-  # a release on the merge commit — the first release is driven manually via workflow_dispatch.
-  # push:
-  #   branches:
-  #     - main
-  #     - beta
-  #     - alpha
+  # Every merge to a release branch publishes automatically (1.0.0 was cut manually via
+  # workflow_dispatch; ongoing releases are push-driven). Non-releasing commit types
+  # (ci/docs/chore/...) compute "no release" and publish nothing, so this is safe to leave on.
+  push:
+    branches:
+      - main
+      - beta
+      - alpha
   workflow_dispatch:
     inputs:
       dry-run:

--- a/V1-TODO.md
+++ b/V1-TODO.md
@@ -104,18 +104,20 @@ active would fire a real release on the merge commit. So for the first cutover:
 - [x] Merge `release.yml` with the **`push:` trigger temporarily removed** (dispatch-only). _Why: lets
       the workflow land on `main` without auto-publishing._ (Done on `chore/semantic-release-v1`: the
       `push:` block is commented out; re-enabled in step 7 after the first release.)
-- [ ] Dry-run: `gh workflow run release.yml --ref main -f dry-run=true` then `gh run watch`. _Why:
+- [x] Dry-run: `gh workflow run release.yml --ref main -f dry-run=true` then `gh run watch`. _Why:
       confirm it computes **1.0.0** and the right files/notes before anything is published._
-- [ ] Real release: `gh workflow run release.yml --ref main -f dry-run=false`. _Why: publishes 1.0.0 to
+- [x] Real release: `gh workflow run release.yml --ref main -f dry-run=false`. _Why: publishes 1.0.0 to
       npm `latest`, commits the version bump + changelog, and cuts the GitHub Release._
-- [ ] Verify: `@spartan-ng/*@1.0.0` on npm, a `v1.0.0` tag, and a GitHub Release.
+- [x] Verify: `@spartan-ng/*@1.0.0` on npm, a `v1.0.0` tag, and a GitHub Release. _Done: npm
+      brain/cli/mcp@1.0.0, tag `v1.0.0`, and the GitHub Release (created manually — semantic-release's
+      release-body POST 422'd on the >125k-char first-release changelog; future releases are small)._
 
 > Why this sequence: it lets you preview the computed version with zero risk before the irreversible
 > npm publish.
 
 ### 7. Enable ongoing automation
 
-- [ ] Follow-up PR that **re-adds `push: [main, beta, alpha]`** to `release.yml`.
+- [x] Follow-up PR that **re-adds `push: [main, beta, alpha]`** to `release.yml`.
 
 > Why: after the verified first release, every merge to a release branch should publish automatically —
 > that's the whole point of the channel model.


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] CI related changes

## Which package are you modifying?

### Others

- [x] repo

## What is the current behavior?

`release.yml` only triggers on `workflow_dispatch` — the `push:` trigger was commented out for the v1
cutover so merging the workflow wouldn't auto-fire a release before the first 1.0.0 was verified. That
first release is now done (npm `@spartan-ng/{brain,cli,mcp}@1.0.0`, tag `v1.0.0`, GitHub Release), so
ongoing releases still require a manual dispatch.

## What is the new behavior?

Re-add `push: [main, beta, alpha]` so every merge to a release branch publishes automatically (step 7
of `V1-TODO.md`). Safe to leave on: non-releasing commit types (ci/docs/chore/...) compute "no release"
and publish nothing, and the release commit carries `[skip ci]` so it can't loop. `workflow_dispatch`
(with dry-run) is kept for previews. Also checks off steps 6–7 in `V1-TODO.md`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

After this merges, releases are fully push-driven per the channel model (`main → latest`,
`beta → beta`, `alpha → alpha`). Note: a first `beta`/`alpha` release will still hit GitHub's 125k
release-body limit like 1.0.0 did (large first-time changelog); `main` releases won't.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated release runs now trigger on pushes to the main, beta, and alpha branches, reducing manual steps.
  * Updated the release checklist to mark dry-run, real release, and verification steps as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->