### PR TITLE
fix(tooltip): tooltip text not updated

### DIFF
--- a/libs/brain/tooltip/src/lib/brn-tooltip.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip.ts
@@ -118,6 +118,17 @@ export class BrnTooltip {
 				this._setupDelayMechanism();
 				this._cleanupTriggerEvents();
 				this._initTriggers();
+
+				/**
+				 * This effect is used to update the tooltip content when the tooltip text changes.
+				 * It's the reactive bridge between the tooltip text and the tooltip content.
+				 */
+				effect(() => {
+					const text = this._tooltipText();
+					if (this._componentRef) {
+						this._applyContentProps(this._componentRef.instance, this._activePosition ?? this.position(), text);
+					}
+				});
 				this._listenersRefs = [
 					...this._listenersRefs,
 					this._renderer.listen(this._overlayRef.hostElement, 'mouseenter', () => (this._tooltipHovered = true)),

--- a/libs/helm/tooltip/src/lib/hlm-tooltip-animation.spec.ts
+++ b/libs/helm/tooltip/src/lib/hlm-tooltip-animation.spec.ts
@@ -129,3 +129,23 @@ describe('HlmTooltip teardown without an exit animation', () => {
 		await waitFor(() => expect(tooltipEl()).toBeNull());
 	});
 });
+
+describe('HlmTooltip dynamic text while open', () => {
+	afterEach(() => {
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	it('updates the tooltip text when the bound string signal changes while the tooltip is open', async () => {
+		const { fixture } = await render(TooltipDynamicHost);
+
+		fireEvent.mouseEnter(triggerEl());
+		await waitFor(() => expect(tooltipEl()?.textContent).toContain('first'));
+
+		// Change the tooltip text while the tooltip is open. No mouseleave!
+		fixture.componentInstance.tip.set('second');
+		fixture.detectChanges();
+
+		await waitFor(() => expect(tooltipEl()?.textContent).toContain('second'));
+		expect(tooltipEl()?.textContent).not.toContain('first');
+	});
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [X] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

While tooltip is open, if tooltip is a text content, when the content change and the tooltip remains open, tooltip content displayed doesn't change

Closes #1566

## What is the new behavior?

Tooltip text change is correctly displayed when tooltip still be open

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltip text now updates immediately while the tooltip is open, so changes to the displayed message are reflected without closing and reopening it.
* **Tests**
  * Added coverage for live tooltip text updates during an open tooltip session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->