### PR TITLE
fix(tabs): correct display of the buttons #1601

### DIFF
--- a/libs/helm/tabs/src/lib/hlm-tabs-paginated-list.ts
+++ b/libs/helm/tabs/src/lib/hlm-tabs-paginated-list.ts
@@ -33,8 +33,6 @@ import { listVariants } from './hlm-tabs-list';
 			type="button"
 			aria-hidden="true"
 			tabindex="-1"
-			[class.flex]="showPaginationControls()"
-			[class.hidden]="!showPaginationControls()"
 			[class]="_paginationButtonClass()"
 			[disabled]="disableScrollBefore || null"
 			(click)="_handlePaginatorClick('before')"
@@ -58,8 +56,6 @@ import { listVariants } from './hlm-tabs-list';
 			type="button"
 			aria-hidden="true"
 			tabindex="-1"
-			[class.flex]="showPaginationControls()"
-			[class.hidden]="!showPaginationControls()"
 			[class]="_paginationButtonClass()"
 			[disabled]="disableScrollAfter || null"
 			(click)="_handlePaginatorClick('after')"
@@ -95,6 +91,7 @@ export class HlmTabsPaginatedList extends BrnTabsPaginatedList {
 			'relative z-[2] select-none disabled:cursor-default',
 			buttonVariants({ variant: 'ghost', size: 'icon-sm' }),
 			this.paginationButtonClass(),
+			this.showPaginationControls() ? 'inline-flex' : 'hidden',
 		),
 	);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [x] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1601 

## What is the new behavior?

Fixed. The buttons stay in the DOM (needed by the viewChild.required paginator refs and the brain's touch-event bindings) but are now reliably hidden via the correct classes when showPaginationControls() is false, which overrides the inline-flex coming from buttonVariants.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for pagination controls in tabs component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->