### PR TITLE
feat(chart): add helm charts entry point

### DIFF
--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--advanced.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--advanced.example.ts
@@ -1,14 +1,15 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, SpnXAxis } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-tooltip-advanced',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
+	imports: [HlmChartImports, SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
 	template: `
-		<div class="w-full">
-			<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin" defaultIndex="1">
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin" defaultIndex="1">
 				<spn-x-axis
 					dataKey="date"
 					axisLine="false"
@@ -16,44 +17,56 @@ import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, 
 					tickSize="0"
 					tickPadding="10"
 					[tickFormatter]="formatDay"
-					stroke="var(--muted-foreground)"
 				/>
 				<spn-bar dataKey="running" name="Running" fill="var(--chart-1)" [radius]="runningRadius" stackId="a" />
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<div
-							class="bg-background border-border/50 grid w-[180px] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
-						>
-							@for (item of state.payload; track item.dataKey; let i = $index) {
-								<div class="flex w-full items-center gap-2">
-									<span class="size-2.5 shrink-0 rounded-[2px]" [style.background]="item.color"></span>
-									<span class="text-muted-foreground">{{ item.name }}</span>
-									<span class="text-foreground ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums">
-										{{ item.value }}
-										<span class="text-muted-foreground font-normal">kcal</span>
-									</span>
-								</div>
-								@if (i === state.payload.length - 1) {
-									<div class="text-foreground mt-1.5 flex basis-full items-center border-t pt-1.5 font-medium">
-										Total
-										<span
-											class="text-foreground ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums"
-										>
-											{{ totalFor(item.payload) }}
-											<span class="text-muted-foreground font-normal">kcal</span>
-										</span>
-									</div>
-								}
-							}
-						</div>
+						<hlm-chart-tooltip-content
+							[config]="chartConfig"
+							[state]="state"
+							[itemTemplate]="customTooltipItem"
+							class="w-45"
+							hideLabel
+						/>
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>
-		</div>
+		</hlm-chart-container>
+
+		<ng-template #customTooltipItem let-item let-last="last">
+			<div class="flex w-full items-center gap-2">
+				<span class="size-2.5 shrink-0 rounded-xs" [style.background]="item.color"></span>
+				<span class="text-muted-foreground">{{ item.name }}</span>
+				<span class="text-foreground ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums">
+					{{ item.value }}
+					<span class="text-muted-foreground font-normal">kcal</span>
+				</span>
+			</div>
+			@if (last) {
+				<div class="text-foreground mt-1.5 flex basis-full items-center border-t pt-1.5 font-medium">
+					Total
+					<span class="text-foreground ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums">
+						{{ totalFor(item.payload) }}
+						<span class="text-muted-foreground font-normal">kcal</span>
+					</span>
+				</div>
+			}
+		</ng-template>
 	`,
 })
 export class TooltipAdvanced {
+	public readonly chartConfig: ChartConfig = {
+		running: {
+			label: 'Running',
+			color: 'var(--chart-1)',
+		},
+		swimming: {
+			label: 'Swimming',
+			color: 'var(--chart-2)',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
 	protected readonly runningRadius: BarRadius = [0, 0, 4, 4];
 	protected readonly swimmingRadius: BarRadius = [4, 4, 0, 0];

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--default.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--default.example.ts
@@ -1,14 +1,15 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, SpnXAxis } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-tooltip-default',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
+	imports: [HlmChartImports, SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
 	template: `
-		<div class="w-full">
-			<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin" defaultIndex="1">
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin" defaultIndex="1">
 				<spn-x-axis
 					dataKey="date"
 					axisLine="false"
@@ -16,33 +17,30 @@ import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, 
 					tickSize="0"
 					tickPadding="10"
 					[tickFormatter]="formatDay"
-					stroke="var(--muted-foreground)"
 				/>
 				<spn-bar dataKey="running" name="Running" fill="var(--chart-1)" [radius]="runningRadius" stackId="a" />
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<div
-							class="bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
-						>
-							@if (state.label !== undefined && state.label !== null && state.label !== '') {
-								<div class="font-medium">{{ state.label }}</div>
-							}
-							@for (item of state.payload; track item.dataKey) {
-								<div class="flex w-full items-center gap-2">
-									<span class="size-2.5 shrink-0 rounded-[2px]" [style.background]="item.color"></span>
-									<span class="text-muted-foreground">{{ item.name }}</span>
-									<span class="text-foreground ml-auto font-mono font-medium tabular-nums">{{ item.value }}</span>
-								</div>
-							}
-						</div>
+						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>
-		</div>
+		</hlm-chart-container>
 	`,
 })
 export class TooltipDefault {
+	public readonly chartConfig: ChartConfig = {
+		running: {
+			label: 'Running',
+			color: 'var(--chart-1)',
+		},
+		swimming: {
+			label: 'Swimming',
+			color: 'var(--chart-2)',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
 	protected readonly runningRadius: BarRadius = [0, 0, 4, 4];
 	protected readonly swimmingRadius: BarRadius = [4, 4, 0, 0];

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--default.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--default.example.ts
@@ -22,7 +22,7 @@ import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" />
+						<hlm-chart-tooltip-content [state]="state" />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--formatter.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--formatter.example.ts
@@ -1,14 +1,15 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, SpnXAxis } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-tooltip-formatter',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
+	imports: [HlmChartImports, SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
 	template: `
-		<div class="w-full">
-			<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin" defaultIndex="1">
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin" defaultIndex="1">
 				<spn-x-axis
 					dataKey="date"
 					axisLine="false"
@@ -22,26 +23,40 @@ import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, 
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<div
-							class="bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
-						>
-							@for (item of state.payload; track item.dataKey) {
-								<div class="text-muted-foreground flex min-w-[130px] items-center text-xs">
-									{{ item.name }}
-									<div class="text-foreground ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums">
-										{{ item.value }}
-										<span class="text-muted-foreground font-normal">kcal</span>
-									</div>
-								</div>
-							}
-						</div>
+						<hlm-chart-tooltip-content
+							[config]="chartConfig"
+							[state]="state"
+							[itemTemplate]="customTooltipItem"
+							hideLabel
+						/>
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>
-		</div>
+		</hlm-chart-container>
+
+		<ng-template #customTooltipItem let-item>
+			<div class="text-muted-foreground flex min-w-32 items-center text-xs">
+				{{ item.name }}
+				<div class="text-foreground ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums">
+					{{ item.value }}
+					<span class="text-muted-foreground font-normal">kcal</span>
+				</div>
+			</div>
+		</ng-template>
 	`,
 })
 export class TooltipFormatter {
+	public readonly chartConfig: ChartConfig = {
+		running: {
+			label: 'Running',
+			color: 'var(--chart-1)',
+		},
+		swimming: {
+			label: 'Swimming',
+			color: 'var(--chart-2)',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
 	protected readonly runningRadius: BarRadius = [0, 0, 4, 4];
 	protected readonly swimmingRadius: BarRadius = [4, 4, 0, 0];

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--icons.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--icons.example.ts
@@ -25,7 +25,7 @@ import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<hlm-chart-tooltip-content [state]="state" [config]="chartConfig" hideLabel />
+						<hlm-chart-tooltip-content [state]="state" hideLabel />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--icons.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--icons.example.ts
@@ -1,17 +1,18 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { NgIcon, provideIcons } from '@ng-icons/core';
+import { provideIcons } from '@ng-icons/core';
 import { lucideFootprints, lucideWaves } from '@ng-icons/lucide';
 import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, SpnXAxis } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-tooltip-icons',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef, NgIcon],
+	imports: [HlmChartImports, SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
 	providers: [provideIcons({ lucideFootprints, lucideWaves })],
 	template: `
-		<div class="w-full">
-			<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin" defaultIndex="1">
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin" defaultIndex="1">
 				<spn-x-axis
 					dataKey="date"
 					axisLine="false"
@@ -19,30 +20,32 @@ import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, 
 					tickSize="0"
 					tickPadding="10"
 					[tickFormatter]="formatDay"
-					stroke="var(--muted-foreground)"
 				/>
 				<spn-bar dataKey="running" name="Running" fill="var(--chart-1)" [radius]="runningRadius" stackId="a" />
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<div
-							class="bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
-						>
-							@for (item of state.payload; track item.dataKey) {
-								<div class="flex w-full items-center gap-2">
-									<ng-icon [name]="iconFor(item.dataKey)" class="text-muted-foreground" size="1rem" />
-									<span class="text-muted-foreground">{{ item.name }}</span>
-									<span class="text-foreground ml-auto font-mono font-medium tabular-nums">{{ item.value }}</span>
-								</div>
-							}
-						</div>
+						<hlm-chart-tooltip-content [state]="state" [config]="chartConfig" hideLabel />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>
-		</div>
+		</hlm-chart-container>
 	`,
 })
 export class TooltipIcons {
+	public readonly chartConfig: ChartConfig = {
+		running: {
+			label: 'Running',
+			color: 'var(--chart-1)',
+			icon: 'lucideFootprints',
+		},
+		swimming: {
+			label: 'Swimming',
+			color: 'var(--chart-2)',
+			icon: 'lucideWaves',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
 	protected readonly runningRadius: BarRadius = [0, 0, 4, 4];
 	protected readonly swimmingRadius: BarRadius = [4, 4, 0, 0];

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--indicator-line.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--indicator-line.example.ts
@@ -22,7 +22,7 @@ import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" indicator="line" />
+						<hlm-chart-tooltip-content [state]="state" indicator="line" />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--indicator-line.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--indicator-line.example.ts
@@ -1,14 +1,15 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, SpnXAxis } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-tooltip-indicator-line',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
+	imports: [HlmChartImports, SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
 	template: `
-		<div class="w-full">
-			<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin" defaultIndex="1">
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin" defaultIndex="1">
 				<spn-x-axis
 					dataKey="date"
 					axisLine="false"
@@ -16,33 +17,30 @@ import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, 
 					tickSize="0"
 					tickPadding="10"
 					[tickFormatter]="formatDay"
-					stroke="var(--muted-foreground)"
 				/>
 				<spn-bar dataKey="running" name="Running" fill="var(--chart-1)" [radius]="runningRadius" stackId="a" />
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<div
-							class="bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
-						>
-							@if (state.label !== undefined && state.label !== null && state.label !== '') {
-								<div class="font-medium">{{ state.label }}</div>
-							}
-							@for (item of state.payload; track item.dataKey) {
-								<div class="flex w-full items-center gap-2">
-									<span class="w-1 shrink-0 self-stretch rounded-[2px]" [style.background]="item.color"></span>
-									<span class="text-muted-foreground">{{ item.name }}</span>
-									<span class="text-foreground ml-auto font-mono font-medium tabular-nums">{{ item.value }}</span>
-								</div>
-							}
-						</div>
+						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" indicator="line" />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>
-		</div>
+		</hlm-chart-container>
 	`,
 })
 export class TooltipIndicatorLine {
+	public readonly chartConfig: ChartConfig = {
+		running: {
+			label: 'Running',
+			color: 'var(--chart-1)',
+		},
+		swimming: {
+			label: 'Swimming',
+			color: 'var(--chart-2)',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
 	protected readonly runningRadius: BarRadius = [0, 0, 4, 4];
 	protected readonly swimmingRadius: BarRadius = [4, 4, 0, 0];

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--indicator-none.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--indicator-none.example.ts
@@ -22,7 +22,7 @@ import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" hideIndicator />
+						<hlm-chart-tooltip-content [state]="state" hideIndicator />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--indicator-none.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--indicator-none.example.ts
@@ -1,14 +1,15 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, SpnXAxis } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-tooltip-indicator-none',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
+	imports: [HlmChartImports, SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
 	template: `
-		<div class="w-full">
-			<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin" defaultIndex="1">
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin" defaultIndex="1">
 				<spn-x-axis
 					dataKey="date"
 					axisLine="false"
@@ -16,32 +17,30 @@ import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, 
 					tickSize="0"
 					tickPadding="10"
 					[tickFormatter]="formatDay"
-					stroke="var(--muted-foreground)"
 				/>
 				<spn-bar dataKey="running" name="Running" fill="var(--chart-1)" [radius]="runningRadius" stackId="a" />
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<div
-							class="bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
-						>
-							@if (state.label !== undefined && state.label !== null && state.label !== '') {
-								<div class="font-medium">{{ state.label }}</div>
-							}
-							@for (item of state.payload; track item.dataKey) {
-								<div class="flex w-full items-center gap-2">
-									<span class="text-muted-foreground">{{ item.name }}</span>
-									<span class="text-foreground ml-auto font-mono font-medium tabular-nums">{{ item.value }}</span>
-								</div>
-							}
-						</div>
+						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" hideIndicator />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>
-		</div>
+		</hlm-chart-container>
 	`,
 })
 export class TooltipIndicatorNone {
+	public readonly chartConfig: ChartConfig = {
+		running: {
+			label: 'Running',
+			color: 'var(--chart-1)',
+		},
+		swimming: {
+			label: 'Swimming',
+			color: 'var(--chart-2)',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
 	protected readonly runningRadius: BarRadius = [0, 0, 4, 4];
 	protected readonly swimmingRadius: BarRadius = [4, 4, 0, 0];

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--label-custom.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--label-custom.example.ts
@@ -1,14 +1,15 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, SpnXAxis } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-tooltip-label-custom',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
+	imports: [HlmChartImports, SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
 	template: `
-		<div class="w-full">
-			<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin" defaultIndex="1">
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin" defaultIndex="1">
 				<spn-x-axis
 					dataKey="date"
 					axisLine="false"
@@ -16,31 +17,33 @@ import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, 
 					tickSize="0"
 					tickPadding="10"
 					[tickFormatter]="formatDay"
-					stroke="var(--muted-foreground)"
 				/>
 				<spn-bar dataKey="running" name="Running" fill="var(--chart-1)" [radius]="runningRadius" stackId="a" />
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<div
-							class="bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
-						>
-							<div class="font-medium">Activities</div>
-							@for (item of state.payload; track item.dataKey) {
-								<div class="flex w-full items-center gap-2">
-									<span class="w-1 shrink-0 self-stretch rounded-[2px]" [style.background]="item.color"></span>
-									<span class="text-muted-foreground">{{ item.name }}</span>
-									<span class="text-foreground ml-auto font-mono font-medium tabular-nums">{{ item.value }}</span>
-								</div>
-							}
-						</div>
+						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" labelKey="activities" indicator="line" />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>
-		</div>
+		</hlm-chart-container>
 	`,
 })
 export class TooltipLabelCustom {
+	public readonly chartConfig: ChartConfig = {
+		activities: {
+			label: 'Activities',
+		},
+		running: {
+			label: 'Running',
+			color: 'var(--chart-1)',
+		},
+		swimming: {
+			label: 'Swimming',
+			color: 'var(--chart-2)',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
 	protected readonly runningRadius: BarRadius = [0, 0, 4, 4];
 	protected readonly swimmingRadius: BarRadius = [4, 4, 0, 0];

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--label-custom.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--label-custom.example.ts
@@ -22,7 +22,7 @@ import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" labelKey="activities" indicator="line" />
+						<hlm-chart-tooltip-content [state]="state" labelKey="activities" indicator="line" />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--label-formatter.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--label-formatter.example.ts
@@ -22,7 +22,7 @@ import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" [labelFormatter]="formatLabel" />
+						<hlm-chart-tooltip-content [state]="state" [labelFormatter]="formatLabel" />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--label-formatter.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--label-formatter.example.ts
@@ -1,14 +1,15 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, SpnXAxis } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-tooltip-label-formatter',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
+	imports: [HlmChartImports, SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
 	template: `
-		<div class="w-full">
-			<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin" defaultIndex="1">
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin" defaultIndex="1">
 				<spn-x-axis
 					dataKey="date"
 					axisLine="false"
@@ -16,33 +17,30 @@ import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, 
 					tickSize="0"
 					tickPadding="10"
 					[tickFormatter]="formatDay"
-					stroke="var(--muted-foreground)"
 				/>
 				<spn-bar dataKey="running" name="Running" fill="var(--chart-1)" [radius]="runningRadius" stackId="a" />
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<div
-							class="bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
-						>
-							@if (state.label !== undefined && state.label !== null && state.label !== '') {
-								<div class="font-medium">{{ formatLabel(state.label) }}</div>
-							}
-							@for (item of state.payload; track item.dataKey) {
-								<div class="flex w-full items-center gap-2">
-									<span class="size-2.5 shrink-0 rounded-[2px]" [style.background]="item.color"></span>
-									<span class="text-muted-foreground">{{ item.name }}</span>
-									<span class="text-foreground ml-auto font-mono font-medium tabular-nums">{{ item.value }}</span>
-								</div>
-							}
-						</div>
+						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" [labelFormatter]="formatLabel" />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>
-		</div>
+		</hlm-chart-container>
 	`,
 })
 export class TooltipLabelFormatter {
+	public readonly chartConfig: ChartConfig = {
+		running: {
+			label: 'Running',
+			color: 'var(--chart-1)',
+		},
+		swimming: {
+			label: 'Swimming',
+			color: 'var(--chart-2)',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
 	protected readonly runningRadius: BarRadius = [0, 0, 4, 4];
 	protected readonly swimmingRadius: BarRadius = [4, 4, 0, 0];

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--label-none.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--label-none.example.ts
@@ -1,14 +1,15 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, SpnXAxis } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-tooltip-label-none',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
+	imports: [HlmChartImports, SpnBarChart, SpnXAxis, SpnBar, SpnTooltip, SpnTooltipContentDef],
 	template: `
-		<div class="w-full">
-			<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin" defaultIndex="1">
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin" defaultIndex="1">
 				<spn-x-axis
 					dataKey="date"
 					axisLine="false"
@@ -16,29 +17,30 @@ import { type BarRadius, SpnBar, SpnBarChart, SpnTooltip, SpnTooltipContentDef, 
 					tickSize="0"
 					tickPadding="10"
 					[tickFormatter]="formatDay"
-					stroke="var(--muted-foreground)"
 				/>
 				<spn-bar dataKey="running" name="Running" fill="var(--chart-1)" [radius]="runningRadius" stackId="a" />
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<div
-							class="bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
-						>
-							@for (item of state.payload; track item.dataKey) {
-								<div class="flex w-full items-center gap-2">
-									<span class="text-muted-foreground">{{ item.name }}</span>
-									<span class="text-foreground ml-auto font-mono font-medium tabular-nums">{{ item.value }}</span>
-								</div>
-							}
-						</div>
+						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" hideLabel hideIndicator />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>
-		</div>
+		</hlm-chart-container>
 	`,
 })
 export class TooltipLabelNone {
+	public readonly chartConfig: ChartConfig = {
+		running: {
+			label: 'Running',
+			color: 'var(--chart-1)',
+		},
+		swimming: {
+			label: 'Swimming',
+			color: 'var(--chart-2)',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
 	protected readonly runningRadius: BarRadius = [0, 0, 4, 4];
 	protected readonly swimmingRadius: BarRadius = [4, 4, 0, 0];

--- a/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--label-none.example.ts
+++ b/apps/app/src/app/pages/(charts)/charts/(chart-tooltip)/chart-tooltip--label-none.example.ts
@@ -22,7 +22,7 @@ import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 				<spn-bar dataKey="swimming" name="Swimming" fill="var(--chart-2)" [radius]="swimmingRadius" stackId="a" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" hideLabel hideIndicator />
+						<hlm-chart-tooltip-content [state]="state" hideLabel hideIndicator />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>

--- a/apps/app/src/app/pages/(components)/components/(charts)/charts--axis.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(charts)/charts--axis.example.ts
@@ -1,0 +1,50 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { SpnBar, SpnBarChart, SpnCartesianGrid, SpnXAxis } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
+
+@Component({
+	selector: 'spartan-charts-axis',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: { class: 'block w-full' },
+	imports: [HlmChartImports, SpnBarChart, SpnBar, SpnCartesianGrid, SpnXAxis],
+	template: `
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin">
+				<spn-cartesian-grid vertical="false" />
+				<spn-x-axis
+					dataKey="month"
+					axisLine="false"
+					tickLine="false"
+					tickSize="0"
+					tickPadding="10"
+					[tickFormatter]="formatMonth"
+				/>
+				<spn-bar dataKey="desktop" name="Desktop" fill="var(--color-desktop)" radius="4" />
+				<spn-bar dataKey="mobile" name="Mobile" fill="var(--color-mobile)" radius="4" />
+			</spn-bar-chart>
+		</hlm-chart-container>
+	`,
+})
+export class ChartsAxis {
+	public readonly chartConfig: ChartConfig = {
+		desktop: {
+			label: 'Desktop',
+			color: '#2563eb',
+		},
+		mobile: {
+			label: 'Mobile',
+			color: '#60a5fa',
+		},
+	};
+
+	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
+	protected readonly formatMonth = (value: unknown): string => String(value).slice(0, 3);
+	protected readonly data = [
+		{ month: 'January', desktop: 186, mobile: 80 },
+		{ month: 'February', desktop: 305, mobile: 200 },
+		{ month: 'March', desktop: 237, mobile: 120 },
+		{ month: 'April', desktop: 73, mobile: 190 },
+		{ month: 'May', desktop: 209, mobile: 130 },
+		{ month: 'June', desktop: 214, mobile: 140 },
+	];
+}

--- a/apps/app/src/app/pages/(components)/components/(charts)/charts--basic.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(charts)/charts--basic.example.ts
@@ -1,24 +1,15 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { SpnBar, SpnBarChart, SpnXAxis } from '@spartan-ng/charts';
+import { SpnBar, SpnBarChart } from '@spartan-ng/charts';
 import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-charts-basic',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [HlmChartImports, SpnBarChart, SpnBar, SpnXAxis],
+	imports: [HlmChartImports, SpnBarChart, SpnBar],
 	template: `
 		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
 			<spn-bar-chart [data]="data" [margin]="margin">
-				<spn-x-axis
-					dataKey="month"
-					axisLine="false"
-					tickLine="false"
-					tickSize="0"
-					tickPadding="10"
-					[tickFormatter]="formatMonth"
-					stroke="var(--muted-foreground)"
-				/>
 				<spn-bar dataKey="desktop" name="Desktop" fill="var(--color-desktop)" radius="4" />
 				<spn-bar dataKey="mobile" name="Mobile" fill="var(--color-mobile)" radius="4" />
 			</spn-bar-chart>
@@ -38,7 +29,6 @@ export class ChartsBasic {
 	};
 
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
-	protected readonly formatMonth = (value: unknown): string => String(value).slice(0, 3);
 	protected readonly data = [
 		{ month: 'January', desktop: 186, mobile: 80 },
 		{ month: 'February', desktop: 305, mobile: 200 },

--- a/apps/app/src/app/pages/(components)/components/(charts)/charts--basic.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(charts)/charts--basic.example.ts
@@ -1,28 +1,42 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { SpnBar, SpnBarChart, SpnXAxis } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-charts-basic',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnBar, SpnXAxis],
+	imports: [HlmChartImports, SpnBarChart, SpnBar, SpnXAxis],
 	template: `
-		<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin">
-			<spn-x-axis
-				dataKey="month"
-				axisLine="false"
-				tickLine="false"
-				tickSize="0"
-				tickPadding="10"
-				[tickFormatter]="formatMonth"
-				stroke="var(--muted-foreground)"
-			/>
-			<spn-bar dataKey="desktop" name="Desktop" fill="var(--chart-1)" radius="4" />
-			<spn-bar dataKey="mobile" name="Mobile" fill="var(--chart-2)" radius="4" />
-		</spn-bar-chart>
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin">
+				<spn-x-axis
+					dataKey="month"
+					axisLine="false"
+					tickLine="false"
+					tickSize="0"
+					tickPadding="10"
+					[tickFormatter]="formatMonth"
+					stroke="var(--muted-foreground)"
+				/>
+				<spn-bar dataKey="desktop" name="Desktop" fill="var(--color-desktop)" radius="4" />
+				<spn-bar dataKey="mobile" name="Mobile" fill="var(--color-mobile)" radius="4" />
+			</spn-bar-chart>
+		</hlm-chart-container>
 	`,
 })
 export class ChartsBasic {
+	public readonly chartConfig: ChartConfig = {
+		desktop: {
+			label: 'Desktop',
+			color: '#2563eb',
+		},
+		mobile: {
+			label: 'Mobile',
+			color: '#60a5fa',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
 	protected readonly formatMonth = (value: unknown): string => String(value).slice(0, 3);
 	protected readonly data = [

--- a/apps/app/src/app/pages/(components)/components/(charts)/charts--grid.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(charts)/charts--grid.example.ts
@@ -1,31 +1,35 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { SpnBar, SpnBarChart, SpnCartesianGrid, SpnXAxis } from '@spartan-ng/charts';
+import { SpnBar, SpnBarChart, SpnCartesianGrid } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-charts-grid',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnBar, SpnCartesianGrid, SpnXAxis],
+	imports: [HlmChartImports, SpnBarChart, SpnBar, SpnCartesianGrid],
 	template: `
-		<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin">
-			<spn-cartesian-grid vertical="false" stroke="color-mix(in oklch, var(--border) 50%, transparent)" />
-			<spn-x-axis
-				dataKey="month"
-				axisLine="false"
-				tickLine="false"
-				tickSize="0"
-				tickPadding="10"
-				[tickFormatter]="formatMonth"
-				stroke="var(--muted-foreground)"
-			/>
-			<spn-bar dataKey="desktop" name="Desktop" fill="var(--chart-1)" radius="4" />
-			<spn-bar dataKey="mobile" name="Mobile" fill="var(--chart-2)" radius="4" />
-		</spn-bar-chart>
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin">
+				<spn-cartesian-grid vertical="false" />
+				<spn-bar dataKey="desktop" name="Desktop" fill="var(--color-desktop)" radius="4" />
+				<spn-bar dataKey="mobile" name="Mobile" fill="var(--color-mobile)" radius="4" />
+			</spn-bar-chart>
+		</hlm-chart-container>
 	`,
 })
 export class ChartsGrid {
+	public readonly chartConfig: ChartConfig = {
+		desktop: {
+			label: 'Desktop',
+			color: '#2563eb',
+		},
+		mobile: {
+			label: 'Mobile',
+			color: '#60a5fa',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
-	protected readonly formatMonth = (value: unknown): string => String(value).slice(0, 3);
 	protected readonly data = [
 		{ month: 'January', desktop: 186, mobile: 80 },
 		{ month: 'February', desktop: 305, mobile: 200 },

--- a/apps/app/src/app/pages/(components)/components/(charts)/charts--legend.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(charts)/charts--legend.example.ts
@@ -1,57 +1,71 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { SpnBar, SpnBarChart, SpnCartesianGrid, SpnTooltip, SpnTooltipContentDef, SpnXAxis } from '@spartan-ng/charts';
+import {
+	SpnBar,
+	SpnBarChart,
+	SpnCartesianGrid,
+	SpnLegend,
+	SpnLegendContentDef,
+	SpnTooltip,
+	SpnTooltipContentDef,
+	SpnXAxis,
+} from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-charts-legend',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnBar, SpnCartesianGrid, SpnXAxis, SpnTooltip, SpnTooltipContentDef],
+	imports: [
+		HlmChartImports,
+		SpnBarChart,
+		SpnBar,
+		SpnCartesianGrid,
+		SpnXAxis,
+		SpnTooltip,
+		SpnTooltipContentDef,
+		SpnLegend,
+		SpnLegendContentDef,
+	],
 	template: `
-		<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin">
-			<spn-cartesian-grid vertical="false" stroke="color-mix(in oklch, var(--border) 50%, transparent)" />
-			<spn-x-axis
-				dataKey="month"
-				axisLine="false"
-				tickLine="false"
-				tickSize="0"
-				tickPadding="10"
-				[tickFormatter]="formatMonth"
-				stroke="var(--muted-foreground)"
-			/>
-			<spn-bar dataKey="desktop" name="Desktop" fill="var(--chart-1)" radius="4" />
-			<spn-bar dataKey="mobile" name="Mobile" fill="var(--chart-2)" radius="4" />
-			<spn-tooltip>
-				<ng-template spnTooltipContent let-state>
-					<div
-						class="bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
-					>
-						@if (state.label !== undefined && state.label !== null && state.label !== '') {
-							<div class="font-medium">{{ state.label }}</div>
-						}
-						@for (item of state.payload; track item.dataKey) {
-							<div class="flex w-full items-center gap-2">
-								<span class="size-2.5 shrink-0 rounded-[2px]" [style.background]="item.color"></span>
-								<span class="text-muted-foreground">{{ item.name }}</span>
-								<span class="text-foreground ml-auto font-mono font-medium tabular-nums">{{ item.value }}</span>
-							</div>
-						}
-					</div>
-				</ng-template>
-			</spn-tooltip>
-		</spn-bar-chart>
-		<div class="flex items-center justify-center gap-4 pt-3">
-			<div class="flex items-center gap-1.5">
-				<span class="size-2 shrink-0 rounded-[2px] bg-[var(--chart-1)]"></span>
-				<span class="text-foreground text-xs leading-none">Desktop</span>
-			</div>
-			<div class="flex items-center gap-1.5">
-				<span class="size-2 shrink-0 rounded-[2px] bg-[var(--chart-2)]"></span>
-				<span class="text-foreground text-xs leading-none">Mobile</span>
-			</div>
-		</div>
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin">
+				<spn-cartesian-grid vertical="false" />
+				<spn-x-axis
+					dataKey="month"
+					axisLine="false"
+					tickLine="false"
+					tickSize="0"
+					tickPadding="10"
+					[tickFormatter]="formatMonth"
+				/>
+				<spn-bar dataKey="desktop" name="Desktop" fill="var(--color-desktop)" radius="4" />
+				<spn-bar dataKey="mobile" name="Mobile" fill="var(--color-mobile)" radius="4" />
+				<spn-tooltip>
+					<ng-template spnTooltipContent let-state>
+						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" />
+					</ng-template>
+				</spn-tooltip>
+				<spn-legend>
+					<ng-template spnLegendContent>
+						<hlm-chart-legend-content [config]="chartConfig" />
+					</ng-template>
+				</spn-legend>
+			</spn-bar-chart>
+		</hlm-chart-container>
 	`,
 })
 export class ChartsLegend {
+	public readonly chartConfig: ChartConfig = {
+		desktop: {
+			label: 'Desktop',
+			color: '#2563eb',
+		},
+		mobile: {
+			label: 'Mobile',
+			color: '#60a5fa',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
 	protected readonly formatMonth = (value: unknown): string => String(value).slice(0, 3);
 	protected readonly data = [

--- a/apps/app/src/app/pages/(components)/components/(charts)/charts--legend.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(charts)/charts--legend.example.ts
@@ -42,12 +42,12 @@ import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 				<spn-bar dataKey="mobile" name="Mobile" fill="var(--color-mobile)" radius="4" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" />
+						<hlm-chart-tooltip-content [state]="state" />
 					</ng-template>
 				</spn-tooltip>
 				<spn-legend>
 					<ng-template spnLegendContent>
-						<hlm-chart-legend-content [config]="chartConfig" />
+						<hlm-chart-legend-content />
 					</ng-template>
 				</spn-legend>
 			</spn-bar-chart>

--- a/apps/app/src/app/pages/(components)/components/(charts)/charts--tooltip.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(charts)/charts--tooltip.example.ts
@@ -1,47 +1,47 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { SpnBar, SpnBarChart, SpnCartesianGrid, SpnTooltip, SpnTooltipContentDef, SpnXAxis } from '@spartan-ng/charts';
+import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 
 @Component({
 	selector: 'spartan-charts-tooltip',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { class: 'block w-full' },
-	imports: [SpnBarChart, SpnBar, SpnCartesianGrid, SpnXAxis, SpnTooltip, SpnTooltipContentDef],
+	imports: [HlmChartImports, SpnBarChart, SpnBar, SpnCartesianGrid, SpnXAxis, SpnTooltip, SpnTooltipContentDef],
 	template: `
-		<spn-bar-chart class="block h-[250px] w-full" [data]="data" [margin]="margin">
-			<spn-cartesian-grid vertical="false" stroke="color-mix(in oklch, var(--border) 50%, transparent)" />
-			<spn-x-axis
-				dataKey="month"
-				axisLine="false"
-				tickLine="false"
-				tickSize="0"
-				tickPadding="10"
-				[tickFormatter]="formatMonth"
-				stroke="var(--muted-foreground)"
-			/>
-			<spn-bar dataKey="desktop" name="Desktop" fill="var(--chart-1)" radius="4" />
-			<spn-bar dataKey="mobile" name="Mobile" fill="var(--chart-2)" radius="4" />
-			<spn-tooltip>
-				<ng-template spnTooltipContent let-state>
-					<div
-						class="bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
-					>
-						@if (state.label !== undefined && state.label !== null && state.label !== '') {
-							<div class="font-medium">{{ state.label }}</div>
-						}
-						@for (item of state.payload; track item.dataKey) {
-							<div class="flex w-full items-center gap-2">
-								<span class="size-2.5 shrink-0 rounded-[2px]" [style.background]="item.color"></span>
-								<span class="text-muted-foreground">{{ item.name }}</span>
-								<span class="text-foreground ml-auto font-mono font-medium tabular-nums">{{ item.value }}</span>
-							</div>
-						}
-					</div>
-				</ng-template>
-			</spn-tooltip>
-		</spn-bar-chart>
+		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
+			<spn-bar-chart [data]="data" [margin]="margin" defaultIndex="1">
+				<spn-cartesian-grid vertical="false" />
+				<spn-x-axis
+					dataKey="month"
+					axisLine="false"
+					tickLine="false"
+					tickSize="0"
+					tickPadding="10"
+					[tickFormatter]="formatMonth"
+				/>
+				<spn-bar dataKey="desktop" name="Desktop" fill="var(--color-desktop)" radius="4" />
+				<spn-bar dataKey="mobile" name="Mobile" fill="var(--color-mobile)" radius="4" />
+				<spn-tooltip>
+					<ng-template spnTooltipContent let-state>
+						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" />
+					</ng-template>
+				</spn-tooltip>
+			</spn-bar-chart>
+		</hlm-chart-container>
 	`,
 })
 export class ChartsTooltip {
+	public readonly chartConfig: ChartConfig = {
+		desktop: {
+			label: 'Desktop',
+			color: '#2563eb',
+		},
+		mobile: {
+			label: 'Mobile',
+			color: '#60a5fa',
+		},
+	};
+
 	protected readonly margin = { top: 12, right: 12, bottom: 24, left: 12 };
 	protected readonly formatMonth = (value: unknown): string => String(value).slice(0, 3);
 	protected readonly data = [

--- a/apps/app/src/app/pages/(components)/components/(charts)/charts--tooltip.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(charts)/charts--tooltip.example.ts
@@ -9,7 +9,7 @@ import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 	imports: [HlmChartImports, SpnBarChart, SpnBar, SpnCartesianGrid, SpnXAxis, SpnTooltip, SpnTooltipContentDef],
 	template: `
 		<hlm-chart-container class="min-h-50 w-full" [config]="chartConfig">
-			<spn-bar-chart [data]="data" [margin]="margin" defaultIndex="1">
+			<spn-bar-chart [data]="data" [margin]="margin">
 				<spn-cartesian-grid vertical="false" />
 				<spn-x-axis
 					dataKey="month"
@@ -23,7 +23,7 @@ import { ChartConfig, HlmChartImports } from '@spartan-ng/helm/chart';
 				<spn-bar dataKey="mobile" name="Mobile" fill="var(--color-mobile)" radius="4" />
 				<spn-tooltip>
 					<ng-template spnTooltipContent let-state>
-						<hlm-chart-tooltip-content [config]="chartConfig" [state]="state" />
+						<hlm-chart-tooltip-content [state]="state" />
 					</ng-template>
 				</spn-tooltip>
 			</spn-bar-chart>

--- a/apps/app/src/app/pages/(components)/components/(charts)/charts.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(charts)/charts.page.ts
@@ -178,7 +178,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_snippets()['tooltip']" />
 			</spartan-tabs>
 
-			<h3 id="your-first-chart__legend" spartanH4>Add a legend</h3>
+			<h3 id="add-legend" spartanH4>Add Legend</h3>
 			<p class="${hlmP}">
 				Charts don't ship a legend element - render your own below the chart so it matches your design exactly. A
 				centered row of coloured swatches and labels keeps it consistent with the

--- a/apps/app/src/app/pages/(components)/components/(charts)/charts.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(charts)/charts.page.ts
@@ -21,6 +21,7 @@ import { metaWith } from '@spartan-ng/app/app/shared/meta/meta.util';
 import { link } from '@spartan-ng/app/app/shared/typography/link';
 import { HlmAlertImports } from '@spartan-ng/helm/alert';
 import { hlmCode, hlmP, hlmUl } from '@spartan-ng/helm/typography';
+import { ChartsAxis } from './charts--axis.example';
 import { ChartsBasic } from './charts--basic.example';
 import { ChartsGrid } from './charts--grid.example';
 import { ChartsLegend } from './charts--legend.example';
@@ -54,6 +55,7 @@ export const routeMeta: RouteMeta = {
 		CodeRtlPreview,
 		ChartsBasic,
 		ChartsGrid,
+		ChartsAxis,
 		ChartsTooltip,
 		ChartsLegend,
 		ChartsRtl,
@@ -102,7 +104,7 @@ export const routeMeta: RouteMeta = {
 			<spartan-section-sub-heading id="your-first-chart">Your First Chart</spartan-section-sub-heading>
 			<p class="${hlmP}">Let's build a bar chart from scratch, one piece at a time.</p>
 
-			<h3 id="your-first-chart__data" spartanH4>Chart data</h3>
+			<h3 id="chart-data" spartanH4>Chart data</h3>
 			<p class="${hlmP}">
 				Charts take a plain array of objects through the
 				<span class="${hlmCode}">data</span>
@@ -110,7 +112,7 @@ export const routeMeta: RouteMeta = {
 			</p>
 			<spartan-code [code]="_dataCode" />
 
-			<h3 id="your-first-chart__build" spartanH4>Build the chart</h3>
+			<h3 id="build-the-chart" spartanH4>Build the chart</h3>
 			<p class="${hlmP}">
 				Wrap the chart in
 				<span class="${hlmCode}">spn-bar-chart</span>
@@ -129,7 +131,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_snippets()['basic']" />
 			</spartan-tabs>
 
-			<h3 id="your-first-chart__grid" spartanH4>Add a grid</h3>
+			<h3 id="add-a-grid" spartanH4>Add a Grid</h3>
 			<p class="${hlmP}">
 				Add a
 				<span class="${hlmCode}">spn-cartesian-grid</span>
@@ -142,7 +144,20 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_snippets()['grid']" />
 			</spartan-tabs>
 
-			<h3 id="your-first-chart__tooltip" spartanH4>Add a tooltip</h3>
+			<h3 id="add-an-axis" spartanH4>Add an Axis</h3>
+			<p class="${hlmP}">
+				To add an x-axis, add the
+				<span class="${hlmCode}">spn-x-axis</span>
+				component.
+			</p>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-charts-axis class="w-full max-w-2xl" />
+				</div>
+				<spartan-code secondTab [code]="_snippets()['axis']" />
+			</spartan-tabs>
+
+			<h3 id="add-tooltip" spartanH4>Add Tooltip</h3>
 			<p class="${hlmP}">
 				Add a
 				<span class="${hlmCode}">spn-tooltip</span>

--- a/apps/ui-storybook/stories/hlm-chart.stories.ts
+++ b/apps/ui-storybook/stories/hlm-chart.stories.ts
@@ -1,24 +1,47 @@
-import { HlmChart, HlmChartImports } from '@spartan-ng/helm/chart';
+import { SpnBar, SpnBarChart, SpnCartesianGrid, SpnXAxis } from '@spartan-ng/charts';
+import { HlmChartContainer, HlmChartImports } from '@spartan-ng/helm/chart';
 import type { Meta, StoryObj } from '@storybook/angular';
 import { moduleMetadata } from '@storybook/angular';
 
 export default {
 	title: 'Chart',
-	component: HlmChart,
+	component: HlmChartContainer,
 	tags: ['autodocs'],
 	decorators: [
 		moduleMetadata({
-			imports: [HlmChartImports],
+			imports: [HlmChartImports, SpnBarChart, SpnBar, SpnCartesianGrid, SpnXAxis],
 		}),
 	],
-} as Meta<HlmChart>;
+} as Meta<HlmChartContainer>;
 
-type Story = StoryObj<HlmChart>;
+type Story = StoryObj<HlmChartContainer>;
 
 export const Default: Story = {
 	render: () => ({
+		props: {
+			chartConfig: {
+				desktop: { label: 'Desktop', color: '#2563eb' },
+				mobile: { label: 'Mobile', color: '#60a5fa' },
+			},
+			margin: { top: 12, right: 12, bottom: 24, left: 12 },
+			data: [
+				{ month: 'January', desktop: 186, mobile: 80 },
+				{ month: 'February', desktop: 305, mobile: 200 },
+				{ month: 'March', desktop: 237, mobile: 120 },
+				{ month: 'April', desktop: 73, mobile: 190 },
+				{ month: 'May', desktop: 209, mobile: 130 },
+				{ month: 'June', desktop: 214, mobile: 140 },
+			],
+		},
 		template: `
-
+			<hlm-chart-container class="h-64 w-96" [config]="chartConfig">
+				<spn-bar-chart [data]="data" [margin]="margin">
+					<spn-cartesian-grid />
+					<spn-x-axis dataKey="month" axisLine="false" tickLine="false" tickSize="0" tickPadding="10" />
+					<spn-bar dataKey="desktop" name="Desktop" fill="var(--color-desktop)" radius="4" />
+					<spn-bar dataKey="mobile" name="Mobile" fill="var(--color-mobile)" radius="4" />
+				</spn-bar-chart>
+			</hlm-chart-container>
 		`,
 	}),
 };

--- a/apps/ui-storybook/stories/hlm-chart.stories.ts
+++ b/apps/ui-storybook/stories/hlm-chart.stories.ts
@@ -1,0 +1,24 @@
+import { HlmChart, HlmChartImports } from '@spartan-ng/helm/chart';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+
+export default {
+	title: 'Chart',
+	component: HlmChart,
+	tags: ['autodocs'],
+	decorators: [
+		moduleMetadata({
+			imports: [HlmChartImports],
+		}),
+	],
+} as Meta<HlmChart>;
+
+type Story = StoryObj<HlmChart>;
+
+export const Default: Story = {
+	render: () => ({
+		template: `
+
+		`,
+	}),
+};

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -20,6 +20,7 @@ module.exports = {
 				'calendar',
 				'card',
 				'carousel',
+				'chart',
 				'checkbox',
 				'cli',
 				'collapsible',

--- a/libs/charts/src/lib/bar-chart/bar-chart.ts
+++ b/libs/charts/src/lib/bar-chart/bar-chart.ts
@@ -228,7 +228,7 @@ export class SpnBarChart<T = unknown> {
 
 			// Render in correct z-order
 			this.renderAxes();
-			this.ensureDefaultValueScale();
+			this.ensureDefaultScales();
 			this.renderGrid();
 			this.renderReferenceLines(false);
 			this.renderBars();
@@ -298,27 +298,71 @@ export class SpnBarChart<T = unknown> {
 	 * shadcn bar charts declare no value axis, so synthesize one (recharts-nice
 	 * domain) when the relevant axis is missing - otherwise there's no value
 	 * scale and the bars can't be positioned.
+	 *
+	 * Also creates a default category (band) scale when no category axis is
+	 * declared, so bars render even without an explicit X/Y axis.
 	 */
-	private ensureDefaultValueScale(): void {
+	private ensureDefaultScales(): void {
 		this.defaultValueTicks = undefined;
 		const isHorizontal = this.layout() === 'horizontal';
+		const data = this.data();
 		const hasX = this.xAxes().some((a) => a.axisId() === 'default' && !a.hide());
 		const hasY = this.yAxes().some((a) => a.axisId() === 'default' && !a.hide());
+
 		const valueAxisMissing = isHorizontal ? !hasX : !hasY;
-		if (!valueAxisMissing) return;
+		const categoryAxisMissing = isHorizontal ? !hasY : !hasX;
+		const autoCategoryKey = this.categoryDataKey();
 
-		const [min, max] = this.calculateValueAxisDomain(this.data(), ['auto', 'auto']);
-		const ticks = niceTicks(min, max, 5);
-		const niceDomain: [number, number] = [ticks[0], ticks[ticks.length - 1]];
-		this.defaultValueTicks = ticks;
+		// Create default value scale when missing
+		if (valueAxisMissing) {
+			const [min, max] = this.calculateValueAxisDomain(data, ['auto', 'auto']);
+			const ticks = niceTicks(min, max, 5);
+			const niceDomain: [number, number] = [ticks[0], ticks[ticks.length - 1]];
+			this.defaultValueTicks = ticks;
 
-		if (isHorizontal) {
-			const scale = createLinearScale(niceDomain, this.chartContext.innerWidth(), false);
-			this.chartContext.registerXScale(scale, 'default');
-		} else {
-			const scale = createLinearScale(niceDomain, this.chartContext.innerHeight(), true);
-			this.chartContext.registerYScale(scale, 'default');
+			if (isHorizontal) {
+				const scale = createLinearScale(niceDomain, this.chartContext.innerWidth(), false);
+				this.chartContext.registerXScale(scale, 'default');
+			} else {
+				const scale = createLinearScale(niceDomain, this.chartContext.innerHeight(), true);
+				this.chartContext.registerYScale(scale, 'default');
+			}
 		}
+
+		// Create default category (band) scale when missing
+		if (categoryAxisMissing && autoCategoryKey) {
+			if (isHorizontal) {
+				const scale = createBandScale(data, autoCategoryKey, this.chartContext.innerHeight());
+				this.chartContext.registerYScale(scale, 'default');
+			} else {
+				const scale = createBandScale(data, autoCategoryKey, this.chartContext.innerWidth());
+				this.chartContext.registerXScale(scale, 'default');
+			}
+		}
+	}
+
+	/**
+	 * Returns the dataKey for the category (non-value) axis.
+	 * Uses the axis component's dataKey if declared, otherwise auto-detects
+	 * a key from the data that isn't used as any bar's dataKey.
+	 */
+	private categoryDataKey(): string {
+		const isHorizontal = this.layout() === 'horizontal';
+		// If an axis is declared and not hidden, use its dataKey
+		const axisKey = isHorizontal
+			? this.yAxes()
+					.find((a) => a.axisId() === 'default' && !a.hide())
+					?.dataKey()
+			: this.xAxes()
+					.find((a) => a.axisId() === 'default' && !a.hide())
+					?.dataKey();
+		if (axisKey) return String(axisKey);
+
+		// Auto-detect: first key in data that's not a bar dataKey
+		const bars = this.bars().filter((bar) => !bar.hide());
+		const barDataKeys = new Set(bars.map((b) => b.dataKey()));
+		const data = this.data();
+		return data.length ? (Object.keys(data[0] as Record<string, unknown>).find((k) => !barDataKeys.has(k)) ?? '') : '';
 	}
 
 	private calculateAxisDomain(
@@ -426,7 +470,7 @@ export class SpnBarChart<T = unknown> {
 		if (!xScale || !yScale) return;
 
 		// Get category dataKey from the correct axis based on layout
-		const categoryDataKey = isHorizontal ? this.yAxes()[0]?.dataKey() || '' : this.xAxes()[0]?.dataKey() || '';
+		const categoryDataKey = this.categoryDataKey();
 
 		// Get the band scale based on layout
 		const bandScale = isHorizontal ? yScale : xScale;
@@ -479,8 +523,8 @@ export class SpnBarChart<T = unknown> {
 		const yScale = this.chartContext.yScale();
 		if (!xScale || !yScale) return;
 
-		// Get category dataKey from the correct axis based on layout
-		const categoryDataKey = isHorizontal ? this.yAxes()[0]?.dataKey() || '' : this.xAxes()[0]?.dataKey() || '';
+		// Get category dataKey from axis or auto-detect from data
+		const categoryDataKey = this.categoryDataKey();
 
 		// Get the band scale based on layout
 		const bandScale = isHorizontal ? yScale : xScale;

--- a/libs/charts/src/lib/cartesian-grid/cartesian-grid.ts
+++ b/libs/charts/src/lib/cartesian-grid/cartesian-grid.ts
@@ -18,5 +18,5 @@ export class SpnCartesianGrid {
 	readonly verticalPoints = input<number[]>();
 	readonly stroke = input('#ccc');
 	readonly strokeWidth = input(1, { transform: numberAttribute });
-	readonly strokeDasharray = input('3 3');
+	readonly strokeDasharray = input('');
 }

--- a/libs/charts/src/lib/chart-utils/axis-renderer.ts
+++ b/libs/charts/src/lib/chart-utils/axis-renderer.ts
@@ -101,9 +101,9 @@ export function renderXAxis(
 	if (!xAxis.axisLine()) g.select('.domain').remove();
 	if (!xAxis.tickLine()) g.selectAll('.tick line').remove();
 
-	g.selectAll('path, line').style('stroke', xAxis.stroke());
+	g.selectAll('path, line').attr('stroke', xAxis.stroke());
 	// recharts default tick font size is 12px (D3's default of 10px is too small)
-	g.selectAll('text').style('fill', xAxis.stroke()).style('font-size', '12px');
+	g.selectAll('text').attr('fill', xAxis.stroke()).style('font-size', '12px');
 }
 
 /**
@@ -148,7 +148,7 @@ export function renderYAxis(
 	if (!yAxis.axisLine()) g.select('.domain').remove();
 	if (!yAxis.tickLine()) g.selectAll('.tick line').remove();
 
-	g.selectAll('path, line').style('stroke', yAxis.stroke());
+	g.selectAll('path, line').attr('stroke', yAxis.stroke());
 	// recharts default tick font size is 12px (D3's default of 10px is too small)
-	g.selectAll('text').style('fill', yAxis.stroke()).style('font-size', '12px');
+	g.selectAll('text').attr('fill', yAxis.stroke()).style('font-size', '12px');
 }

--- a/libs/charts/src/lib/chart-utils/grid-renderer.ts
+++ b/libs/charts/src/lib/chart-utils/grid-renderer.ts
@@ -49,7 +49,10 @@ export function renderGrid(
 			.attr('y2', (d) => (yScale as d3.ScaleLinear<number, number>)(d))
 			.attr('stroke', grid.stroke())
 			.attr('stroke-width', grid.strokeWidth())
-			.attr('stroke-dasharray', grid.strokeDasharray());
+			.call((sel) => {
+				const dash = grid.strokeDasharray();
+				if (dash) sel.attr('stroke-dasharray', dash);
+			});
 	}
 
 	// Render vertical lines
@@ -85,7 +88,10 @@ export function renderGrid(
 				.attr('y2', innerHeight)
 				.attr('stroke', grid.stroke())
 				.attr('stroke-width', grid.strokeWidth())
-				.attr('stroke-dasharray', grid.strokeDasharray());
+				.call((sel) => {
+					const dash = grid.strokeDasharray();
+					if (dash) sel.attr('stroke-dasharray', dash);
+				});
 		} else if ('step' in xScale) {
 			// Point scale (for line/area charts)
 			gridGroup
@@ -105,7 +111,10 @@ export function renderGrid(
 				.attr('y2', innerHeight)
 				.attr('stroke', grid.stroke())
 				.attr('stroke-width', grid.strokeWidth())
-				.attr('stroke-dasharray', grid.strokeDasharray());
+				.call((sel) => {
+					const dash = grid.strokeDasharray();
+					if (dash) sel.attr('stroke-dasharray', dash);
+				});
 		} else {
 			// Linear scale
 			gridGroup
@@ -119,7 +128,10 @@ export function renderGrid(
 				.attr('y2', innerHeight)
 				.attr('stroke', grid.stroke())
 				.attr('stroke-width', grid.strokeWidth())
-				.attr('stroke-dasharray', grid.strokeDasharray());
+				.call((sel) => {
+					const dash = grid.strokeDasharray();
+					if (dash) sel.attr('stroke-dasharray', dash);
+				});
 		}
 	}
 }

--- a/libs/charts/src/lib/legend/legend.ts
+++ b/libs/charts/src/lib/legend/legend.ts
@@ -181,6 +181,7 @@ export class SpnLegendContentDef {
 			:host {
 				display: block;
 				position: absolute;
+				inset-inline: 0;
 				z-index: 10;
 			}
 

--- a/libs/cli/src/generators/ui/libs/chart/files/index.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/index.ts.template
@@ -1,0 +1,6 @@
+import { HlmChartContainer } from './lib/hlm-chart-container';
+
+export * from './lib/hlm-chart-container';
+export * from './lib/hlm-chart.token';
+
+export const HlmChartImports = [HlmChartContainer] as const;

--- a/libs/cli/src/generators/ui/libs/chart/files/index.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/index.ts.template
@@ -1,6 +1,8 @@
 import { HlmChartContainer } from './lib/hlm-chart-container';
+import { HlmChartTooltipContent } from './lib/hlm-chart-tooltip-content';
 
 export * from './lib/hlm-chart-container';
+export * from './lib/hlm-chart-tooltip-content';
 export * from './lib/hlm-chart.token';
 
-export const HlmChartImports = [HlmChartContainer] as const;
+export const HlmChartImports = [HlmChartContainer, HlmChartTooltipContent] as const;

--- a/libs/cli/src/generators/ui/libs/chart/files/index.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/index.ts.template
@@ -1,8 +1,10 @@
 import { HlmChartContainer } from './lib/hlm-chart-container';
+import { HlmChartLegendContent } from './lib/hlm-chart-legend-content';
 import { HlmChartTooltipContent } from './lib/hlm-chart-tooltip-content';
 
 export * from './lib/hlm-chart-container';
+export * from './lib/hlm-chart-legend-content';
 export * from './lib/hlm-chart-tooltip-content';
 export * from './lib/hlm-chart.token';
 
-export const HlmChartImports = [HlmChartContainer, HlmChartTooltipContent] as const;
+export const HlmChartImports = [HlmChartContainer, HlmChartLegendContent, HlmChartTooltipContent] as const;

--- a/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-container.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-container.ts.template
@@ -20,7 +20,11 @@ export class HlmChartContainer {
 	public readonly config = input<ChartConfig>(this._config);
 
 	constructor() {
-		classes(() => 'flex aspect-video justify-center text-xs');
+		classes(() => [
+			'flex aspect-video justify-center text-xs',
+			"[&_.grid-layer_line[stroke='#ccc']]:stroke-border/50",
+			'[&_.axes-layer_text]:fill-muted-foreground [&_.axes-layer_line]:stroke-border [&_.axes-layer_path]:stroke-border',
+		]);
 
 		afterNextRender(() => {
 			effect(

--- a/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-container.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-container.ts.template
@@ -1,0 +1,60 @@
+import { DOCUMENT } from '@angular/common';
+import { afterNextRender, Directive, effect, ElementRef, inject, Injector, input } from '@angular/core';
+import { classes } from '<%- importAlias %>/utils';
+import { CHART_THEMES, ChartConfig, injectHlmChartConfig } from './hlm-chart.token';
+
+@Directive({
+	selector: '[hlmChartContainer],hlm-chart-container',
+	host: { 'data-slot': 'chart', '[attr.data-chart]': 'id()' },
+})
+export class HlmChartContainer {
+	private static _id = 0;
+
+	private readonly _config = injectHlmChartConfig();
+	private readonly _host = inject(ElementRef<HTMLElement>);
+	private readonly _document = inject(DOCUMENT);
+	private readonly _injector = inject(Injector);
+
+	public readonly id = input<string>(`hlm-chart-container-${++HlmChartContainer._id}`);
+
+	public readonly config = input<ChartConfig>(this._config);
+
+	constructor() {
+		classes(() => 'flex aspect-video justify-center text-xs');
+
+		afterNextRender(() => {
+			effect(
+				(onCleanup) => {
+					// Remove the previous style element before creating a new one.
+					// This is more reliable than relying solely on onCleanup, since
+					// the effect can re-run multiple times during initialization.
+					this._host.nativeElement.querySelector('style')?.remove();
+
+					const styleEl = this._document.createElement('style');
+					const chartId = this.id();
+					const colorConfig = Object.entries(this.config()).filter(
+						([, itemConfig]) => itemConfig.theme ?? itemConfig.color,
+					);
+
+					if (colorConfig.length) {
+						styleEl.textContent = (Object.entries(CHART_THEMES) as Array<[keyof typeof CHART_THEMES, string]>)
+							.map(([theme, prefix]) => {
+								const rules = colorConfig
+									.map(([key, itemConfig]) => {
+										const color = itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ?? itemConfig.color;
+										return color ? `  --color-${key}: ${color};` : null;
+									})
+									.filter(Boolean)
+									.join('\n');
+								return `${prefix} [data-chart="${chartId}"] {\n${rules}\n}`;
+							})
+							.join('\n');
+						this._host.nativeElement.append(styleEl);
+						onCleanup(() => styleEl.remove());
+					}
+				},
+				{ injector: this._injector },
+			);
+		});
+	}
+}

--- a/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-legend-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-legend-content.ts.template
@@ -1,0 +1,58 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { NgIcon } from '@ng-icons/core';
+import { classes } from '<%- importAlias %>/utils';
+import { ChartConfig, injectHlmChartConfig } from './hlm-chart.token';
+
+/**
+ * Default shadcn-styled chart legend content.
+ * Derives legend items directly from the chart config.
+ *
+ * @example
+ * ```html
+ * <hlm-chart-legend-content />
+ * ```
+ */
+@Component({
+	selector: 'hlm-chart-legend-content',
+	imports: [NgIcon],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: { '[attr.data-align]': 'verticalAlign()' },
+	template: `
+		@for (item of _items(); track item.key) {
+			<div class="[&>ng-icon]:text-muted-foreground flex items-center gap-1.5 [&>ng-icon]:text-[length:--spacing(3)]">
+				@if (item.icon && !hideIcon()) {
+					<ng-icon [name]="item.icon" />
+				} @else {
+					<div class="h-2 w-2 shrink-0 rounded-xs bg-(--color-bg)" [style.--color-bg]="item.color"></div>
+				}
+				<span class="text-foreground text-xs leading-none">{{ item.label }}</span>
+			</div>
+		}
+	`,
+})
+export class HlmChartLegendContent {
+	private readonly _config = injectHlmChartConfig();
+
+	/** Override the injected chart config. */
+	public readonly config = input<ChartConfig>(this._config);
+
+	public readonly verticalAlign = input<'top' | 'bottom'>('bottom');
+
+	/** Whether to hide the icon from the config. */
+	public readonly hideIcon = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
+
+	protected readonly _items = computed(() => {
+		const config = this.config();
+		return Object.entries(config).map(([key, itemConfig]) => ({
+			key,
+			label: itemConfig.label ?? key,
+			icon: itemConfig.icon,
+			color: `var(--color-${key})`,
+		}));
+	});
+
+	constructor() {
+		classes(() => 'flex items-center justify-center gap-4 data-[align=bottom]:pt-3 data-[align=top]:pb-3');
+	}
+}

--- a/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-legend-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-legend-content.ts.template
@@ -1,8 +1,8 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { NgIcon } from '@ng-icons/core';
 import { classes } from '<%- importAlias %>/utils';
-import { ChartConfig, injectHlmChartConfig } from './hlm-chart.token';
+import { HlmChartContainer } from './hlm-chart-container';
 
 /**
  * Default shadcn-styled chart legend content.
@@ -32,10 +32,7 @@ import { ChartConfig, injectHlmChartConfig } from './hlm-chart.token';
 	`,
 })
 export class HlmChartLegendContent {
-	private readonly _config = injectHlmChartConfig();
-
-	/** Override the injected chart config. */
-	public readonly config = input<ChartConfig>(this._config);
+	private readonly _chartContainer = inject(HlmChartContainer);
 
 	public readonly verticalAlign = input<'top' | 'bottom'>('bottom');
 
@@ -43,7 +40,7 @@ export class HlmChartLegendContent {
 	public readonly hideIcon = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 
 	protected readonly _items = computed(() => {
-		const config = this.config();
+		const config = this._chartContainer.config();
 		return Object.entries(config).map(([key, itemConfig]) => ({
 			key,
 			label: itemConfig.label ?? key,

--- a/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-tooltip-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-tooltip-content.ts.template
@@ -32,8 +32,8 @@ export interface HlmChartTooltipItemContext {
  */
 @Component({
 	selector: 'hlm-chart-tooltip-content',
-	changeDetection: ChangeDetectionStrategy.OnPush,
 	imports: [NgIcon, NgTemplateOutlet],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		@if (_tooltipLabel(); as label) {
 			<div class="font-medium">{{ label }}</div>
@@ -59,7 +59,7 @@ export interface HlmChartTooltipItemContext {
 						}
 						<div class="flex flex-1 items-center justify-between leading-none">
 							<span class="text-muted-foreground">{{ item.label ?? item.name }}</span>
-							@if (item.value != null) {
+							@if (item.value !== null) {
 								<span class="text-foreground font-mono font-medium tabular-nums">{{ item.value }}</span>
 							}
 						</div>

--- a/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-tooltip-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-tooltip-content.ts.template
@@ -1,10 +1,19 @@
 import { BooleanInput } from '@angular/cdk/coercion';
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, TemplateRef } from '@angular/core';
+import {
+	booleanAttribute,
+	ChangeDetectionStrategy,
+	Component,
+	computed,
+	inject,
+	input,
+	TemplateRef,
+} from '@angular/core';
 import { NgIcon } from '@ng-icons/core';
 import type { DataKey, TooltipState } from '@spartan-ng/charts';
 import { classes } from '<%- importAlias %>/utils';
-import { ChartConfig, getPayloadConfigFromPayload, injectHlmChartConfig } from './hlm-chart.token';
+import { HlmChartContainer } from './hlm-chart-container';
+import { getPayloadConfigFromPayload } from './hlm-chart.token';
 
 /** Context provided to the custom item template. */
 export interface HlmChartTooltipItemContext {
@@ -70,11 +79,9 @@ export interface HlmChartTooltipItemContext {
 	`,
 })
 export class HlmChartTooltipContent {
-	private readonly _config = injectHlmChartConfig();
+	private readonly _chartContainer = inject(HlmChartContainer);
 
 	public readonly state = input.required<TooltipState>();
-
-	public readonly config = input<ChartConfig>(this._config);
 
 	public readonly hideLabel = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 	public readonly hideIndicator = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
@@ -89,7 +96,7 @@ export class HlmChartTooltipContent {
 		input<TemplateRef<{ $implicit: HlmChartTooltipItemContext; index: number; first: boolean; last: boolean }>>();
 
 	protected readonly _items = computed(() => {
-		const config = this.config();
+		const config = this._chartContainer.config();
 		return this.state().payload.map((item) => {
 			const key = `${item.dataKey ?? item.name ?? 'value'}`;
 			const itemConfig = getPayloadConfigFromPayload(config, item, key);
@@ -111,7 +118,7 @@ export class HlmChartTooltipContent {
 		if (labelKey === undefined || labelKey === null || labelKey === '') {
 			value = stateLabel;
 		} else {
-			const itemConfig = this.config()[labelKey];
+			const itemConfig = this._chartContainer.config()[labelKey];
 			value = itemConfig?.label ?? stateLabel;
 		}
 

--- a/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-tooltip-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-tooltip-content.ts.template
@@ -18,8 +18,7 @@ import type { TooltipState } from '@spartan-ng/charts';
 	selector: 'hlm-chart-tooltip-content',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
-		class:
-			'bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl',
+		class: 'bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl',
 	},
 	template: `
 		@if (showLabel()) {

--- a/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-tooltip-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-tooltip-content.ts.template
@@ -4,7 +4,7 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, 
 import { NgIcon } from '@ng-icons/core';
 import type { DataKey, TooltipState } from '@spartan-ng/charts';
 import { classes } from '<%- importAlias %>/utils';
-import { ChartConfig, injectHlmChartConfig } from './hlm-chart.token';
+import { ChartConfig, getPayloadConfigFromPayload, injectHlmChartConfig } from './hlm-chart.token';
 
 /** Context provided to the custom item template. */
 export interface HlmChartTooltipItemContext {
@@ -122,39 +122,4 @@ export class HlmChartTooltipContent {
 	constructor() {
 		classes(() => 'spartan-chart-tooltip grid min-w-32 items-start');
 	}
-}
-
-function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
-	if (typeof payload !== 'object' || payload === null) {
-		return undefined;
-	}
-
-	const payloadPayload =
-		'payload' in payload && typeof payload.payload === 'object' && payload.payload !== null
-			? payload.payload
-			: undefined;
-
-	let configLabelKey: string = key;
-
-	if (key in payload && typeof payload[key as keyof typeof payload] === 'string') {
-		configLabelKey = payload[key as keyof typeof payload] as string;
-	} else if (
-		payloadPayload &&
-		key in payloadPayload &&
-		typeof payloadPayload[key as keyof typeof payloadPayload] === 'string'
-	) {
-		configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
-	}
-
-	if (configLabelKey in config) {
-		return config[configLabelKey];
-	}
-
-	// Fallback: try to find a config entry whose label matches the key
-	const labelMatchKey = Object.keys(config).find((k) => config[k]?.label === key);
-	if (labelMatchKey !== undefined) {
-		return config[labelMatchKey];
-	}
-
-	return config[key];
 }

--- a/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-tooltip-content.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart-tooltip-content.ts.template
@@ -1,0 +1,44 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import type { TooltipState } from '@spartan-ng/charts';
+
+/**
+ * Default shadcn-styled chart tooltip content.
+ * Use inside an `spnTooltipContent` template to avoid repeating the markup.
+ *
+ * @example
+ * ```html
+ * <spn-tooltip>
+ *   <ng-template spnTooltipContent let-state>
+ *     <hlm-chart-tooltip-content [state]="state" />
+ *   </ng-template>
+ * </spn-tooltip>
+ * ```
+ */
+@Component({
+	selector: 'hlm-chart-tooltip-content',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class:
+			'bg-background border-border/50 grid min-w-[8rem] gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl',
+	},
+	template: `
+		@if (showLabel()) {
+			<div class="font-medium">{{ state().label }}</div>
+		}
+		@for (item of state().payload; track item.dataKey) {
+			<div class="flex w-full items-center gap-2">
+				<span class="size-2.5 shrink-0 rounded-xs" [style.background]="item.color"></span>
+				<span class="text-muted-foreground">{{ item.name }}</span>
+				<span class="text-foreground ml-auto font-mono font-medium tabular-nums">{{ item.value }}</span>
+			</div>
+		}
+	`,
+})
+export class HlmChartTooltipContent {
+	readonly state = input.required<TooltipState>();
+
+	protected readonly showLabel = computed(() => {
+		const label = this.state().label;
+		return label !== undefined && label !== null && label !== '';
+	});
+}

--- a/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart.token.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart.token.ts.template
@@ -1,4 +1,4 @@
-import { inject, InjectionToken, ValueProvider } from '@angular/core';
+import { inject, InjectionToken, type ValueProvider } from '@angular/core';
 
 export const CHART_THEMES = { light: '', dark: '.dark' } as const;
 

--- a/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart.token.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart.token.ts.template
@@ -21,3 +21,38 @@ export function provideHlmChartConfig(config: Partial<ChartConfig>): ValueProvid
 export function injectHlmChartConfig(): ChartConfig {
 	return inject(ChartConfigToken, { optional: true }) ?? defaultConfig;
 }
+
+export function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
+	if (typeof payload !== 'object' || payload === null) {
+		return undefined;
+	}
+
+	const payloadPayload =
+		'payload' in payload && typeof payload.payload === 'object' && payload.payload !== null
+			? payload.payload
+			: undefined;
+
+	let configLabelKey: string = key;
+
+	if (key in payload && typeof payload[key as keyof typeof payload] === 'string') {
+		configLabelKey = payload[key as keyof typeof payload] as string;
+	} else if (
+		payloadPayload &&
+		key in payloadPayload &&
+		typeof payloadPayload[key as keyof typeof payloadPayload] === 'string'
+	) {
+		configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
+	}
+
+	if (configLabelKey in config) {
+		return config[configLabelKey];
+	}
+
+	// Fallback: try to find a config entry whose label matches the key
+	const labelMatchKey = Object.keys(config).find((k) => config[k]?.label === key);
+	if (labelMatchKey !== undefined) {
+		return config[labelMatchKey];
+	}
+
+	return config[key];
+}

--- a/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart.token.ts.template
+++ b/libs/cli/src/generators/ui/libs/chart/files/lib/hlm-chart.token.ts.template
@@ -1,0 +1,23 @@
+import { inject, InjectionToken, ValueProvider } from '@angular/core';
+
+export const CHART_THEMES = { light: '', dark: '.dark' } as const;
+
+export type ChartConfig = Record<
+	string,
+	{
+		label?: string;
+		icon?: string;
+	} & ({ color?: string; theme?: never } | { color?: never; theme: Record<keyof typeof CHART_THEMES, string> })
+>;
+
+const defaultConfig: ChartConfig = {};
+
+const ChartConfigToken = new InjectionToken<ChartConfig>('ChartConfig');
+
+export function provideHlmChartConfig(config: Partial<ChartConfig>): ValueProvider {
+	return { provide: ChartConfigToken, useValue: { ...defaultConfig, ...config } };
+}
+
+export function injectHlmChartConfig(): ChartConfig {
+	return inject(ChartConfigToken, { optional: true }) ?? defaultConfig;
+}

--- a/libs/cli/src/generators/ui/libs/chart/generator.ts
+++ b/libs/cli/src/generators/ui/libs/chart/generator.ts
@@ -1,0 +1,7 @@
+import type { Tree } from '@nx/devkit';
+import hlmBaseGenerator from '../../../base/generator';
+import type { HlmBaseGeneratorSchema } from '../../../base/schema';
+
+export async function generator(tree: Tree, options: HlmBaseGeneratorSchema) {
+	return await hlmBaseGenerator(tree, { ...options, name: 'chart' });
+}

--- a/libs/cli/src/generators/ui/primitive-deps.ts
+++ b/libs/cli/src/generators/ui/primitive-deps.ts
@@ -14,6 +14,7 @@ export const primitiveDependencies: Record<Primitive, Primitive[]> = {
 	calendar: ['utils', 'button', 'select'],
 	card: ['utils'],
 	carousel: ['utils', 'button'],
+	chart: ['utils'],
 	checkbox: ['utils'],
 	collapsible: ['utils'],
 	combobox: ['utils', 'input-group', 'button'],

--- a/libs/cli/src/generators/ui/primitives.ts
+++ b/libs/cli/src/generators/ui/primitives.ts
@@ -12,6 +12,7 @@ export type Primitive =
 	| 'calendar'
 	| 'card'
 	| 'carousel'
+	| 'chart'
 	| 'checkbox'
 	| 'collapsible'
 	| 'combobox'

--- a/libs/cli/src/generators/ui/supported-ui-libraries.json
+++ b/libs/cli/src/generators/ui/supported-ui-libraries.json
@@ -116,7 +116,8 @@
 			"@angular/common": ">=21.0.0 <23.0.0",
 			"@angular/core": ">=21.0.0 <23.0.0",
 			"@angular/cdk": ">=21.0.0 <23.0.0",
-			"@ng-icons/core": ">=32.0.0 <34.0.0"
+			"@ng-icons/core": ">=32.0.0 <34.0.0",
+			"@spartan-ng/charts": "1.0.0-alpha.0"
 		}
 	},
 	"checkbox": {

--- a/libs/cli/src/generators/ui/supported-ui-libraries.json
+++ b/libs/cli/src/generators/ui/supported-ui-libraries.json
@@ -110,6 +110,13 @@
 			"embla-carousel-angular": ">=21.0.0 <23.0.0"
 		}
 	},
+	"chart": {
+		"name": "chart",
+		"peerDependencies": {
+			"@angular/common": ">=21.0.0 <23.0.0",
+			"@angular/core": ">=21.0.0 <23.0.0"
+		}
+	},
 	"checkbox": {
 		"name": "checkbox",
 		"peerDependencies": {

--- a/libs/cli/src/generators/ui/supported-ui-libraries.json
+++ b/libs/cli/src/generators/ui/supported-ui-libraries.json
@@ -114,7 +114,9 @@
 		"name": "chart",
 		"peerDependencies": {
 			"@angular/common": ">=21.0.0 <23.0.0",
-			"@angular/core": ">=21.0.0 <23.0.0"
+			"@angular/core": ">=21.0.0 <23.0.0",
+			"@angular/cdk": ">=21.0.0 <23.0.0",
+			"@ng-icons/core": ">=32.0.0 <34.0.0"
 		}
 	},
 	"checkbox": {

--- a/libs/helm/chart/README.md
+++ b/libs/helm/chart/README.md
@@ -1,0 +1,3 @@
+# @spartan-ng/helm/chart
+
+Secondary entry point of `@spartan-ng/helm`. It can be used by importing from `@spartan-ng/helm/chart`.

--- a/libs/helm/chart/ng-package.json
+++ b/libs/helm/chart/ng-package.json
@@ -1,0 +1,5 @@
+{
+	"lib": {
+		"entryFile": "src/index.ts"
+	}
+}

--- a/libs/helm/chart/src/index.ts
+++ b/libs/helm/chart/src/index.ts
@@ -1,0 +1,6 @@
+import { HlmChartContainer } from './lib/hlm-chart-container';
+
+export * from './lib/hlm-chart-container';
+export * from './lib/hlm-chart.token';
+
+export const HlmChartImports = [HlmChartContainer] as const;

--- a/libs/helm/chart/src/index.ts
+++ b/libs/helm/chart/src/index.ts
@@ -1,6 +1,8 @@
 import { HlmChartContainer } from './lib/hlm-chart-container';
+import { HlmChartTooltipContent } from './lib/hlm-chart-tooltip-content';
 
 export * from './lib/hlm-chart-container';
+export * from './lib/hlm-chart-tooltip-content';
 export * from './lib/hlm-chart.token';
 
-export const HlmChartImports = [HlmChartContainer] as const;
+export const HlmChartImports = [HlmChartContainer, HlmChartTooltipContent] as const;

--- a/libs/helm/chart/src/index.ts
+++ b/libs/helm/chart/src/index.ts
@@ -1,8 +1,10 @@
 import { HlmChartContainer } from './lib/hlm-chart-container';
+import { HlmChartLegendContent } from './lib/hlm-chart-legend-content';
 import { HlmChartTooltipContent } from './lib/hlm-chart-tooltip-content';
 
 export * from './lib/hlm-chart-container';
+export * from './lib/hlm-chart-legend-content';
 export * from './lib/hlm-chart-tooltip-content';
 export * from './lib/hlm-chart.token';
 
-export const HlmChartImports = [HlmChartContainer, HlmChartTooltipContent] as const;
+export const HlmChartImports = [HlmChartContainer, HlmChartLegendContent, HlmChartTooltipContent] as const;

--- a/libs/helm/chart/src/lib/hlm-chart-container.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-container.ts
@@ -20,10 +20,10 @@ export class HlmChartContainer {
 	public readonly config = input<ChartConfig>(this._config);
 
 	constructor() {
-		classes(() => 'flex aspect-video justify-center text-xs');
 		classes(() => [
 			'flex aspect-video justify-center text-xs',
 			"[&_.grid-layer_line[stroke='#ccc']]:stroke-border/50",
+			'[&_.axes-layer_text]:fill-muted-foreground [&_.axes-layer_line]:stroke-border [&_.axes-layer_path]:stroke-border',
 		]);
 
 		afterNextRender(() => {

--- a/libs/helm/chart/src/lib/hlm-chart-container.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-container.ts
@@ -1,0 +1,60 @@
+import { DOCUMENT } from '@angular/common';
+import { afterNextRender, Directive, effect, ElementRef, inject, Injector, input } from '@angular/core';
+import { classes } from '@spartan-ng/helm/utils';
+import { CHART_THEMES, ChartConfig, injectHlmChartConfig } from './hlm-chart.token';
+
+@Directive({
+	selector: '[hlmChartContainer],hlm-chart-container',
+	host: { 'data-slot': 'chart', '[attr.data-chart]': 'id()' },
+})
+export class HlmChartContainer {
+	private static _id = 0;
+
+	private readonly _config = injectHlmChartConfig();
+	private readonly _host = inject(ElementRef<HTMLElement>);
+	private readonly _document = inject(DOCUMENT);
+	private readonly _injector = inject(Injector);
+
+	public readonly id = input<string>(`hlm-chart-container-${++HlmChartContainer._id}`);
+
+	public readonly config = input<ChartConfig>(this._config);
+
+	constructor() {
+		classes(() => 'flex aspect-video justify-center text-xs');
+
+		afterNextRender(() => {
+			effect(
+				(onCleanup) => {
+					// Remove the previous style element before creating a new one.
+					// This is more reliable than relying solely on onCleanup, since
+					// the effect can re-run multiple times during initialization.
+					this._host.nativeElement.querySelector('style')?.remove();
+
+					const styleEl = this._document.createElement('style');
+					const chartId = this.id();
+					const colorConfig = Object.entries(this.config()).filter(
+						([, itemConfig]) => itemConfig.theme ?? itemConfig.color,
+					);
+
+					if (colorConfig.length) {
+						styleEl.textContent = (Object.entries(CHART_THEMES) as Array<[keyof typeof CHART_THEMES, string]>)
+							.map(([theme, prefix]) => {
+								const rules = colorConfig
+									.map(([key, itemConfig]) => {
+										const color = itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ?? itemConfig.color;
+										return color ? `  --color-${key}: ${color};` : null;
+									})
+									.filter(Boolean)
+									.join('\n');
+								return `${prefix} [data-chart="${chartId}"] {\n${rules}\n}`;
+							})
+							.join('\n');
+						this._host.nativeElement.append(styleEl);
+						onCleanup(() => styleEl.remove());
+					}
+				},
+				{ injector: this._injector },
+			);
+		});
+	}
+}

--- a/libs/helm/chart/src/lib/hlm-chart-container.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-container.ts
@@ -21,6 +21,10 @@ export class HlmChartContainer {
 
 	constructor() {
 		classes(() => 'flex aspect-video justify-center text-xs');
+		classes(() => [
+			'flex aspect-video justify-center text-xs',
+			"[&_.grid-layer_line[stroke='#ccc']]:stroke-border/50",
+		]);
 
 		afterNextRender(() => {
 			effect(

--- a/libs/helm/chart/src/lib/hlm-chart-legend-content.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-legend-content.ts
@@ -1,0 +1,58 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { NgIcon } from '@ng-icons/core';
+import { classes } from '@spartan-ng/helm/utils';
+import { ChartConfig, injectHlmChartConfig } from './hlm-chart.token';
+
+/**
+ * Default shadcn-styled chart legend content.
+ * Derives legend items directly from the chart config.
+ *
+ * @example
+ * ```html
+ * <hlm-chart-legend-content />
+ * ```
+ */
+@Component({
+	selector: 'hlm-chart-legend-content',
+	imports: [NgIcon],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: { '[attr.data-align]': 'verticalAlign()' },
+	template: `
+		@for (item of _items(); track item.key) {
+			<div class="[&>ng-icon]:text-muted-foreground flex items-center gap-1.5 [&>ng-icon]:text-[length:--spacing(3)]">
+				@if (item.icon && !hideIcon()) {
+					<ng-icon [name]="item.icon" />
+				} @else {
+					<div class="h-2 w-2 shrink-0 rounded-xs bg-(--color-bg)" [style.--color-bg]="item.color"></div>
+				}
+				<span class="text-foreground text-xs leading-none">{{ item.label }}</span>
+			</div>
+		}
+	`,
+})
+export class HlmChartLegendContent {
+	private readonly _config = injectHlmChartConfig();
+
+	/** Override the injected chart config. */
+	public readonly config = input<ChartConfig>(this._config);
+
+	public readonly verticalAlign = input<'top' | 'bottom'>('bottom');
+
+	/** Whether to hide the icon from the config. */
+	public readonly hideIcon = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
+
+	protected readonly _items = computed(() => {
+		const config = this.config();
+		return Object.entries(config).map(([key, itemConfig]) => ({
+			key,
+			label: itemConfig.label ?? key,
+			icon: itemConfig.icon,
+			color: `var(--color-${key})`,
+		}));
+	});
+
+	constructor() {
+		classes(() => 'flex items-center justify-center gap-4 data-[align=bottom]:pt-3 data-[align=top]:pb-3');
+	}
+}

--- a/libs/helm/chart/src/lib/hlm-chart-legend-content.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-legend-content.ts
@@ -1,8 +1,8 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { NgIcon } from '@ng-icons/core';
 import { classes } from '@spartan-ng/helm/utils';
-import { ChartConfig, injectHlmChartConfig } from './hlm-chart.token';
+import { HlmChartContainer } from './hlm-chart-container';
 
 /**
  * Default shadcn-styled chart legend content.
@@ -32,10 +32,7 @@ import { ChartConfig, injectHlmChartConfig } from './hlm-chart.token';
 	`,
 })
 export class HlmChartLegendContent {
-	private readonly _config = injectHlmChartConfig();
-
-	/** Override the injected chart config. */
-	public readonly config = input<ChartConfig>(this._config);
+	private readonly _chartContainer = inject(HlmChartContainer);
 
 	public readonly verticalAlign = input<'top' | 'bottom'>('bottom');
 
@@ -43,7 +40,7 @@ export class HlmChartLegendContent {
 	public readonly hideIcon = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 
 	protected readonly _items = computed(() => {
-		const config = this.config();
+		const config = this._chartContainer.config();
 		return Object.entries(config).map(([key, itemConfig]) => ({
 			key,
 			label: itemConfig.label ?? key,

--- a/libs/helm/chart/src/lib/hlm-chart-tooltip-content.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-tooltip-content.ts
@@ -32,8 +32,8 @@ export interface HlmChartTooltipItemContext {
  */
 @Component({
 	selector: 'hlm-chart-tooltip-content',
-	changeDetection: ChangeDetectionStrategy.OnPush,
 	imports: [NgIcon, NgTemplateOutlet],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		@if (_tooltipLabel(); as label) {
 			<div class="font-medium">{{ label }}</div>
@@ -59,7 +59,7 @@ export interface HlmChartTooltipItemContext {
 						}
 						<div class="flex flex-1 items-center justify-between leading-none">
 							<span class="text-muted-foreground">{{ item.label ?? item.name }}</span>
-							@if (item.value != null) {
+							@if (item.value !== null) {
 								<span class="text-foreground font-mono font-medium tabular-nums">{{ item.value }}</span>
 							}
 						</div>

--- a/libs/helm/chart/src/lib/hlm-chart-tooltip-content.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-tooltip-content.ts
@@ -1,10 +1,19 @@
 import { BooleanInput } from '@angular/cdk/coercion';
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, TemplateRef } from '@angular/core';
+import {
+	booleanAttribute,
+	ChangeDetectionStrategy,
+	Component,
+	computed,
+	inject,
+	input,
+	TemplateRef,
+} from '@angular/core';
 import { NgIcon } from '@ng-icons/core';
 import type { DataKey, TooltipState } from '@spartan-ng/charts';
 import { classes } from '@spartan-ng/helm/utils';
-import { ChartConfig, getPayloadConfigFromPayload, injectHlmChartConfig } from './hlm-chart.token';
+import { HlmChartContainer } from './hlm-chart-container';
+import { getPayloadConfigFromPayload } from './hlm-chart.token';
 
 /** Context provided to the custom item template. */
 export interface HlmChartTooltipItemContext {
@@ -70,11 +79,9 @@ export interface HlmChartTooltipItemContext {
 	`,
 })
 export class HlmChartTooltipContent {
-	private readonly _config = injectHlmChartConfig();
+	private readonly _chartContainer = inject(HlmChartContainer);
 
 	public readonly state = input.required<TooltipState>();
-
-	public readonly config = input<ChartConfig>(this._config);
 
 	public readonly hideLabel = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 	public readonly hideIndicator = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
@@ -89,7 +96,7 @@ export class HlmChartTooltipContent {
 		input<TemplateRef<{ $implicit: HlmChartTooltipItemContext; index: number; first: boolean; last: boolean }>>();
 
 	protected readonly _items = computed(() => {
-		const config = this.config();
+		const config = this._chartContainer.config();
 		return this.state().payload.map((item) => {
 			const key = `${item.dataKey ?? item.name ?? 'value'}`;
 			const itemConfig = getPayloadConfigFromPayload(config, item, key);
@@ -111,7 +118,7 @@ export class HlmChartTooltipContent {
 		if (labelKey === undefined || labelKey === null || labelKey === '') {
 			value = stateLabel;
 		} else {
-			const itemConfig = this.config()[labelKey];
+			const itemConfig = this._chartContainer.config()[labelKey];
 			value = itemConfig?.label ?? stateLabel;
 		}
 

--- a/libs/helm/chart/src/lib/hlm-chart-tooltip-content.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-tooltip-content.ts
@@ -4,7 +4,7 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, 
 import { NgIcon } from '@ng-icons/core';
 import type { DataKey, TooltipState } from '@spartan-ng/charts';
 import { classes } from '@spartan-ng/helm/utils';
-import { ChartConfig, injectHlmChartConfig } from './hlm-chart.token';
+import { ChartConfig, getPayloadConfigFromPayload, injectHlmChartConfig } from './hlm-chart.token';
 
 /** Context provided to the custom item template. */
 export interface HlmChartTooltipItemContext {
@@ -122,39 +122,4 @@ export class HlmChartTooltipContent {
 	constructor() {
 		classes(() => 'spartan-chart-tooltip grid min-w-32 items-start');
 	}
-}
-
-function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
-	if (typeof payload !== 'object' || payload === null) {
-		return undefined;
-	}
-
-	const payloadPayload =
-		'payload' in payload && typeof payload.payload === 'object' && payload.payload !== null
-			? payload.payload
-			: undefined;
-
-	let configLabelKey: string = key;
-
-	if (key in payload && typeof payload[key as keyof typeof payload] === 'string') {
-		configLabelKey = payload[key as keyof typeof payload] as string;
-	} else if (
-		payloadPayload &&
-		key in payloadPayload &&
-		typeof payloadPayload[key as keyof typeof payloadPayload] === 'string'
-	) {
-		configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
-	}
-
-	if (configLabelKey in config) {
-		return config[configLabelKey];
-	}
-
-	// Fallback: try to find a config entry whose label matches the key
-	const labelMatchKey = Object.keys(config).find((k) => config[k]?.label === key);
-	if (labelMatchKey !== undefined) {
-		return config[labelMatchKey];
-	}
-
-	return config[key];
 }

--- a/libs/helm/chart/src/lib/hlm-chart-tooltip-content.ts
+++ b/libs/helm/chart/src/lib/hlm-chart-tooltip-content.ts
@@ -3,7 +3,7 @@ import { NgTemplateOutlet } from '@angular/common';
 import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, TemplateRef } from '@angular/core';
 import { NgIcon } from '@ng-icons/core';
 import type { DataKey, TooltipState } from '@spartan-ng/charts';
-import { classes } from '<%- importAlias %>/utils';
+import { classes } from '@spartan-ng/helm/utils';
 import { ChartConfig, injectHlmChartConfig } from './hlm-chart.token';
 
 /** Context provided to the custom item template. */

--- a/libs/helm/chart/src/lib/hlm-chart.token.ts
+++ b/libs/helm/chart/src/lib/hlm-chart.token.ts
@@ -1,4 +1,4 @@
-import { inject, InjectionToken, ValueProvider } from '@angular/core';
+import { inject, InjectionToken, type ValueProvider } from '@angular/core';
 
 export const CHART_THEMES = { light: '', dark: '.dark' } as const;
 

--- a/libs/helm/chart/src/lib/hlm-chart.token.ts
+++ b/libs/helm/chart/src/lib/hlm-chart.token.ts
@@ -21,3 +21,38 @@ export function provideHlmChartConfig(config: Partial<ChartConfig>): ValueProvid
 export function injectHlmChartConfig(): ChartConfig {
 	return inject(ChartConfigToken, { optional: true }) ?? defaultConfig;
 }
+
+export function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
+	if (typeof payload !== 'object' || payload === null) {
+		return undefined;
+	}
+
+	const payloadPayload =
+		'payload' in payload && typeof payload.payload === 'object' && payload.payload !== null
+			? payload.payload
+			: undefined;
+
+	let configLabelKey: string = key;
+
+	if (key in payload && typeof payload[key as keyof typeof payload] === 'string') {
+		configLabelKey = payload[key as keyof typeof payload] as string;
+	} else if (
+		payloadPayload &&
+		key in payloadPayload &&
+		typeof payloadPayload[key as keyof typeof payloadPayload] === 'string'
+	) {
+		configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
+	}
+
+	if (configLabelKey in config) {
+		return config[configLabelKey];
+	}
+
+	// Fallback: try to find a config entry whose label matches the key
+	const labelMatchKey = Object.keys(config).find((k) => config[k]?.label === key);
+	if (labelMatchKey !== undefined) {
+		return config[labelMatchKey];
+	}
+
+	return config[key];
+}

--- a/libs/helm/chart/src/lib/hlm-chart.token.ts
+++ b/libs/helm/chart/src/lib/hlm-chart.token.ts
@@ -1,0 +1,23 @@
+import { inject, InjectionToken, ValueProvider } from '@angular/core';
+
+export const CHART_THEMES = { light: '', dark: '.dark' } as const;
+
+export type ChartConfig = Record<
+	string,
+	{
+		label?: string;
+		icon?: string;
+	} & ({ color?: string; theme?: never } | { color?: never; theme: Record<keyof typeof CHART_THEMES, string> })
+>;
+
+const defaultConfig: ChartConfig = {};
+
+const ChartConfigToken = new InjectionToken<ChartConfig>('ChartConfig');
+
+export function provideHlmChartConfig(config: Partial<ChartConfig>): ValueProvider {
+	return { provide: ChartConfigToken, useValue: { ...defaultConfig, ...config } };
+}
+
+export function injectHlmChartConfig(): ChartConfig {
+	return inject(ChartConfigToken, { optional: true }) ?? defaultConfig;
+}

--- a/libs/helm/package.json
+++ b/libs/helm/package.json
@@ -12,6 +12,7 @@
 		"@ng-icons/core": ">=32.0.0 <34.0.0",
 		"@ng-icons/lucide": ">=32.0.0 <34.0.0",
 		"@spartan-ng/brain": "1.0.2",
+		"@spartan-ng/charts": "1.0.0-alpha.0",
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
 		"embla-carousel": ">=8.0.0 <9.0.0",

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -1220,11 +1220,6 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
       "HlmChartLegendContent": {
         "inputs": [
           {
-            "name": "config",
-            "required": false,
-            "type": "ChartConfig",
-          },
-          {
             "name": "verticalAlign",
             "required": false,
             "type": "'top' | 'bottom'",
@@ -1245,11 +1240,6 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "name": "state",
             "required": true,
             "type": "TooltipState",
-          },
-          {
-            "name": "config",
-            "required": false,
-            "type": "ChartConfig",
           },
           {
             "name": "hideLabel",

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -1217,6 +1217,28 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
         "outputs": [],
         "selector": "[hlmChartContainer],hlm-chart-container",
       },
+      "HlmChartLegendContent": {
+        "inputs": [
+          {
+            "name": "config",
+            "required": false,
+            "type": "ChartConfig",
+          },
+          {
+            "name": "verticalAlign",
+            "required": false,
+            "type": "'top' | 'bottom'",
+          },
+          {
+            "name": "hideIcon",
+            "required": false,
+            "type": "boolean",
+          },
+        ],
+        "models": [],
+        "outputs": [],
+        "selector": "hlm-chart-legend-content",
+      },
       "HlmChartTooltipContent": {
         "inputs": [
           {

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -1198,6 +1198,74 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
       },
     },
   },
+  "chart": {
+    "helm": {
+      "HlmChartContainer": {
+        "inputs": [
+          {
+            "name": "id",
+            "required": false,
+            "type": "string",
+          },
+          {
+            "name": "config",
+            "required": false,
+            "type": "ChartConfig",
+          },
+        ],
+        "models": [],
+        "outputs": [],
+        "selector": "[hlmChartContainer],hlm-chart-container",
+      },
+      "HlmChartTooltipContent": {
+        "inputs": [
+          {
+            "name": "state",
+            "required": true,
+            "type": "TooltipState",
+          },
+          {
+            "name": "config",
+            "required": false,
+            "type": "ChartConfig",
+          },
+          {
+            "name": "hideLabel",
+            "required": false,
+            "type": "boolean",
+          },
+          {
+            "name": "hideIndicator",
+            "required": false,
+            "type": "boolean",
+          },
+          {
+            "name": "labelKey",
+            "required": false,
+            "type": "string",
+          },
+          {
+            "name": "labelFormatter",
+            "required": false,
+            "type": "(value: unknown) => string",
+          },
+          {
+            "name": "indicator",
+            "required": false,
+            "type": "'line' | 'dot' | 'dashed'",
+          },
+          {
+            "name": "itemTemplate",
+            "required": false,
+            "type": "TemplateRef<{ $implicit: HlmChartTooltipItemContext; index: number; first: boolean; last: boolean }>",
+          },
+        ],
+        "models": [],
+        "outputs": [],
+        "selector": "hlm-chart-tooltip-content",
+      },
+    },
+  },
   "checkbox": {
     "brain": {
       "BrnCheckbox": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -91,6 +91,7 @@
 			"@spartan-ng/helm/calendar": ["libs/helm/calendar/src/index.ts"],
 			"@spartan-ng/helm/card": ["libs/helm/card/src/index.ts"],
 			"@spartan-ng/helm/carousel": ["libs/helm/carousel/src/index.ts"],
+			"@spartan-ng/helm/chart": ["./libs/helm/chart/src/index.ts"],
 			"@spartan-ng/helm/checkbox": ["libs/helm/checkbox/src/index.ts"],
 			"@spartan-ng/helm/collapsible": ["libs/helm/collapsible/src/index.ts"],
 			"@spartan-ng/helm/combobox": ["libs/helm/combobox/src/index.ts"],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] chart

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the new behavior?

Add a helm chart primitive for 

- HlmChartContainer
- HlmChartTooltipContent
- HlmChartLegendContent
- render bar scales without axis


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable Helm chart container plus shared tooltip and legend content components for consistent chart UI.
  * Introduced a chart configuration system to control per-series labels, colors, and optional icons.
  * Updated chart demos/tooltips to use the shared container and tooltip content, including new axis examples.
  * Added a Storybook story for the chart container.

* **Bug Fixes**
  * Improved bar chart default scale/category handling.
  * Adjusted default grid dash behavior and made dashed rendering conditional when set.
  * Refined SVG axis styling to apply stroke/fill correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->