### PR TITLE
ci: guard release commits by chore(release) prefix instead of the skip-ci token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
         run: pnpm nx affected -t test --parallel=3
 
   e2e:
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     # Not gated on `build`: the e2e suite runs cypress against storybook (its cypress executor's
     # devServerTarget is ui-storybook:static-storybook), so it builds/serves storybook itself and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ env:
 
 jobs:
   commitlint:
+    # Skip release commits pushed to main (already validated during the release), but always run on
+    # pull_request so this required check reports and never blocks a promotion/sync PR whose tip is a
+    # `chore(release):` commit. Replaces the old `[skip ci]` token, which skipped PR checks too.
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -40,6 +44,7 @@ jobs:
           helpURL: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
 
   format-and-lint:
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -57,6 +62,7 @@ jobs:
         run: pnpm nx affected -t lint --parallel=3
 
   build:
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -68,6 +74,7 @@ jobs:
         run: pnpm nx affected -t build --parallel=1
 
   unit:
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     # No longer gated on `build`: vitest runs against source, so unit tests start immediately and
     # run in parallel with the build instead of waiting ~13 min for it.

--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -27,6 +27,9 @@ concurrency:
 
 jobs:
   setup-matrix:
+    # Skip release commits pushed to main; always run on pull_request so `cli-smoke result` reports
+    # (a `[skip ci]` token would skip the whole workflow, leaving the required check pending forever).
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     strategy:
       # Don't cancel the other cells when one fails - we want the full picture of which setups broke.
@@ -84,6 +87,7 @@ jobs:
     # Runs in parallel with the cells (does not delay them). Fails if matrix.ts declares a cell that the
     # static matrix above does not cover, so the hardcoded list cannot silently go stale. Only the matrix
     # source or this workflow can introduce drift, so it installs only when one of those changed.
+    if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -121,7 +125,9 @@ jobs:
     # don't affect the CLI (every cell short-circuits to a pass).
     name: cli-smoke result
     needs: [setup-matrix, drift-guard]
-    if: always()
+    # always() so it still reports when cells short-circuit, but carry the same release-commit guard so
+    # it isn't left evaluating skipped needs into a failure on a `chore(release):` push to main.
+    if: ${{ always() && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Verify all cells and the drift guard passed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
   # release on both. This mirrors .github/workflows/cli-smoke.yml so the release isn't bottlenecked
   # on the smoke cells running serially in a single runner (~20 min -> roughly the slowest cell).
   verify-libs:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry-run) }}
+    if: ${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')) && !(github.event_name == 'workflow_dispatch' && inputs.dry-run) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -72,7 +72,7 @@ jobs:
   # NX_BASE/NX_HEAD, isSmokeAffected() runs rather than skips (apps/cli-smoke/src/support/affected.ts).
   # Keep the cell list in sync with apps/cli-smoke/src/matrix.ts and .github/workflows/cli-smoke.yml.
   verify-smoke:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry-run) }}
+    if: ${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')) && !(github.event_name == 'workflow_dispatch' && inputs.dry-run) }}
     runs-on: ubuntu-latest
     strategy:
       # Don't cancel the other cells when one fails - we want the full picture of which setups broke.
@@ -107,7 +107,7 @@ jobs:
   # dry-run preview). always() so it still reports a status when the matrix fans out or is skipped.
   verify:
     needs: [verify-libs, verify-smoke]
-    if: always()
+    if: ${{ always() && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Require verify-libs and verify-smoke to pass
@@ -130,7 +130,7 @@ jobs:
     needs: [verify]
     # Run when verify passed (push / real dispatch) or was skipped (dry-run preview), but never
     # when it failed or was cancelled.
-    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # create tags, commits and GitHub Releases
@@ -181,10 +181,11 @@ jobs:
   # prerelease miscomputes. We MERGE (never rebase/reset): a merge is a fast-forwardable append, so it
   # satisfies the `non_fast_forward` ruleset that blocks force-pushes; a rebase would rewrite SHAs and
   # confuse semantic-release's tag tracking. The App token is a bypass actor, so it pushes straight to
-  # the protected branches. `[skip ci]` on the merge keeps this from re-firing the heavy verify+release
-  # pipeline on every sync — the change is already published on its own channel; this only keeps the
-  # downstream branches consistent. A real conflict (a code hotfix touching prerelease-only lines)
-  # stops the automation and opens a PR to resolve by hand rather than guessing.
+  # the protected branches. The merge commits are `chore(release):`, so this workflow's prefix guard
+  # keeps them from re-firing the heavy verify+release pipeline on every sync — the change is already
+  # published on its own channel; this only keeps the downstream branches consistent. A real conflict
+  # (a code hotfix touching prerelease-only lines) stops the automation and opens a PR to resolve by
+  # hand rather than guessing.
   backmerge:
     needs: [release]
     # Run after any REAL release: plain pushes, and a workflow_dispatch with dry-run=false. Skip
@@ -217,8 +218,8 @@ jobs:
         run: |
           set -euo pipefail
           # Adjacent hops to replay top-down from the branch that just released. main fans the release
-          # all the way to alpha in one job because the [skip ci] merge to beta won't re-trigger a
-          # beta release to continue the chain on its own.
+          # all the way to alpha in one job because the guarded chore(release): merge to beta won't
+          # re-trigger a beta release to continue the chain on its own.
           case "${GITHUB_REF_NAME}" in
             main) hops=("main beta" "beta alpha") ;;
             beta) hops=("beta alpha") ;;
@@ -230,9 +231,17 @@ jobs:
           for hop in "${hops[@]}"; do
             src="${hop% *}"
             dst="${hop#* }"
-            git fetch origin "$src" "$dst"
+            git fetch origin "$src"
+            # Self-heal a missing downstream branch (e.g. one deleted by a promotion PR merge) by
+            # recreating it from the source, instead of dying on "couldn't find remote ref".
+            if ! git ls-remote --exit-code --heads origin "$dst" >/dev/null 2>&1; then
+              echo "::warning::$dst is missing; recreating it at $src"
+              git push "$remote" "origin/$src:refs/heads/$dst"
+              continue
+            fi
+            git fetch origin "$dst"
             git checkout -B "$dst" "origin/$dst"
-            if ! git merge --no-ff "origin/$src" -m "chore(release): backmerge $src into $dst [skip ci]"; then
+            if ! git merge --no-ff "origin/$src" -m "chore(release): backmerge $src into $dst"; then
               git merge --abort
               echo "::error::backmerge $src -> $dst conflicted; opening a PR to resolve by hand"
               gh pr create --base "$dst" --head "$src" \

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -66,7 +66,12 @@ export default {
 				// single `git commit -m` argument, and the first release's notes (thousands of commits)
 				// blow past the OS arg limit -> `spawn E2BIG`. The full changelog still lands in
 				// CHANGELOG.md (committed as an asset above) and in the GitHub Release.
-				message: 'chore(release): ${nextRelease.version} [skip ci]',
+				//
+				// No `[skip ci]`: that token skips ALL workflows for the commit, on push AND pull_request,
+				// so a promotion/sync PR whose tip is a release commit gets its required checks skipped and
+				// can never merge. Loop prevention lives in the workflows instead — ci/cli-smoke/release
+				// skip release commits on push via a `chore(release):`-prefix guard, leaving PR checks intact.
+				message: 'chore(release): ${nextRelease.version}',
 			},
 		],
 		'@semantic-release/github',


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

- [x] repo

## What is the current behavior?

semantic-release stamps a `skip-ci` marker into every release commit so the
release workflow does not re-fire on its own commit. But that marker is honored
by GitHub globally — it skips ALL workflows for the commit, on `push` AND
`pull_request`. So the moment anyone opens a promotion or sync PR whose tip is a
release commit (e.g. `beta -> main`), `ci` and `cli-smoke` are skipped, the
required checks never report, and the ruleset blocks the merge forever.

A related failure: merging a `beta -> main` PR with "auto-delete head branch" on
deletes `beta`, and the backmerge job then dies on `couldn't find remote ref`.

## What is the new behavior?

- Drop the `skip-ci` marker from the release commit message.
- Guard `ci`, `cli-smoke` and `release` jobs so they skip release commits **only
  on push** (via a `chore(release):`-prefix check) and **always run on
  `pull_request`**. Promotion/sync PRs now get their required checks; the
  loop/waste-prevention on release-branch pushes is preserved exactly.
- Backmerge **self-heals a missing downstream branch** — if `beta`/`alpha` is
  gone it recreates it from the source instead of failing the job.

Guard expression used everywhere:

```
github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
```

Note: existing commits already on `beta`/`alpha` still carry the old marker, so a
promotion PR opened before the next release still blocks; it self-clears once the
next release stamps a clean `chore(release):` tip.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Pairs with disabling the repo's "automatically delete head branches" setting,
which is what deleted `beta` on the #1604 promotion merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release and CI workflow handling so automated release commits no longer trigger unnecessary checks.
  * Release workflows now better distinguish real pull requests and manual runs from release automation, reducing skipped or misleading results.
  * Backmerge behavior was updated to recover more reliably when downstream branches are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->