### PR TITLE
build: keep helm @spartan-ng/brain peer in sync with releases

### DIFF
--- a/libs/helm/package.json
+++ b/libs/helm/package.json
@@ -11,7 +11,7 @@
 		"@angular/router": ">=21.0.0 <23.0.0",
 		"@ng-icons/core": ">=32.0.0 <34.0.0",
 		"@ng-icons/lucide": ">=32.0.0 <34.0.0",
-		"@spartan-ng/brain": "0.0.1-alpha.720",
+		"@spartan-ng/brain": "1.0.0",
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
 		"embla-carousel": ">=8.0.0 <9.0.0",

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -55,6 +55,10 @@ export default {
 					'libs/brain/package.json',
 					'libs/cli/package.json',
 					'libs/mcp/package.json',
+					// helm is private (not version-stamped), but its `@spartan-ng/brain` peer is bumped in
+					// lockstep by the `lint --fix` in prepare-manual-release; commit it so that sync persists
+					// (otherwise the corrected file is discarded each release and helm:lint goes stale).
+					'libs/helm/package.json',
 					'libs/cli/src/generators/ui/**',
 					'CHANGELOG.md',
 				],


### PR DESCRIPTION
## PR Type

- [x] Build related changes

## Which package are you modifying?

- [x] helm
- [x] repo

## What is the current behavior?

`helm:lint` (nx `@nx/dependency-checks`) fails on `main` and every branch off it: `libs/helm/package.json`
pins `@spartan-ng/brain` to the stale pre-1.0 `0.0.1-alpha.720`, but brain is now `1.0.0`, so the peer
range no longer contains the installed version.

Root cause: the release *does* sync the peer (`prepare-manual-release` runs `lint --fix`), but
`@semantic-release/git` only commits files in its `assets` list, and `libs/helm/package.json` wasn't in
it — so the corrected file was discarded each release and `main` kept the stale value.

## What is the new behavior?

- Pin `@spartan-ng/brain` to `1.0.0` in `libs/helm/package.json` (fixes the red `main`).
- Add `libs/helm/package.json` to the `@semantic-release/git` `assets` so the `lint --fix` sync persists
  into the release commit from the next release on — keeping helm's brain peer in lockstep automatically.

## Does this PR introduce a breaking change?

- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a package dependency to the latest major version for better compatibility.
  * Kept release metadata in sync so this package’s version updates are preserved during publish workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->