### PR TITLE
fix: stop CDK backdrop fade doubling the overlay open animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## <small>1.0.1-alpha.1 (2026-06-24)</small>
+
+- fix: stop CDK backdrop fade doubling the overlay open animation (#1560) ([75f1789](https://github.com/spartan-ng/spartan/commit/75f1789)), closes [#1560](https://github.com/spartan-ng/spartan/issues/1560) [#1555](https://github.com/spartan-ng/spartan/issues/1555)
+- ci: publish releases on push to main/beta/alpha (#1559) ([5e5ddea](https://github.com/spartan-ng/spartan/commit/5e5ddea)), closes [#1559](https://github.com/spartan-ng/spartan/issues/1559)
+- build: keep helm @spartan-ng/brain peer in sync with releases (#1561) ([bb18cbf](https://github.com/spartan-ng/spartan/commit/bb18cbf)), closes [#1561](https://github.com/spartan-ng/spartan/issues/1561)
+
 ## 1.0.0 (2026-06-24)
 
 - fix: 300 mobile responsiveness (#487) ([5ea2c87](https://github.com/spartan-ng/spartan/commit/5ea2c87)), closes [#487](https://github.com/spartan-ng/spartan/issues/487)

--- a/libs/brain/hlm-tailwind-preset.css
+++ b/libs/brain/hlm-tailwind-preset.css
@@ -1,6 +1,22 @@
 @import '@angular/cdk/overlay-prebuilt.css';
 @import 'tw-animate-css';
 
+/* CDK fades the backdrop with its own opacity transition, and the spartan overlay class fades it again
+   with a tw-animate keyframe - two fades that visibly double up on iOS (#1555). Neutralize CDK's so the
+   spartan keyframe is the sole animator. Kept UNLAYERED so it reliably beats CDK's runtime
+   `@layer cdk-overlay` (unlayered wins over any layer; a custom `@layer` here gets dropped by Tailwind).
+   The vars let consumers re-enable/tune the CDK fade without `!important`, e.g.
+   `:root { --spartan-overlay-backdrop-transition: opacity 200ms ease; }`.
+   Note: the spartan keyframe itself doesn't smoothly interpolate on Safari/iOS - upstream tw-animate-css#59
+   (the `blur()` in its keyframes) - so on iOS the backdrop appears in one step rather than a smooth fade.
+   Tracked upstream; out of scope for this double-fade fix.
+   Scoped off `.cdk-overlay-transparent-backdrop` so CDK's invisible click-catcher backdrops (menus,
+   popovers) keep their own `opacity: 0` and aren't forced visible. */
+.cdk-overlay-backdrop:not(.cdk-overlay-transparent-backdrop) {
+	opacity: var(--spartan-overlay-backdrop-opacity, 1);
+	transition: var(--spartan-overlay-backdrop-transition, none);
+}
+
 @custom-variant dark (&:is(.dark *));
 
 @custom-variant data-open {

--- a/libs/brain/package.json
+++ b/libs/brain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@spartan-ng/brain",
-	"version": "1.0.0",
+	"version": "1.0.1-alpha.1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/spartan-ng/spartan.git"

--- a/libs/cli/package.json
+++ b/libs/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@spartan-ng/cli",
-	"version": "1.0.0",
+	"version": "1.0.1-alpha.1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/spartan-ng/spartan.git"

--- a/libs/cli/src/generators/ui/supported-ui-libraries.json
+++ b/libs/cli/src/generators/ui/supported-ui-libraries.json
@@ -3,7 +3,7 @@
 		"name": "accordion",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
 			"clsx": "^2.1.1"
@@ -20,7 +20,7 @@
 		"name": "alert-dialog",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"clsx": "^2.1.1"
 		}
 	},
@@ -36,7 +36,7 @@
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@angular/forms": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0"
@@ -46,7 +46,7 @@
 		"name": "avatar",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"badge": {
@@ -69,7 +69,7 @@
 		"name": "button",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"class-variance-authority": "^0.7.0",
 			"clsx": "^2.1.1"
 		}
@@ -78,7 +78,7 @@
 		"name": "button-group",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"class-variance-authority": "^0.7.0"
 		}
 	},
@@ -89,7 +89,7 @@
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"card": {
@@ -118,7 +118,7 @@
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"clsx": "^2.1.1"
 		}
 	},
@@ -126,7 +126,7 @@
 		"name": "collapsible",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"combobox": {
@@ -134,7 +134,7 @@
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@angular/forms": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
@@ -146,7 +146,7 @@
 		"peerDependencies": {
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"clsx": "^2.1.1",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0"
@@ -156,7 +156,7 @@
 		"name": "context-menu",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"@angular/cdk": ">=21.0.0 <23.0.0"
 		}
 	},
@@ -165,7 +165,7 @@
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@angular/forms": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
@@ -176,7 +176,7 @@
 		"name": "dialog",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@angular/common": ">=21.0.0 <23.0.0",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
@@ -188,7 +188,7 @@
 		"name": "drawer",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"clsx": "^2.1.1"
 		}
 	},
@@ -199,7 +199,7 @@
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"rxjs": "^7.8.0"
 		}
 	},
@@ -214,7 +214,7 @@
 		"name": "field",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"class-variance-authority": "^0.7.0"
 		}
@@ -223,7 +223,7 @@
 		"name": "hover-card",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"input": {
@@ -231,7 +231,7 @@
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@angular/forms": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"input-group": {
@@ -248,7 +248,7 @@
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"item": {
@@ -256,7 +256,7 @@
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"class-variance-authority": "^0.7.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"kbd": {
@@ -269,14 +269,14 @@
 		"name": "label",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"menubar": {
 		"name": "menubar",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"@angular/cdk": ">=21.0.0 <23.0.0"
 		}
 	},
@@ -288,7 +288,7 @@
 			"@angular/forms": ">=21.0.0 <23.0.0",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"clsx": "^2.1.1"
 		}
 	},
@@ -297,7 +297,7 @@
 		"peerDependencies": {
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0"
 		}
@@ -318,7 +318,7 @@
 		"peerDependencies": {
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"progress": {
@@ -326,7 +326,7 @@
 		"peerDependencies": {
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"radio-group": {
@@ -334,7 +334,7 @@
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@angular/forms": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"clsx": "^2.1.1",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@angular/common": ">=21.0.0 <23.0.0"
@@ -344,7 +344,7 @@
 		"name": "resizable",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"scroll-area": {
@@ -360,7 +360,7 @@
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@angular/forms": ">=21.0.0 <23.0.0",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
 			"clsx": "^2.1.1"
@@ -370,14 +370,14 @@
 		"name": "separator",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"sheet": {
 		"name": "sheet",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
@@ -389,7 +389,7 @@
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"class-variance-authority": "^0.7.0",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
@@ -408,7 +408,7 @@
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@angular/forms": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"sonner": {
@@ -418,7 +418,7 @@
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
 			"@ng-icons/lucide": ">=32.0.0 <34.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"clsx": "^2.1.1"
 		}
 	},
@@ -436,7 +436,7 @@
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@angular/forms": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"clsx": "^2.1.1"
 		}
 	},
@@ -450,7 +450,7 @@
 		"name": "tabs",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"class-variance-authority": "^0.7.0",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@ng-icons/core": ">=32.0.0 <34.0.0",
@@ -464,14 +464,14 @@
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@angular/forms": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0"
+			"@spartan-ng/brain": "1.0.1-alpha.1"
 		}
 	},
 	"toggle": {
 		"name": "toggle",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"class-variance-authority": "^0.7.0"
 		}
 	},
@@ -479,7 +479,7 @@
 		"name": "toggle-group",
 		"peerDependencies": {
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"@angular/cdk": ">=21.0.0 <23.0.0"
 		}
 	},
@@ -488,7 +488,7 @@
 		"peerDependencies": {
 			"@angular/cdk": ">=21.0.0 <23.0.0",
 			"@angular/core": ">=21.0.0 <23.0.0",
-			"@spartan-ng/brain": "1.0.0",
+			"@spartan-ng/brain": "1.0.1-alpha.1",
 			"class-variance-authority": "^0.7.0"
 		}
 	},

--- a/libs/helm/package.json
+++ b/libs/helm/package.json
@@ -11,7 +11,7 @@
 		"@angular/router": ">=21.0.0 <23.0.0",
 		"@ng-icons/core": ">=32.0.0 <34.0.0",
 		"@ng-icons/lucide": ">=32.0.0 <34.0.0",
-		"@spartan-ng/brain": "1.0.0",
+		"@spartan-ng/brain": "1.0.1-alpha.1",
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
 		"embla-carousel": ">=8.0.0 <9.0.0",

--- a/libs/mcp/package.json
+++ b/libs/mcp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@spartan-ng/mcp",
-	"version": "1.0.0",
+	"version": "1.0.1-alpha.1",
 	"description": "Model Context Protocol server exposing Spartan Angular UI documentation, components, and blocks as AI-consumable tools.",
 	"keywords": [
 		"mcp",


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## Which package are you modifying?

- [x] dialog
- [x] sheet

## What is the new behavior?

Promotes the `#1555` backdrop double-fade fix from `alpha` to `beta`. Merging publishes
`1.0.1-beta.1` to the `@beta` dist-tag (already live as `1.0.1-alpha.1` on `@alpha`).

## Does this PR introduce a breaking change?

- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backdrop fading so overlay open animations no longer run twice, improving dialog and overlay transitions.

* **Chores**
  * Published new `1.0.1-alpha.1` release entries and updated package versions to stay aligned.
  * Kept release publishing and version references in sync across the toolkit so updates ship consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->