### PR TITLE
fix(field): allow BrnFieldControl to inject ngControl from host component, set label's for attribute if not assigned a form control

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(field)/field.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(field)/field.preview.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { HlmButtonImports } from '@spartan-ng/helm/button';
 import { HlmCheckboxImports } from '@spartan-ng/helm/checkbox';
 import { HlmFieldImports } from '@spartan-ng/helm/field';
@@ -16,7 +15,6 @@ import { HlmTextareaImports } from '@spartan-ng/helm/textarea';
 		HlmInputImports,
 		HlmFieldImports,
 		HlmSelectImports,
-		ReactiveFormsModule,
 	],
 	host: {
 		class: 'w-full max-w-md',
@@ -115,9 +113,7 @@ import { HlmTextareaImports } from '@spartan-ng/helm/textarea';
 		</form>
 	`,
 })
-export class FieldPreview {
-	public control = new FormControl('', Validators.required);
-}
+export class FieldPreview {}
 
 export const defaultImports = `
 import { HlmFieldImports } from "@spartan-ng/helm/field";

--- a/libs/brain/field/src/lib/brn-field-control.spec.ts
+++ b/libs/brain/field/src/lib/brn-field-control.spec.ts
@@ -1,7 +1,18 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, viewChild } from '@angular/core';
-import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, forwardRef, inject, viewChild } from '@angular/core';
+import {
+	type ControlValueAccessor,
+	FormControl,
+	FormsModule,
+	NG_VALUE_ACCESSOR,
+	ReactiveFormsModule,
+	Validators,
+} from '@angular/forms';
+import { By } from '@angular/platform-browser';
 import { BrnInput } from '@spartan-ng/brain/input';
+import { BrnLabel } from '@spartan-ng/brain/label';
 import { render } from '@testing-library/angular';
+import { BrnField } from './brn-field';
+import { BrnFieldControl } from './brn-field-control';
 
 @Component({
 	selector: 'brn-test-host',
@@ -13,7 +24,7 @@ import { render } from '@testing-library/angular';
 })
 class TestHostComponent {
 	public ctrl = new FormControl('initial');
-	public readonly brnInput = viewChild(BrnInput);
+	public readonly brnFieldControl = viewChild(BrnFieldControl);
 }
 
 @Component({
@@ -47,14 +58,96 @@ class TestHostValidationComponent {
 	public ctrl = new FormControl('', [Validators.required]);
 }
 
+@Component({
+	selector: 'brn-test-label-for',
+	imports: [BrnField, BrnLabel, BrnInput, ReactiveFormsModule],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div brnField>
+			<label brnLabel>Test Label</label>
+			<input brnInput [formControl]="ctrl" />
+		</div>
+	`,
+})
+class TestLabelForComponent {
+	public ctrl = new FormControl('');
+}
+
+@Component({
+	selector: 'brn-test-label-for-without-control',
+	imports: [BrnField, BrnLabel, BrnInput],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div brnField>
+			<label brnLabel>Test Label</label>
+			<input brnInput />
+		</div>
+	`,
+})
+class TestLabelForWithoutControlComponent {}
+
+@Component({
+	selector: 'brn-test-cva-input',
+	imports: [BrnField, BrnLabel, BrnInput, FormsModule, ReactiveFormsModule],
+	providers: [
+		{
+			provide: NG_VALUE_ACCESSOR,
+			useExisting: forwardRef(() => TestCvaInputComponent),
+			multi: true,
+		},
+	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div brnField>
+			<label brnLabel>Test Label</label>
+			<input brnInput id="cva-input-id" />
+		</div>
+	`,
+})
+class TestCvaInputComponent implements ControlValueAccessor {
+	/* eslint-disable @typescript-eslint/no-empty-function */
+	writeValue(): void {}
+	/* eslint-disable @typescript-eslint/no-empty-function */
+	registerOnChange(): void {}
+	/* eslint-disable @typescript-eslint/no-empty-function */
+	registerOnTouched(): void {}
+	/* eslint-disable @typescript-eslint/no-empty-function */
+	setDisabledState?(): void {}
+
+	public readonly brnFieldControl = viewChild(BrnFieldControl);
+}
+
+@Component({
+	selector: 'brn-test-cva-host',
+	imports: [TestCvaInputComponent, ReactiveFormsModule],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<brn-test-cva-input [formControl]="ctrl" />
+	`,
+})
+class TestCvaHostComponent {
+	public ctrl = new FormControl('');
+	public readonly testCvaInputComponent = viewChild(TestCvaInputComponent);
+}
+
+@Component({
+	selector: 'brn-test-cva-host-without-control',
+	imports: [TestCvaInputComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<brn-test-cva-input />
+	`,
+})
+class TestCvaHostWithoutControlComponent {}
+
 describe('BrnFieldControl', () => {
 	describe('ngDoCheck - tracker lifecycle', () => {
 		it('should create a state tracker when the control becomes available', async () => {
 			const { fixture } = await render(TestHostComponent);
 			fixture.detectChanges();
 
-			const brnInput = fixture.componentInstance.brnInput();
-			expect(brnInput).toBeTruthy();
+			const controlState = fixture.componentInstance.brnFieldControl()?.controlState();
+			expect(controlState).toBeTruthy();
 		});
 
 		it('should expose dirty state from the underlying form control', async () => {
@@ -145,6 +238,61 @@ describe('BrnFieldControl', () => {
 			await fixture.whenStable();
 
 			expect(input.getAttribute('data-invalid')).toBeNull();
+		});
+
+		it('should create a state tracker for a field control whose host component is a Control Value Accessor', async () => {
+			const { fixture } = await render(TestCvaHostComponent);
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			const controlState = fixture.componentInstance.testCvaInputComponent()?.brnFieldControl()?.controlState();
+			expect(controlState).toBeTruthy();
+		});
+	});
+
+	describe('BrnLabelable - automatic "for" attribute set', () => {
+		it('should render the correct for attribute when the control is bound on the input', async () => {
+			const { fixture } = await render(TestLabelForComponent);
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			const input = fixture.debugElement.query(By.css('input'));
+			const label = fixture.debugElement.query(By.css('label'));
+			expect(input.attributes['id']).toBeTruthy();
+			expect(label.attributes['for']).toBe(input.attributes['id']);
+		});
+
+		it('should render the correct for attribute when control is not bound on the input', async () => {
+			const { fixture } = await render(TestLabelForWithoutControlComponent);
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			const input = fixture.debugElement.query(By.css('input'));
+			const label = fixture.debugElement.query(By.css('label'));
+			expect(input.attributes['id']).toBeTruthy();
+			expect(label.attributes['for']).toBe(input.attributes['id']);
+		});
+
+		it('should render the correct for attribute when wrapped in a ControlValueAccessor host', async () => {
+			const { fixture } = await render(TestCvaHostComponent);
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			const input = fixture.debugElement.query(By.css('input'));
+			const label = fixture.debugElement.query(By.css('label'));
+			expect(input.attributes['id']).toBe('cva-input-id');
+			expect(label.attributes['for']).toBe('cva-input-id');
+		});
+
+		it('should render the correct for attribute when wrapped in a ControlValueAccessor host without an assigned form control', async () => {
+			const { fixture } = await render(TestCvaHostWithoutControlComponent);
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			const input = fixture.debugElement.query(By.css('input'));
+			const label = fixture.debugElement.query(By.css('label'));
+			expect(input.attributes['id']).toBe('cva-input-id');
+			expect(label.attributes['for']).toBe('cva-input-id');
 		});
 	});
 });

--- a/libs/brain/field/src/lib/brn-field-control.spec.ts
+++ b/libs/brain/field/src/lib/brn-field-control.spec.ts
@@ -107,12 +107,10 @@ class TestLabelForWithoutControlComponent {}
 class TestCvaInputComponent implements ControlValueAccessor {
 	/* eslint-disable @typescript-eslint/no-empty-function */
 	writeValue(): void {}
-	/* eslint-disable @typescript-eslint/no-empty-function */
 	registerOnChange(): void {}
-	/* eslint-disable @typescript-eslint/no-empty-function */
 	registerOnTouched(): void {}
-	/* eslint-disable @typescript-eslint/no-empty-function */
 	setDisabledState?(): void {}
+	/* eslint-enable @typescript-eslint/no-empty-function */
 
 	public readonly brnFieldControl = viewChild(BrnFieldControl);
 }

--- a/libs/brain/field/src/lib/brn-field-control.ts
+++ b/libs/brain/field/src/lib/brn-field-control.ts
@@ -13,6 +13,8 @@ export class BrnFieldControl implements OnInit, DoCheck {
 	private readonly _field = inject(BrnField, { optional: true });
 	private readonly _destroyRef = inject(DestroyRef);
 
+	private _labelable: BrnLabelable | null = null;
+
 	private readonly _stateTracker = signal<StateTracker | null>(null);
 	/** Sentinel value to differentiate "never checked" from "control is null". */
 	private _lastControl: AbstractControl | null = null;
@@ -31,6 +33,10 @@ export class BrnFieldControl implements OnInit, DoCheck {
 
 	constructor() {
 		this._destroyRef.onDestroy(() => {
+			this._field?.unregisterFieldControl(this);
+			if (this._labelable) {
+				this._field?.unregisterLabelable(this._labelable);
+			}
 			this._stateTracker()?.destroy();
 		});
 	}
@@ -54,9 +60,9 @@ export class BrnFieldControl implements OnInit, DoCheck {
 			});
 		}
 
-		const labelable = this._injector.get(BrnLabelable, null);
-		if (labelable) {
-			this._field?.registerLabelable(labelable);
+		this._labelable = this._injector.get(BrnLabelable, null);
+		if (this._labelable) {
+			this._field?.registerLabelable(this._labelable);
 		}
 	}
 
@@ -69,7 +75,7 @@ export class BrnFieldControl implements OnInit, DoCheck {
 
 	/** @returns true if the control reference changed */
 	private _syncTracker(): void {
-		if (!this.ngControl || this._field?.brnFieldControl() !== this) return;
+		if (!this.ngControl || (this._field && this._field.brnFieldControl() !== this)) return;
 		const currentControl = this.ngControl.control ?? null;
 		if (currentControl === this._lastControl) return;
 		this._lastControl = currentControl;

--- a/libs/brain/field/src/lib/brn-field-control.ts
+++ b/libs/brain/field/src/lib/brn-field-control.ts
@@ -14,6 +14,7 @@ export class BrnFieldControl implements OnInit, DoCheck {
 	private readonly _destroyRef = inject(DestroyRef);
 
 	private _labelable: BrnLabelable | null = null;
+	private _parentFieldControl: BrnFieldControl | null = null;
 
 	private readonly _stateTracker = signal<StateTracker | null>(null);
 	/** Sentinel value to differentiate "never checked" from "control is null". */
@@ -41,6 +42,7 @@ export class BrnFieldControl implements OnInit, DoCheck {
 
 	ngOnInit(): void {
 		this.ngControl = this._injector.get(NgControl, null);
+		this._parentFieldControl = this._injector.get(BrnFieldControl, null, { skipSelf: true });
 
 		if (this.ngControl) {
 			this._field?.registerFieldControl(this);
@@ -90,7 +92,6 @@ export class BrnFieldControl implements OnInit, DoCheck {
 			return this._field.brnFieldControl() !== this;
 		}
 
-		const parent = this._injector.get(BrnFieldControl, null, { skipSelf: true });
-		return !!parent?.ngControl && parent.ngControl === this.ngControl;
+		return !!this._parentFieldControl?.ngControl && this._parentFieldControl.ngControl === this.ngControl;
 	}
 }

--- a/libs/brain/field/src/lib/brn-field-control.ts
+++ b/libs/brain/field/src/lib/brn-field-control.ts
@@ -38,11 +38,8 @@ export class BrnFieldControl implements OnInit, DoCheck {
 	}
 
 	ngOnInit(): void {
-		// `self` prevents descendants (e.g. calendar selects) from inheriting an ancestor's NgControl.
-		this.ngControl = this._injector.get(NgControl, null, { optional: true, self: true });
+		this.ngControl = this._injector.get(NgControl, null);
 
-		// Only register with BrnField when this control has its own NgControl, otherwise descendant
-		// field controls rendered in portals (e.g. calendar selects) overwrite the real control's registration.
 		if (this.ngControl) {
 			this._field?.registerFieldControl(this);
 		}
@@ -61,12 +58,7 @@ export class BrnFieldControl implements OnInit, DoCheck {
 
 		const labelable = this._injector.get(BrnLabelable, null);
 		if (labelable) {
-			this._idEffectRef = effect(
-				() => {
-					this.id.set(labelable.labelableId());
-				},
-				{ injector: this._injector },
-			);
+			this._field?.registerLabelable(labelable);
 		}
 	}
 
@@ -79,7 +71,7 @@ export class BrnFieldControl implements OnInit, DoCheck {
 
 	/** @returns true if the control reference changed */
 	private _syncTracker(): void {
-		if (!this.ngControl) return;
+		if (!this.ngControl || this._field?.brnFieldControl() !== this) return;
 		const currentControl = this.ngControl.control ?? null;
 		if (currentControl === this._lastControl) return;
 		this._lastControl = currentControl;

--- a/libs/brain/field/src/lib/brn-field-control.ts
+++ b/libs/brain/field/src/lib/brn-field-control.ts
@@ -1,4 +1,4 @@
-import { computed, DestroyRef, Directive, DoCheck, effect, inject, Injector, OnInit, signal } from '@angular/core';
+import { computed, DestroyRef, Directive, DoCheck, inject, Injector, OnInit, signal } from '@angular/core';
 import { type AbstractControl, FormGroupDirective, NgControl, NgForm } from '@angular/forms';
 import { createStateTracker, ErrorStateMatcher, type StateTracker } from '@spartan-ng/brain/forms';
 import { BrnField } from './brn-field';
@@ -13,7 +13,6 @@ export class BrnFieldControl implements OnInit, DoCheck {
 	private readonly _field = inject(BrnField, { optional: true });
 	private readonly _destroyRef = inject(DestroyRef);
 
-	private _idEffectRef?: ReturnType<typeof effect>;
 	private readonly _stateTracker = signal<StateTracker | null>(null);
 	/** Sentinel value to differentiate "never checked" from "control is null". */
 	private _lastControl: AbstractControl | null = null;
@@ -32,7 +31,6 @@ export class BrnFieldControl implements OnInit, DoCheck {
 
 	constructor() {
 		this._destroyRef.onDestroy(() => {
-			this._idEffectRef?.destroy();
 			this._stateTracker()?.destroy();
 		});
 	}

--- a/libs/brain/field/src/lib/brn-field-control.ts
+++ b/libs/brain/field/src/lib/brn-field-control.ts
@@ -22,8 +22,6 @@ export class BrnFieldControl implements OnInit, DoCheck {
 	/** Gets the AbstractControlDirective for this control. */
 	public ngControl: NgControl | null = null;
 
-	public readonly id = signal<string | null | undefined>(undefined);
-
 	public readonly controlState = computed(() => this._stateTracker()?.controlState() ?? null);
 	public readonly errors = computed(() => this._stateTracker()?.errors() ?? null);
 	public readonly dirty = computed(() => this._stateTracker()?.dirty() ?? null);
@@ -75,7 +73,7 @@ export class BrnFieldControl implements OnInit, DoCheck {
 
 	/** @returns true if the control reference changed */
 	private _syncTracker(): void {
-		if (!this.ngControl || (this._field && this._field.brnFieldControl() !== this)) return;
+		if (!this.ngControl || this._hasFieldControlParent()) return;
 		const currentControl = this.ngControl.control ?? null;
 		if (currentControl === this._lastControl) return;
 		this._lastControl = currentControl;
@@ -85,5 +83,13 @@ export class BrnFieldControl implements OnInit, DoCheck {
 				? createStateTracker(this.ngControl, this._errorStateMatcher, this._parentFormGroup, this._parentForm)
 				: null,
 		);
+	}
+
+	private _hasFieldControlParent() {
+		if (this._field) {
+			return this._field.brnFieldControl() !== this;
+		}
+
+		return !!this._injector.get(BrnFieldControl, null, { skipSelf: true });
 	}
 }

--- a/libs/brain/field/src/lib/brn-field-control.ts
+++ b/libs/brain/field/src/lib/brn-field-control.ts
@@ -90,6 +90,7 @@ export class BrnFieldControl implements OnInit, DoCheck {
 			return this._field.brnFieldControl() !== this;
 		}
 
-		return !!this._injector.get(BrnFieldControl, null, { skipSelf: true });
+		const parent = this._injector.get(BrnFieldControl, null, { skipSelf: true });
+		return !!parent?.ngControl && parent.ngControl === this.ngControl;
 	}
 }

--- a/libs/brain/field/src/lib/brn-field.ts
+++ b/libs/brain/field/src/lib/brn-field.ts
@@ -53,16 +53,19 @@ export class BrnField {
 		return this._brnFieldControl()?.controlState()?.touched ?? null;
 	});
 
-	public readonly labelableId = computed(() => this._brnFieldControl()?.id?.() ?? this._labelable()?.labelableId());
+	public readonly labelableId = computed(() => this._labelable()?.labelableId());
 
+	public readonly brnFieldControl = this._brnFieldControl.asReadonly();
 	public readonly errors = computed(() => this._brnFieldControl()?.errors() ?? null);
 	public readonly controlState = computed(() => this._brnFieldControl()?.controlState() ?? null);
 
 	public registerFieldControl(fieldControl: BrnFieldControl) {
+		if (this._brnFieldControl()) return;
 		this._brnFieldControl.set(fieldControl);
 	}
 
 	public registerLabelable(labelable: BrnLabelable) {
+		if (this._labelable()) return;
 		this._labelable.set(labelable);
 	}
 }

--- a/libs/brain/field/src/lib/brn-field.ts
+++ b/libs/brain/field/src/lib/brn-field.ts
@@ -68,4 +68,14 @@ export class BrnField {
 		if (this._labelable()) return;
 		this._labelable.set(labelable);
 	}
+
+	public unregisterFieldControl(fieldControl: BrnFieldControl) {
+		if (this._brnFieldControl() !== fieldControl) return;
+		this._brnFieldControl.set(null);
+	}
+
+	public unregisterLabelable(labelable: BrnLabelable) {
+		if (this._labelable() !== labelable) return;
+		this._labelable.set(null);
+	}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [x] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

Now, if a `brnField` with a label and input is wrapped inside a component that implements `ControlValueAccessor`, the `brnField` and `brnInput` can't access the host's `NgControl` and display the control state. Also, a label's `for` attribute is not automatically set to input's `id` if the input is not assigned a `FormControl`.

```
@Component({
    selector: 'test-text-input',
    imports: [BrnInput, ReactiveFormsModule, BrnLabel, BrnField, FormsModule],
    providers: [
        {
            provide: NG_VALUE_ACCESSOR,
            useExisting: forwardRef(() => TestLabelForComponent),
            multi: true,
        },
    ],
    changeDetection: ChangeDetectionStrategy.OnPush,
    template: `
        <div brnField>
            <label brnLabel>Test Label</label>
            <input brnInput />
        </div>
    `,
})
class TestLabelForComponent implements ControlValueAccessor {
    writeValue(obj: any): void {}
    registerOnChange(fn: any): void {}
    registerOnTouched(fn: any): void {}
    setDisabledState?(isDisabled: boolean): void {}
    public value = model('');
}

@Component({
    selector: 'brn-test-for-label',
    imports: [ReactiveFormsModule, TestLabelForComponent],
    changeDetection: ChangeDetectionStrategy.OnPush,
    template: `
        <test-text-input [formControl]="_control" />
    `,
})
class TestLabelForAComponent {
    protected readonly _control = new FormControl();
}
```




<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

`brnField` and `brnInput` can inject the host's `NgControl`. Also, the label's `for` is automatically set if the input is not assigned a `FormControl`.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label and `id` synchronization by consistently deriving the label “for” and related `id` from the active labelable.
  * Made field-control/label registration and unregistration safer (prevents overwrites and ignores mismatches) for more reliable error/state ownership.
  * Simplified field preview to remove unnecessary form validation behavior while keeping the same output.
* **New Features**
  * Added an accessor to retrieve the currently registered field control.
* **Tests**
  * Expanded coverage for label “for”/`id` behavior, including Control Value Accessor scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->