### PR TITLE
fix(tooltip): keep the arrow pointing at the trigger at viewport edges

### DIFF
--- a/libs/brain/tooltip/src/lib/brn-tooltip-arrow.spec.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-arrow.spec.ts
@@ -1,0 +1,74 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
+import { BrnTooltip } from './brn-tooltip';
+
+// A trigger pinned to the top-left corner with a large tooltip: 'top' is off-screen and the
+// left/right sides can't fit the tall panel, so CDK keeps 'bottom' and *pushes* it right to stay in
+// the viewport. That push is what knocks a center-anchored arrow off the trigger (issue #1247).
+@Component({
+	selector: 'brn-tooltip-arrow-host',
+	imports: [BrnTooltip],
+	providers: [Directionality],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<button
+			brnTooltip="tip"
+			position="bottom"
+			[showDelay]="0"
+			[hideDelay]="0"
+			style="position: fixed; top: 0; left: 0; width: 40px; height: 24px"
+		>
+			trigger
+		</button>
+	`,
+})
+class TooltipArrowHost {}
+
+const triggerEl = () => screen.getByText('trigger');
+const tooltipEl = () => document.querySelector<HTMLElement>('[role="tooltip"]');
+const arrowEl = () => tooltipEl()?.querySelector<HTMLElement>('span') ?? null;
+const centerX = (el: Element) => {
+	const rect = el.getBoundingClientRect();
+	return rect.left + rect.width / 2;
+};
+
+describe('BrnTooltip arrow anchoring (#1247)', () => {
+	let style: HTMLStyleElement;
+
+	beforeEach(() => {
+		// Tailwind utilities aren't loaded in unit tests, so stand in the geometry the arrow relies on
+		// in production: a fixed-size panel with the arrow absolutely centered on it. The directive's
+		// job under test is to slide that centered arrow back onto the trigger after a push.
+		style = document.createElement('style');
+		style.textContent = `
+			[role='tooltip'] { position: relative; box-sizing: border-box; width: 120px; height: 480px; }
+			[role='tooltip'] > span { position: absolute; top: 0; left: calc(50% - 5px); display: block; width: 10px; height: 10px; }
+		`;
+		document.head.appendChild(style);
+	});
+
+	afterEach(() => {
+		style.remove();
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	it('keeps the arrow pointing at the trigger when the tooltip is pushed into the viewport', async () => {
+		await render(TooltipArrowHost);
+
+		fireEvent.mouseEnter(triggerEl());
+		await waitFor(() => expect(tooltipEl()).toBeTruthy());
+
+		const tooltip = tooltipEl() as HTMLElement;
+		// Preconditions: the scenario must be a horizontal push, not a flip. If CDK behaved differently
+		// in this environment these fail loudly rather than letting the real assertion pass by accident.
+		expect(tooltip.getAttribute('data-side')).toBe('bottom');
+		expect(tooltip.getBoundingClientRect().left).toBeGreaterThanOrEqual(0);
+
+		// The tooltip is pushed, so its center is well to the right of the trigger's center...
+		expect(centerX(tooltip) - centerX(triggerEl())).toBeGreaterThan(20);
+
+		// ...but the arrow must still sit over the trigger's center.
+		await waitFor(() => expect(Math.abs(centerX(arrowEl() as Element) - centerX(triggerEl()))).toBeLessThanOrEqual(2));
+	});
+});

--- a/libs/brain/tooltip/src/lib/brn-tooltip-arrow.spec.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-arrow.spec.ts
@@ -25,13 +25,37 @@ import { BrnTooltip } from './brn-tooltip';
 })
 class TooltipArrowHost {}
 
+// A short tooltip on a tall trigger, centered mid-viewport (no edge, so no push). The arrow must stay
+// centered on the trigger; it must NOT be shoved to the panel edge (the bug from the initial
+// pre-positioning measurement).
+@Component({
+	selector: 'brn-tooltip-tall-host',
+	imports: [BrnTooltip],
+	providers: [Directionality],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<button
+			brnTooltip="tip"
+			position="right"
+			[showDelay]="0"
+			[hideDelay]="0"
+			style="position: fixed; top: 180px; left: 8px; width: 40px; height: 220px"
+		>
+			tall
+		</button>
+	`,
+})
+class TooltipTallTriggerHost {}
+
 const triggerEl = () => screen.getByText('trigger');
 const tooltipEl = () => document.querySelector<HTMLElement>('[role="tooltip"]');
 const arrowEl = () => tooltipEl()?.querySelector<HTMLElement>('span') ?? null;
-const centerX = (el: Element) => {
+const center = (el: Element, axis: 'x' | 'y') => {
 	const rect = el.getBoundingClientRect();
-	return rect.left + rect.width / 2;
+	return axis === 'x' ? rect.left + rect.width / 2 : rect.top + rect.height / 2;
 };
+const centerX = (el: Element) => center(el, 'x');
+const centerY = (el: Element) => center(el, 'y');
 
 describe('BrnTooltip arrow anchoring (#1247)', () => {
 	let style: HTMLStyleElement;
@@ -70,5 +94,26 @@ describe('BrnTooltip arrow anchoring (#1247)', () => {
 
 		// ...but the arrow must still sit over the trigger's center.
 		await waitFor(() => expect(Math.abs(centerX(arrowEl() as Element) - centerX(triggerEl()))).toBeLessThanOrEqual(2));
+	});
+
+	it('keeps a left/right arrow centered on a short tooltip over a tall, un-pushed trigger', async () => {
+		// A short tooltip whose arrow is centered vertically, like the real left/right arrow classes.
+		style.textContent = `
+			[role='tooltip'] { position: relative; box-sizing: border-box; width: 160px; height: 32px; }
+			[role='tooltip'] > span { position: absolute; left: 0; top: calc(50% - 5px); display: block; width: 10px; height: 10px; }
+		`;
+
+		await render(TooltipTallTriggerHost);
+
+		fireEvent.mouseEnter(screen.getByText('tall'));
+		await waitFor(() => expect(tooltipEl()).toBeTruthy());
+
+		const tooltip = tooltipEl() as HTMLElement;
+		// Centered on the trigger, mid-viewport: CDK does not push, so the arrow must stay centered.
+		expect(tooltip.getAttribute('data-side')).toBe('right');
+
+		// Let any post-open repositioning settle, then assert the arrow did not drift off-center.
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(Math.abs(centerY(arrowEl() as Element) - centerY(screen.getByText('tall')))).toBeLessThanOrEqual(2);
 	});
 });

--- a/libs/brain/tooltip/src/lib/brn-tooltip-content.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-content.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, input, signal } from '@angular/core';
 import { ClassValue } from 'clsx';
-import { BrnTooltipPosition } from './brn-tooltip-position';
+import { ArrowOffset, BrnTooltipPosition } from './brn-tooltip-position';
 import { BrnTooltipStringTemplateOutlet } from './brn-tooltip-string-template-outlet';
 import { BrnTooltipType } from './brn-tooltip-type';
 
@@ -37,7 +37,7 @@ export class BrnTooltipContent {
 	protected readonly _position = signal<BrnTooltipPosition>('top');
 	protected readonly _tooltipText = signal<BrnTooltipType>(null);
 	/** Applied as a margin so the arrow keeps pointing at the trigger after a viewport push (#1247). */
-	protected readonly _arrowOffset = signal<{ x: number; y: number }>({ x: 0, y: 0 });
+	protected readonly _arrowOffset = signal<ArrowOffset>({ x: 0, y: 0 });
 
 	public setProps(
 		tooltipText: BrnTooltipType,
@@ -56,7 +56,7 @@ export class BrnTooltipContent {
 		this._svgClass.set(svgClasses);
 	}
 
-	public setArrowOffset(offset: { x: number; y: number }): void {
+	public setArrowOffset(offset: ArrowOffset): void {
 		this._arrowOffset.set(offset);
 	}
 }

--- a/libs/brain/tooltip/src/lib/brn-tooltip-content.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-content.ts
@@ -19,7 +19,7 @@ let uniqueId = 0;
 	template: `
 		<ng-container *brnTooltipStringTemplateOutlet="_tooltipText()">{{ _tooltipText() }}</ng-container>
 
-		<span [class]="_arrowClass()">
+		<span [class]="_arrowClass()" [style.margin-left.px]="_arrowOffset().x" [style.margin-top.px]="_arrowOffset().y">
 			<svg [class]="_svgClass()" width="10" height="5" viewBox="0 0 30 10" preserveAspectRatio="none">
 				<polygon points="0,0 30,0 15,10" />
 			</svg>
@@ -36,6 +36,8 @@ export class BrnTooltipContent {
 
 	protected readonly _position = signal<BrnTooltipPosition>('top');
 	protected readonly _tooltipText = signal<BrnTooltipType>(null);
+	/** Applied as a margin so the arrow keeps pointing at the trigger after a viewport push (#1247). */
+	protected readonly _arrowOffset = signal<{ x: number; y: number }>({ x: 0, y: 0 });
 
 	public setProps(
 		tooltipText: BrnTooltipType,
@@ -52,5 +54,9 @@ export class BrnTooltipContent {
 		this._tooltipClass.set(tooltipClasses);
 		this._arrowClass.set(arrowClasses);
 		this._svgClass.set(svgClasses);
+	}
+
+	public setArrowOffset(offset: { x: number; y: number }): void {
+		this._arrowOffset.set(offset);
 	}
 }

--- a/libs/brain/tooltip/src/lib/brn-tooltip-position.spec.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-position.spec.ts
@@ -1,0 +1,55 @@
+import { getTooltipArrowOffset, resolveTooltipPosition, type TooltipRect } from './brn-tooltip-position';
+
+const rect = (partial: Partial<TooltipRect>): TooltipRect => ({ left: 0, top: 0, width: 0, height: 0, ...partial });
+
+describe('getTooltipArrowOffset', () => {
+	describe('top/bottom tooltips track on X', () => {
+		it('is zero when the tooltip is centered on the trigger', () => {
+			const trigger = rect({ left: 100, width: 40 }); // center 120
+			const tooltip = rect({ left: 60, width: 120 }); // center 120
+			expect(getTooltipArrowOffset(trigger, tooltip, 'top')).toEqual({ x: 0, y: 0 });
+		});
+
+		it('slides the arrow toward the trigger when the tooltip was pushed right', () => {
+			const trigger = rect({ left: 0, width: 40 }); // center 20
+			const tooltip = rect({ left: 8, width: 120 }); // center 68
+			// arrow must move -48 to sit over the trigger; well within the clamp so it lands exactly
+			expect(getTooltipArrowOffset(trigger, tooltip, 'bottom')).toEqual({ x: -48, y: 0 });
+		});
+
+		it('clamps so the arrow never leaves the tooltip', () => {
+			const trigger = rect({ left: 1000, width: 40 }); // far to the right
+			const tooltip = rect({ left: 0, width: 120 });
+			// max = 120/2 - 10/2 - 4 = 51
+			expect(getTooltipArrowOffset(trigger, tooltip, 'top')).toEqual({ x: 51, y: 0 });
+		});
+	});
+
+	describe('left/right tooltips track on Y', () => {
+		it('slides the arrow vertically toward the trigger', () => {
+			const trigger = rect({ top: 0, height: 40 }); // center 20
+			const tooltip = rect({ top: 8, height: 120 }); // center 68
+			expect(getTooltipArrowOffset(trigger, tooltip, 'right')).toEqual({ x: 0, y: -48 });
+		});
+
+		it('clamps on the Y axis', () => {
+			const trigger = rect({ top: -1000, height: 40 });
+			const tooltip = rect({ top: 0, height: 120 });
+			expect(getTooltipArrowOffset(trigger, tooltip, 'left')).toEqual({ x: 0, y: -51 });
+		});
+	});
+});
+
+describe('resolveTooltipPosition', () => {
+	it('maps a known CDK connection pair back to a position', () => {
+		expect(resolveTooltipPosition({ originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top' })).toBe(
+			'bottom',
+		);
+	});
+
+	it('returns null for an unknown pair', () => {
+		expect(
+			resolveTooltipPosition({ originX: 'start', originY: 'top', overlayX: 'end', overlayY: 'bottom' }),
+		).toBeNull();
+	});
+});

--- a/libs/brain/tooltip/src/lib/brn-tooltip-position.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-position.ts
@@ -41,6 +41,37 @@ export const BRN_TOOLTIP_FALLBACK_POSITIONS: Record<BrnTooltipPosition, BrnToolt
 	right: ['left', 'top', 'bottom'],
 };
 
+/** The fields we read off a `DOMRect`; broken out so the arrow math is unit-testable without the DOM. */
+export type TooltipRect = Pick<DOMRect, 'left' | 'top' | 'width' | 'height'>;
+
+/** Arrow is 10px across (see the arrow classes in helm's tooltip). */
+const ARROW_SIZE = 10;
+/** Keep the arrow this far clear of the tooltip's rounded corners. */
+const ARROW_EDGE_GAP = 4;
+
+/**
+ * How far to slide the arrow from the tooltip's center toward the trigger's center, so it keeps
+ * pointing at the trigger after CDK pushes an edge-anchored tooltip back into the viewport (#1247).
+ * Top/bottom tooltips track on X, left/right on Y. Clamped so the arrow stays within the tooltip.
+ */
+export function getTooltipArrowOffset(
+	triggerRect: TooltipRect,
+	tooltipRect: TooltipRect,
+	position: BrnTooltipPosition,
+): { x: number; y: number } {
+	if (position === 'top' || position === 'bottom') {
+		const delta = triggerRect.left + triggerRect.width / 2 - (tooltipRect.left + tooltipRect.width / 2);
+		return { x: clampArrowOffset(delta, tooltipRect.width), y: 0 };
+	}
+	const delta = triggerRect.top + triggerRect.height / 2 - (tooltipRect.top + tooltipRect.height / 2);
+	return { x: 0, y: clampArrowOffset(delta, tooltipRect.height) };
+}
+
+function clampArrowOffset(offset: number, tooltipExtent: number): number {
+	const max = Math.max(0, tooltipExtent / 2 - ARROW_SIZE / 2 - ARROW_EDGE_GAP);
+	return Math.min(Math.max(offset, -max), max);
+}
+
 /** Map a resolved CDK ConnectedPosition back to a BrnTooltipPosition, or null if no match. */
 export function resolveTooltipPosition(pair: ConnectedPosition): BrnTooltipPosition | null {
 	for (const [pos, config] of Object.entries(BRN_TOOLTIP_POSITIONS_MAP)) {

--- a/libs/brain/tooltip/src/lib/brn-tooltip-position.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip-position.ts
@@ -44,6 +44,9 @@ export const BRN_TOOLTIP_FALLBACK_POSITIONS: Record<BrnTooltipPosition, BrnToolt
 /** The fields we read off a `DOMRect`; broken out so the arrow math is unit-testable without the DOM. */
 export type TooltipRect = Pick<DOMRect, 'left' | 'top' | 'width' | 'height'>;
 
+/** Pixel offset applied to the arrow to slide it back onto the trigger. One axis is always zero. */
+export type ArrowOffset = { x: number; y: number };
+
 /** Arrow is 10px across (see the arrow classes in helm's tooltip). */
 const ARROW_SIZE = 10;
 /** Keep the arrow this far clear of the tooltip's rounded corners. */
@@ -58,7 +61,7 @@ export function getTooltipArrowOffset(
 	triggerRect: TooltipRect,
 	tooltipRect: TooltipRect,
 	position: BrnTooltipPosition,
-): { x: number; y: number } {
+): ArrowOffset {
 	if (position === 'top' || position === 'bottom') {
 		const delta = triggerRect.left + triggerRect.width / 2 - (tooltipRect.left + tooltipRect.width / 2);
 		return { x: clampArrowOffset(delta, tooltipRect.width), y: 0 };

--- a/libs/brain/tooltip/src/lib/brn-tooltip.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip.ts
@@ -263,9 +263,10 @@ export class BrnTooltip {
 			this._applyContentProps(this._componentRef.instance, this.position());
 		}
 
-		// Subscribe to position changes for the lifetime of the tooltip so that
-		// arrow direction and CSS classes stay in sync when the CDK flips the
-		// overlay (initial show, viewport resize, scroll, etc.).
+		// Subscribe to position changes for the lifetime of the tooltip so that arrow direction, CSS
+		// classes and the arrow offset stay in sync when CDK positions or flips the overlay (initial
+		// show, viewport resize, scroll, etc.). CDK emits the first event only after it has actually
+		// positioned the pane, so this - not the synchronous show path - is where the offset is measured.
 		const strategy = this._overlayRef?.getConfig().positionStrategy as FlexibleConnectedPositionStrategy | undefined;
 		if (strategy && this._componentRef) {
 			const compRef = this._componentRef;
@@ -273,10 +274,12 @@ export class BrnTooltip {
 				.pipe(takeUntilDestroyed(this._destroyRef))
 				.subscribe((change) => {
 					const resolved = resolveTooltipPosition(change.connectionPair);
+					// Skip unmappable pairs: without a resolved side we can't know the arrow's axis, and
+					// measuring against a stale one would offset the wrong way.
 					if (resolved) {
 						this._applyContentProps(compRef.instance, resolved, null);
+						this._updateArrowOffset();
 					}
-					this._updateArrowOffset();
 				});
 		}
 
@@ -290,7 +293,6 @@ export class BrnTooltip {
 				}
 			});
 		});
-		this._updateArrowOffset();
 		this.show.emit();
 	}
 

--- a/libs/brain/tooltip/src/lib/brn-tooltip.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip.ts
@@ -38,6 +38,7 @@ import {
 	BRN_TOOLTIP_FALLBACK_POSITIONS,
 	BRN_TOOLTIP_POSITIONS_MAP,
 	BrnTooltipPosition,
+	getTooltipArrowOffset,
 	resolveTooltipPosition,
 } from './brn-tooltip-position';
 import { BrnTooltipType } from './brn-tooltip-type';
@@ -244,6 +245,7 @@ export class BrnTooltip {
 				// Re-apply props so a programmatic text change during the close is reflected on revive.
 				// Keep the live (possibly flipped) position rather than resetting to the raw input.
 				this._applyContentProps(this._componentRef.instance, this._activePosition ?? this.position());
+				this._updateArrowOffset();
 				this._group?.onOpen();
 				this.show.emit();
 			}
@@ -274,6 +276,7 @@ export class BrnTooltip {
 					if (resolved) {
 						this._applyContentProps(compRef.instance, resolved, null);
 					}
+					this._updateArrowOffset();
 				});
 		}
 
@@ -287,6 +290,7 @@ export class BrnTooltip {
 				}
 			});
 		});
+		this._updateArrowOffset();
 		this.show.emit();
 	}
 
@@ -305,6 +309,16 @@ export class BrnTooltip {
 			this._config.arrowClasses(position),
 			this._config.svgClasses,
 		);
+	}
+
+	/** Slide the arrow back onto the trigger after CDK has positioned (and possibly pushed) the tooltip. */
+	private _updateArrowOffset(): void {
+		const content = this._componentRef?.instance;
+		const tooltipElement = this._componentRef?.location.nativeElement as HTMLElement | undefined;
+		if (!content || !tooltipElement) return;
+		const triggerRect = this._elementRef.nativeElement.getBoundingClientRect();
+		const tooltipRect = tooltipElement.getBoundingClientRect();
+		content.setArrowOffset(getTooltipArrowOffset(triggerRect, tooltipRect, this._activePosition ?? this.position()));
 	}
 
 	private _hide(): void {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] tooltip

## What is the current behavior?

Closes #1247

When a tooltip trigger sits near a viewport edge, CDK pushes the tooltip back
into the viewport along the cross axis so it stays fully visible. The arrow,
however, is a statically centered element on the panel — it has no knowledge of
the push — so after the shift it points into empty space beside the trigger
instead of at it.

This is a structural gap in the CDK approach: CDK has no arrow concept and
exposes no "how far did I push" value, so the arrow could never follow the
trigger on its own.

## What is the new behavior?

The arrow now tracks the trigger. We compute the delta between the trigger's
center and the panel's center from their bounding rects and slide the arrow by
that amount (clamped so it can't leave the panel) — the manual equivalent of
Floating UI's `arrow` middleware, which is what Radix relies on.

- Top/bottom tooltips track on the X axis, left/right on the Y axis.
- The geometry is a pure helper (`getTooltipArrowOffset`) in the position
  module, unit-tested for tracking and clamping on both axes.
- The directive applies it as a margin on show and on every CDK position
  change, so it survives flips, scroll and resize.
- Applied as a margin so it does not clobber the arrow's existing
  rotate/translate transform.

### Tests

- `brn-tooltip-arrow.spec.ts` — real-browser reproduction: a corner-anchored
  trigger forces a horizontal push and asserts the arrow still sits over the
  trigger's center (fails on `main`, passes here).
- `brn-tooltip-position.spec.ts` — pure unit coverage of the offset + clamp math.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Scoped deliberately to the arrow-anchoring bug (#1247). The dynamic-text bug
(#1566) and mobile-viewport positioning (#1582) are tracked in their own PRs
(#1581, #1590).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip arrow alignment when a tooltip is pushed to stay within the viewport.
  * Tooltips now keep the arrow centered on the trigger more reliably after repositioning.
  * Added coverage for arrow placement and tooltip position behavior to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->