### PR TITLE
fix(docs) : Fix height of FieldDemo component.

### DIFF
--- a/apps/app/src/app/pages/(home)/components/overview/components/field-demo.ts
+++ b/apps/app/src/app/pages/(home)/components/overview/components/field-demo.ts
@@ -12,7 +12,7 @@ import { HlmTextarea } from '@spartan-ng/helm/textarea';
 	imports: [HlmFieldImports, HlmSelectImports, HlmInput, HlmTextarea, HlmButton, HlmCheckbox],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
-		class: 'w-full max-w-md rounded-lg border p-6 h-full',
+		class: 'w-full max-w-md rounded-lg border p-6',
 	},
 	template: `
 		<form>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

In the Home page of the docs, the FiledDocument gets stretched to fit height of component.

Closes #

## What is the new behavior?

The FieldComponent height is now fitting what is inside.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
Before :
<img width="1669" height="345" alt="Capture d&#39;écran 2026-06-25 095909" src="https://github.com/user-attachments/assets/51ab1f67-7a31-4fb1-89a6-6101ec63e4e2" />
After :
<img width="1580" height="330" alt="Capture d&#39;écran 2026-06-25 095938" src="https://github.com/user-attachments/assets/d65fff82-a089-408c-a564-f96e47e37756" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the home page field demo container styling so it no longer forces full-height layout, improving visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->