### PR TITLE
fix(resizable): initial size when defaultSize is set

### DIFF
--- a/libs/brain/resizable/src/lib/brn-resizable-group.spec.ts
+++ b/libs/brain/resizable/src/lib/brn-resizable-group.spec.ts
@@ -23,6 +23,18 @@ class ResizableHost {
 }
 
 @Component({
+	imports: [BrnResizablePanel],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<brn-resizable-group>
+			<brn-resizable-panel [defaultSize]="25" />
+			<brn-resizable-panel [defaultSize]="75" />
+		</brn-resizable-group>
+	`,
+})
+class ResizableDefaultSize {}
+
+@Component({
 	imports: [BrnResizableGroup, BrnResizablePanel, BrnResizableHandle],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
@@ -240,6 +252,25 @@ describe('BrnResizableGroup', () => {
 				Number(panel.getAttribute('data-panel-size')),
 			),
 		).toEqual([20, 30, 50]);
+	});
+
+	it('renders panels at their default sizes on the first paint (no 50/50 flash)', async () => {
+		// Mount panels against a stub group so the real BrnResizableGroup's afterRenderEffect
+		// never runs to setSize them. Whatever flex the panels emit here IS the first paint.
+		const view = await render(ResizableDefaultSize, {
+			providers: [
+				{
+					provide: BrnResizableGroup,
+					useValue: { id: signal('standalone-group'), direction: signal('horizontal') },
+				},
+			],
+		});
+		view.detectChanges();
+
+		const panels = Array.from(view.container.querySelectorAll<HTMLElement>('[data-slot="resizable-panel"]'));
+		// Chromium serializes the `0` flex-basis as `0px`; normalize so the assertion is portable.
+		const flexValues = panels.map((panel) => panel.style.flex.replace(/0px$/, '0'));
+		expect(flexValues).toEqual(['25 1 0', '75 1 0']);
 	});
 
 	it('applies an external layout update without a panel membership change', async () => {

--- a/libs/brain/resizable/src/lib/brn-resizable-panel.ts
+++ b/libs/brain/resizable/src/lib/brn-resizable-panel.ts
@@ -66,7 +66,10 @@ export class BrnResizablePanel {
 	 * share (e.g. 50/50) and then snapping to the configured size. Example: `"25 1 0"` means
 	 * 25% width (or height in vertical layout).
 	 */
-	protected readonly _flex = computed(() => `${this._panelSize() ?? this.defaultSize()} 1 0`);
+	protected readonly _flex = computed(() => {
+		const size = this._panelSize() ?? this.defaultSize() ?? 100;
+		return `${size} 1 0`;
+	});
 	/**
 	 * Sets the size of the panel.
 	 * @param size New size (percentage of container space).

--- a/libs/brain/resizable/src/lib/brn-resizable-panel.ts
+++ b/libs/brain/resizable/src/lib/brn-resizable-panel.ts
@@ -55,16 +55,18 @@ export class BrnResizablePanel {
 	public readonly collapsible = input<boolean, BooleanInput>(true, { transform: booleanAttribute });
 
 	/** Reactive signal holding the current size of the panel. */
-	protected readonly _panelSize = signal<number>(100);
+	protected readonly _panelSize = signal<number | undefined>(undefined);
 
 	/**
 	 * CSS flex style for this panel, derived from its current size.
 	 * Format: `"flex-grow flex-shrink flex-basis"`.
 	 *
-	 * Example: `"25 1 0"` means 25% width (or height in vertical layout).
+	 * Before the group synchronizes the layout, falls back to {@link defaultSize} so the panel
+	 * paints at its intended size on the very first render instead of briefly flexing to an equal
+	 * share (e.g. 50/50) and then snapping to the configured size. Example: `"25 1 0"` means
+	 * 25% width (or height in vertical layout).
 	 */
-	protected readonly _flex = computed(() => `${this._panelSize()} 1 0`);
-
+	protected readonly _flex = computed(() => `${this._panelSize() ?? this.defaultSize()} 1 0`);
 	/**
 	 * Sets the size of the panel.
 	 * @param size New size (percentage of container space).


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [x] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When two panels have a defined `defaultSize` like 25 (first) and 75 (second), the content starts at 50/50 and flashes to the 25/75 size.

https://github.com/user-attachments/assets/ef7433b6-4b63-4b2d-bec0-fc6562ca7e63

The flash is also noticable on the `/blocks/sidebar` when run locally, when refreshed on the page.

## What is the new behavior?

Uses the `defaultSize` as fallback to avoid the flash

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where resizable panels briefly showed an incorrect equal (50/50) layout on first render.
  * Improved initial sizing behavior by using configured default sizes until the group finishes synchronizing layout, resulting in a smoother first-paint experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->