### PR TITLE
ci: push contributors update via release app to bypass main ruleset

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -11,10 +11,20 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Mint a short-lived token from the release GitHub App. It is a bypass actor on the branch
+      # ruleset, so the contributors commit can push straight to main even though PRs are required.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:
           # Full history is required to derive contributor usernames from git log.
           fetch-depth: 0
+          # Persist the app token as the push credential so add-and-commit pushes as the bypass actor.
+          token: ${{ steps.app-token.outputs.token }}
       - name: Install pnpm
         uses: pnpm/action-setup@v5
       - name: Install Node

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -5,26 +5,31 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+# Read-only by default: the checkout + contributors API only need read. The push is done with a
+# scoped GitHub App token minted below, not the default token.
+permissions:
+  contents: read
+
 jobs:
   update-contributors:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       # Mint a short-lived token from the release GitHub App. It is a bypass actor on the branch
       # ruleset, so the contributors commit can push straight to main even though PRs are required.
+      # Scoped to contents:write - the only permission the push path needs.
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
       - uses: actions/checkout@v6
         with:
           # Full history is required to derive contributor usernames from git log.
           fetch-depth: 0
-          # Persist the app token as the push credential so add-and-commit pushes as the bypass actor.
-          token: ${{ steps.app-token.outputs.token }}
+          # Keep the App token out of .git/config; it's applied inline only at push time below.
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@v5
       - name: Install Node
@@ -39,10 +44,19 @@ jobs:
           # Lets the generator enhance git history with the GitHub contributors API.
           GH_TOKEN: ${{ github.token }}
         run: pnpm update-contributors
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          author_name: Leonidas
-          author_email: leonidas@spartan.ng
-          message: 'chore: add new contributors to our 300'
-          add: "README.md 'apps/app/src/app/pages/(home)/components/three-hundred.ts'"
+      - name: Commit and push changes
+        env:
+          # Bypass-actor token, used only for the push on the last line.
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          files=(README.md 'apps/app/src/app/pages/(home)/components/three-hundred.ts')
+          if git diff --quiet -- "${files[@]}"; then
+            echo 'No new contributors to commit.'
+            exit 0
+          fi
+          git config user.name Leonidas
+          git config user.email leonidas@spartan.ng
+          git add "${files[@]}"
+          # docs: is a non-releasing type, so pushing to main does not trigger semantic-release.
+          git commit -m 'docs: add new contributors to our 300'
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [x] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

The scheduled `update-contributors` workflow commits with the default
`github.token` and pushes straight to `main`. Since `main` requires changes to go
through a PR and `github.token` is not a bypass actor on the branch ruleset, the
push is rejected:

```
remote: - Changes must be made through a pull request.
error: failed to push some refs to 'https://github.com/spartan-ng/spartan'
```

So the daily contributors update never lands.

## What is the new behavior?

Mint a short-lived token from the same GitHub App that `release.yml` uses (it is a
bypass actor on the ruleset) and check out with it, so `add-and-commit` pushes as
the bypass actor and the commit is accepted. The commit message is switched to a
`docs:` type so the resulting push to `main` computes "no release" and never
triggers semantic-release.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Reuses the existing `APP_ID` / `APP_PRIVATE_KEY` secrets — no new secrets needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the contributor automation to use a short-lived GitHub App token for repository access.
  * Improved the checkout and push flow to avoid credential persistence and ensure reliable targeting of the main branch.
  * Replaced the previous commit-and-push approach with a streamlined inline commit and HTTPS push process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->