### PR TITLE
fix: stop CDK backdrop fade doubling the overlay open animation

### DIFF
--- a/libs/brain/hlm-tailwind-preset.css
+++ b/libs/brain/hlm-tailwind-preset.css
@@ -1,6 +1,22 @@
 @import '@angular/cdk/overlay-prebuilt.css';
 @import 'tw-animate-css';
 
+/* CDK fades the backdrop with its own opacity transition, and the spartan overlay class fades it again
+   with a tw-animate keyframe - two fades that visibly double up on iOS (#1555). Neutralize CDK's so the
+   spartan keyframe is the sole animator. Kept UNLAYERED so it reliably beats CDK's runtime
+   `@layer cdk-overlay` (unlayered wins over any layer; a custom `@layer` here gets dropped by Tailwind).
+   The vars let consumers re-enable/tune the CDK fade without `!important`, e.g.
+   `:root { --spartan-overlay-backdrop-transition: opacity 200ms ease; }`.
+   Note: the spartan keyframe itself doesn't smoothly interpolate on Safari/iOS - upstream tw-animate-css#59
+   (the `blur()` in its keyframes) - so on iOS the backdrop appears in one step rather than a smooth fade.
+   Tracked upstream; out of scope for this double-fade fix.
+   Scoped off `.cdk-overlay-transparent-backdrop` so CDK's invisible click-catcher backdrops (menus,
+   popovers) keep their own `opacity: 0` and aren't forced visible. */
+.cdk-overlay-backdrop:not(.cdk-overlay-transparent-backdrop) {
+	opacity: var(--spartan-overlay-backdrop-opacity, 1);
+	transition: var(--spartan-overlay-backdrop-transition, none);
+}
+
 @custom-variant dark (&:is(.dark *));
 
 @custom-variant data-open {


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## Which package are you modifying?

### Primitives

- [x] dialog
- [x] sheet

## What is the current behavior?

The overlay backdrop fades twice on iOS — CDK's prebuilt opacity transition and the spartan overlay
class's tw-animate keyframe both animate it, and on iOS the two visibly double up (the flicker in
#1555).

## What is the new behavior?

Neutralize CDK's backdrop opacity/transition in the hlm tailwind preset (unlayered so it reliably
beats CDK's runtime `@layer cdk-overlay`) so the spartan keyframe is the sole animator. Exposed via
CSS vars so consumers can re-enable/tune the CDK fade without `!important`.

Note: the spartan keyframe itself doesn't smoothly interpolate on Safari/iOS due to an upstream
tw-animate-css bug (`blur()` in its keyframes, tw-animate-css#59); that's tracked upstream and out of
scope here.

## Does this PR introduce a breaking change?

- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable styling for Angular CDK overlay backdrops, letting backdrop opacity and transition behavior be controlled via CSS variables.
* **Bug Fixes**
  * Resolved an iOS “double fade” issue by neutralizing the default backdrop opacity animation, producing smoother and more consistent overlay transition effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->