### PR TITLE
fix(dialog): forward generic result type through HlmDialogService.open

### DIFF
--- a/libs/helm/dialog/src/lib/hlm-dialog.service.spec.ts
+++ b/libs/helm/dialog/src/lib/hlm-dialog.service.spec.ts
@@ -1,0 +1,46 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { BrnDialogRef } from '@spartan-ng/brain/dialog';
+import { render } from '@testing-library/angular';
+import type { Observable } from 'rxjs';
+import { HlmDialogService } from './hlm-dialog.service';
+
+type SelectedUser = { id: number; name: string };
+type UserDialogData = { users: SelectedUser[] };
+
+@Component({
+	selector: 'hlm-dialog-service-host',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: '',
+})
+class DialogServiceHost {
+	public readonly service = inject(HlmDialogService);
+}
+
+@Component({
+	selector: 'hlm-dialog-service-content',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<span data-testid="content">content</span>
+	`,
+})
+class DialogServiceContent {}
+
+describe('HlmDialogService typed open()', () => {
+	afterEach(() => {
+		document.querySelectorAll('.cdk-overlay-container').forEach((el) => el.remove());
+	});
+
+	it('returns a BrnDialogRef whose result type follows open<TResult>()', async () => {
+		const view = await render(DialogServiceHost);
+		const { service } = view.fixture.componentInstance;
+
+		const dialogRef = service.open<SelectedUser, UserDialogData>(DialogServiceContent, {
+			context: { users: [{ id: 1, name: 'Ada' }] },
+		});
+
+		const closed$: Observable<SelectedUser | undefined> = dialogRef.closed$;
+
+		expect(dialogRef).toBeInstanceOf(BrnDialogRef);
+		expect(closed$).toBeDefined();
+	});
+});

--- a/libs/helm/dialog/src/lib/hlm-dialog.service.ts
+++ b/libs/helm/dialog/src/lib/hlm-dialog.service.ts
@@ -1,6 +1,11 @@
 import type { ComponentType } from '@angular/cdk/portal';
 import { inject, Injectable, type TemplateRef } from '@angular/core';
-import { type BrnDialogOptions, BrnDialogService, cssClassesToArray } from '@spartan-ng/brain/dialog';
+import {
+	type BrnDialogOptions,
+	type BrnDialogRef,
+	BrnDialogService,
+	cssClassesToArray,
+} from '@spartan-ng/brain/dialog';
 import { HlmDialogContent } from './hlm-dialog-content';
 import { hlmDialogOverlayClass } from './hlm-dialog-overlay';
 
@@ -16,7 +21,10 @@ export type HlmDialogOptions<DialogContext = unknown> = BrnDialogOptions & {
 export class HlmDialogService {
 	private readonly _brnDialogService = inject(BrnDialogService);
 
-	public open(component: ComponentType<unknown> | TemplateRef<unknown>, options?: Partial<HlmDialogOptions>) {
+	public open<TResult = unknown, TContext = unknown>(
+		component: ComponentType<unknown> | TemplateRef<unknown>,
+		options?: Partial<HlmDialogOptions<TContext>>,
+	): BrnDialogRef<TResult> {
 		const mergedOptions = {
 			...(options ?? {}),
 			backdropClass: cssClassesToArray(`${hlmDialogOverlayClass} ${options?.backdropClass ?? ''}`),
@@ -28,6 +36,11 @@ export class HlmDialogService {
 			},
 		};
 
-		return this._brnDialogService.open(HlmDialogContent, undefined, mergedOptions.context, mergedOptions);
+		return this._brnDialogService.open<unknown, TResult>(
+			HlmDialogContent,
+			undefined,
+			mergedOptions.context,
+			mergedOptions,
+		);
 	}
 }


### PR DESCRIPTION
BrnDialogService.open exposes a DialogResult generic, but HlmDialogService.open dropped it, forcing callers to cast closed$. Forward it via open<TResult, TContext>; both default to unknown so existing calls are unaffected.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] dialog

## What is the current behavior?

`HlmDialogService.open()` is not generic over the dialog result. Although
`BrnDialogService.open<DialogContext, DialogResult>()` returns `BrnDialogRef<DialogResult>`,
the helm wrapper drops that generic — so every call resolves to `BrnDialogRef<unknown>` and
consumers must cast `closed$` to recover the result type.

## What is the new behavior?

`HlmDialogService.open<TResult = unknown, TContext = unknown>()` now returns
`BrnDialogRef<TResult>` and forwards the result type to
`BrnDialogService.open<unknown, TResult>(...)`.

- Callers type the result at the call site — `open<User>(cmp, { ... })` — and `closed$` is
  `Observable<User | undefined>` with no cast.
- `TContext` types the `context` option.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Both generics default to `unknown`, so existing `open(cmp, { ... })` calls are unchanged — no
runtime change and no new API surface, purely additive typing.

## Other information

Adds `hlm-dialog.service.spec.ts` covering the typed `open()` → `closed$` contract. The helm
API docs are generated from the source signature, so no manual docs change was needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog opening so result and context types are preserved more reliably when using the dialog service.
  * Added better handling for dialog options passed into the service.

* **Tests**
  * Added coverage for the dialog service’s typed `open()` behavior.
  * Included cleanup to avoid leftover overlay elements during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->