### PR TITLE
build: allow the release scope in commitlint

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -69,6 +69,8 @@ module.exports = {
 				'typography',
 				'nx',
 				'repo',
+				// semantic-release stamps the release commit as `chore(release): <version>`.
+				'release',
 			],
 		],
 	},


### PR DESCRIPTION
## PR Type

- [x] Build related changes

## Which package are you modifying?

- [x] repo

## What is the current behavior?

semantic-release commits each release as `chore(release): <version> [skip ci]`, but `release` is not
in the commitlint `scope-enum`. So whenever commitlint runs over a release commit (e.g. `ci.yml` on a
`beta → main` promotion merge), it fails with `scope must be one of [...]`. It slipped by on the
alpha/beta promotions only because their head commits carried `[skip ci]`, which skipped `ci.yml`.

## What is the new behavior?

Add `release` to the `scope-enum` so the `chore(release): …` commits semantic-release generates pass
commitlint.

## Does this PR introduce a breaking change?

- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release commit validation to accept the `release` scope, helping automated release commits go through smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->