### PR TITLE
feat(switch): introduce additional switch sizes

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(switch)/switch--sizes.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(switch)/switch--sizes.example.ts
@@ -6,7 +6,7 @@ import { HlmSwitch } from '@spartan-ng/helm/switch';
 	selector: 'spartan-switch-sizes',
 	imports: [HlmLabel, HlmSwitch],
 	host: {
-		class: 'flex items-center gap-6',
+		class: 'flex flex-wrap items-center gap-6',
 	},
 	template: `
 		<label class="flex items-center" hlmLabel>
@@ -14,8 +14,16 @@ import { HlmSwitch } from '@spartan-ng/helm/switch';
 			Small
 		</label>
 		<label class="flex items-center" hlmLabel>
-			<hlm-switch class="me-2" size="default" />
-			Default
+			<hlm-switch class="me-2" size="md" />
+			Medium
+		</label>
+		<label class="flex items-center" hlmLabel>
+			<hlm-switch class="me-2" size="lg" />
+			Large
+		</label>
+		<label class="flex items-center" hlmLabel>
+			<hlm-switch class="me-2" size="xl" />
+			Extra large
 		</label>
 	`,
 })

--- a/libs/brain/switch/src/lib/brn-switch.spec.ts
+++ b/libs/brain/switch/src/lib/brn-switch.spec.ts
@@ -291,14 +291,14 @@ describe('BrnSwitchComponent', () => {
 			return view;
 		};
 
-		it('defaults data-size to "default" on the button', async () => {
+		it('defaults data-size to "md" on the button', async () => {
 			await renderWithSize();
-			expect(screen.getByRole('switch')).toHaveAttribute('data-size', 'default');
+			expect(screen.getByRole('switch')).toHaveAttribute('data-size', 'md');
 		});
 
-		it('reflects the size input on the button', async () => {
-			await renderWithSize('sm');
-			expect(screen.getByRole('switch')).toHaveAttribute('data-size', 'sm');
+		it.each(['sm', 'md', 'lg', 'xl', 'default'])('reflects size "%s" on the button', async (size) => {
+			await renderWithSize(size);
+			expect(screen.getByRole('switch')).toHaveAttribute('data-size', size);
 		});
 	});
 

--- a/libs/brain/switch/src/lib/brn-switch.spec.ts
+++ b/libs/brain/switch/src/lib/brn-switch.spec.ts
@@ -291,9 +291,9 @@ describe('BrnSwitchComponent', () => {
 			return view;
 		};
 
-		it('defaults data-size to "md" on the button', async () => {
+		it('defaults data-size to "default" on the button', async () => {
 			await renderWithSize();
-			expect(screen.getByRole('switch')).toHaveAttribute('data-size', 'md');
+			expect(screen.getByRole('switch')).toHaveAttribute('data-size', 'default');
 		});
 
 		it.each(['sm', 'md', 'lg', 'xl', 'default'])('reflects size "%s" on the button', async (size) => {

--- a/libs/brain/switch/src/lib/brn-switch.ts
+++ b/libs/brain/switch/src/lib/brn-switch.ts
@@ -136,9 +136,9 @@ export class BrnSwitch implements AfterContentInit, OnDestroy, ControlValueAcces
 	/**
 	 * Size of the switch.
 	 * Drives the size-keyed registry style rules via the `data-size` attribute.
-	 * @default 'md'
+	 * @default 'default'
 	 */
-	public readonly size = input<BrnSwitchSize>('md');
+	public readonly size = input<BrnSwitchSize>('default');
 
 	/**
 	 * Accessibility label for screen readers.

--- a/libs/brain/switch/src/lib/brn-switch.ts
+++ b/libs/brain/switch/src/lib/brn-switch.ts
@@ -35,7 +35,7 @@ export const BRN_SWITCH_VALUE_ACCESSOR = {
 	multi: true,
 };
 
-export type BrnSwitchSize = 'default' | 'sm';
+export type BrnSwitchSize = 'sm' | 'md' | 'lg' | 'xl' | 'default';
 
 const CONTAINER_POST_FIX = '-switch';
 
@@ -136,9 +136,9 @@ export class BrnSwitch implements AfterContentInit, OnDestroy, ControlValueAcces
 	/**
 	 * Size of the switch.
 	 * Drives the size-keyed registry style rules via the `data-size` attribute.
-	 * @default 'default'
+	 * @default 'md'
 	 */
-	public readonly size = input<BrnSwitchSize>('default');
+	public readonly size = input<BrnSwitchSize>('md');
 
 	/**
 	 * Accessibility label for screen readers.

--- a/libs/cli/src/generators/ui/libs/switch/files/lib/hlm-switch.ts.template
+++ b/libs/cli/src/generators/ui/libs/switch/files/lib/hlm-switch.ts.template
@@ -1,3 +1,4 @@
+import { hlm } from '<%- importAlias %>/utils';
 import type { BooleanInput } from '@angular/cdk/coercion';
 import {
 	booleanAttribute,
@@ -12,7 +13,6 @@ import {
 import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import type { ChangeFn, TouchFn } from '@spartan-ng/brain/forms';
 import { BrnSwitch, type BrnSwitchSize, BrnSwitchThumb } from '@spartan-ng/brain/switch';
-import { hlm } from '<%- importAlias %>/utils';
 import type { ClassValue } from 'clsx';
 import { HlmSwitchThumb } from './hlm-switch-thumb';
 
@@ -73,7 +73,7 @@ export class HlmSwitch implements ControlValueAccessor {
 	});
 
 	/** The size of the switch. */
-	public readonly size = input<BrnSwitchSize>('default');
+	public readonly size = input<BrnSwitchSize>('md');
 
 	/** Used to set the id on the underlying brn element. */
 	public readonly inputId = input<string | null>(null);

--- a/libs/cli/src/generators/ui/libs/switch/files/lib/hlm-switch.ts.template
+++ b/libs/cli/src/generators/ui/libs/switch/files/lib/hlm-switch.ts.template
@@ -73,7 +73,7 @@ export class HlmSwitch implements ControlValueAccessor {
 	});
 
 	/** The size of the switch. */
-	public readonly size = input<BrnSwitchSize>('md');
+	public readonly size = input<BrnSwitchSize>('default');
 
 	/** Used to set the id on the underlying brn element. */
 	public readonly inputId = input<string | null>(null);

--- a/libs/helm/switch/src/lib/hlm-switch.ts
+++ b/libs/helm/switch/src/lib/hlm-switch.ts
@@ -73,7 +73,7 @@ export class HlmSwitch implements ControlValueAccessor {
 	});
 
 	/** The size of the switch. */
-	public readonly size = input<BrnSwitchSize>('md');
+	public readonly size = input<BrnSwitchSize>('default');
 
 	/** Used to set the id on the underlying brn element. */
 	public readonly inputId = input<string | null>(null);

--- a/libs/helm/switch/src/lib/hlm-switch.ts
+++ b/libs/helm/switch/src/lib/hlm-switch.ts
@@ -73,7 +73,7 @@ export class HlmSwitch implements ControlValueAccessor {
 	});
 
 	/** The size of the switch. */
-	public readonly size = input<BrnSwitchSize>('default');
+	public readonly size = input<BrnSwitchSize>('md');
 
 	/** Used to set the id on the underlying brn element. */
 	public readonly inputId = input<string | null>(null);

--- a/libs/registry/src/styles/style-luma.css
+++ b/libs/registry/src/styles/style-luma.css
@@ -47,11 +47,11 @@
 
 	/* MARK: Switch */
 	.spartan-switch {
-		@apply data-checked:bg-primary data-unchecked:bg-input/90 data-checked:border-primary focus-visible:border-ring focus-visible:ring-ring/30 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 shrink-0 rounded-full border-2 focus-visible:ring-3 data-unchecked:border-transparent data-[matches-spartan-invalid=true]:ring-3 data-[size=default]:h-5 data-[size=default]:w-11 data-[size=sm]:h-4 data-[size=sm]:w-7;
+		@apply data-checked:bg-primary data-unchecked:bg-input/90 data-checked:border-primary focus-visible:border-ring focus-visible:ring-ring/30 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 shrink-0 rounded-full border-2 focus-visible:ring-3 data-unchecked:border-transparent data-[matches-spartan-invalid=true]:ring-3 data-[size=default]:h-5 data-[size=default]:w-11 data-[size=lg]:h-6 data-[size=lg]:w-13 data-[size=md]:h-5 data-[size=md]:w-11 data-[size=sm]:h-4 data-[size=sm]:w-7 data-[size=xl]:h-7 data-[size=xl]:w-15;
 	}
 
 	.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full shadow-sm not-dark:bg-clip-padding group-data-[size=default]/switch:h-4 group-data-[size=default]/switch:w-6 group-data-[size=sm]/switch:h-3 group-data-[size=sm]/switch:w-4 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-8px)] data-checked:rtl:-translate-x-[calc(100%-8px)];
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full shadow-sm not-dark:bg-clip-padding group-data-[size=default]/switch:h-4 group-data-[size=default]/switch:w-6 group-data-[size=lg]/switch:h-5 group-data-[size=lg]/switch:w-7 group-data-[size=md]/switch:h-4 group-data-[size=md]/switch:w-6 group-data-[size=sm]/switch:h-3 group-data-[size=sm]/switch:w-4 group-data-[size=xl]/switch:h-6 group-data-[size=xl]/switch:w-8 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-8px)] data-checked:rtl:-translate-x-[calc(100%-8px)];
 	}
 
 	/* MARK: Radio */

--- a/libs/registry/src/styles/style-lyra.css
+++ b/libs/registry/src/styles/style-lyra.css
@@ -1067,7 +1067,7 @@
 
 	/* MARK: Switch */
 	.spartan-switch {
-		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-1 data-[matches-spartan-invalid=true]:ring-1 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-5 data-[size=md]:w-8 data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
+		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-1 data-[matches-spartan-invalid=true]:ring-1 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-[18.4px] data-[size=md]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
 	}
 
 	.spartan-switch-thumb {

--- a/libs/registry/src/styles/style-lyra.css
+++ b/libs/registry/src/styles/style-lyra.css
@@ -1067,11 +1067,11 @@
 
 	/* MARK: Switch */
 	.spartan-switch {
-		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-1 data-[matches-spartan-invalid=true]:ring-1 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px];
+		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-1 data-[matches-spartan-invalid=true]:ring-1 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-5 data-[size=md]:w-8 data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
 	}
 
 	.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=lg]/switch:size-5 group-data-[size=md]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=xl]/switch:size-6 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
 	}
 
 	/* MARK: Table */

--- a/libs/registry/src/styles/style-maia.css
+++ b/libs/registry/src/styles/style-maia.css
@@ -1089,7 +1089,7 @@
 
 	/* MARK: Switch */
 	.spartan-switch {
-		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-[3px] data-[matches-spartan-invalid=true]:ring-[3px] data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-5 data-[size=md]:w-8 data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
+		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-[3px] data-[matches-spartan-invalid=true]:ring-[3px] data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-[18.4px] data-[size=md]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
 	}
 
 	.spartan-switch-thumb {

--- a/libs/registry/src/styles/style-maia.css
+++ b/libs/registry/src/styles/style-maia.css
@@ -1089,11 +1089,11 @@
 
 	/* MARK: Switch */
 	.spartan-switch {
-		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-[3px] data-[matches-spartan-invalid=true]:ring-[3px] data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px];
+		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-[3px] data-[matches-spartan-invalid=true]:ring-[3px] data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-5 data-[size=md]:w-8 data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
 	}
 
 	.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=lg]/switch:size-5 group-data-[size=md]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=xl]/switch:size-6 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
 	}
 
 	/* MARK: Table */

--- a/libs/registry/src/styles/style-mira.css
+++ b/libs/registry/src/styles/style-mira.css
@@ -1089,11 +1089,11 @@
 
 	/* MARK: Switch */
 	.spartan-switch {
-		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/30 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-2 data-[matches-spartan-invalid=true]:ring-2 data-[size=default]:h-[16.6px] data-[size=default]:w-[28px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-5 data-[size=md]:w-8 data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
+		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/30 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-2 data-[matches-spartan-invalid=true]:ring-2 data-[size=default]:h-[16.6px] data-[size=default]:w-[28px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-[16.6px] data-[size=md]:w-[28px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
 	}
 
 	.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-3.5 group-data-[size=lg]/switch:size-5 group-data-[size=md]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=xl]/switch:size-6 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-3.5 group-data-[size=lg]/switch:size-5 group-data-[size=md]/switch:size-3.5 group-data-[size=sm]/switch:size-3 group-data-[size=xl]/switch:size-6 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
 	}
 
 	/* MARK: Table */

--- a/libs/registry/src/styles/style-mira.css
+++ b/libs/registry/src/styles/style-mira.css
@@ -1089,11 +1089,11 @@
 
 	/* MARK: Switch */
 	.spartan-switch {
-		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/30 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-2 data-[matches-spartan-invalid=true]:ring-2 data-[size=default]:h-[16.6px] data-[size=default]:w-[28px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px];
+		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/30 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-2 data-[matches-spartan-invalid=true]:ring-2 data-[size=default]:h-[16.6px] data-[size=default]:w-[28px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-5 data-[size=md]:w-8 data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
 	}
 
 	.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-3.5 group-data-[size=sm]/switch:size-3 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-3.5 group-data-[size=lg]/switch:size-5 group-data-[size=md]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=xl]/switch:size-6 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
 	}
 
 	/* MARK: Table */

--- a/libs/registry/src/styles/style-nova.css
+++ b/libs/registry/src/styles/style-nova.css
@@ -1119,7 +1119,7 @@
 
 	/* MARK: Switch */
 	.spartan-switch {
-		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-3 data-[matches-spartan-invalid=true]:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-5 data-[size=md]:w-8 data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
+		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-3 data-[matches-spartan-invalid=true]:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-[18.4px] data-[size=md]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
 	}
 
 	.spartan-switch-thumb {

--- a/libs/registry/src/styles/style-nova.css
+++ b/libs/registry/src/styles/style-nova.css
@@ -1119,11 +1119,11 @@
 
 	/* MARK: Switch */
 	.spartan-switch {
-		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-3 data-[matches-spartan-invalid=true]:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px];
+		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-3 data-[matches-spartan-invalid=true]:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-5 data-[size=md]:w-8 data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
 	}
 
 	.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=lg]/switch:size-5 group-data-[size=md]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=xl]/switch:size-6 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
 	}
 
 	/* MARK: Table */

--- a/libs/registry/src/styles/style-vega.css
+++ b/libs/registry/src/styles/style-vega.css
@@ -1219,7 +1219,7 @@
 
 	/* MARK: Switch */
 	.spartan-switch {
-		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent shadow-xs focus-visible:ring-3 data-[matches-spartan-invalid=true]:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-5 data-[size=md]:w-8 data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
+		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent shadow-xs focus-visible:ring-3 data-[matches-spartan-invalid=true]:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-[18.4px] data-[size=md]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
 	}
 
 	.spartan-switch-thumb {

--- a/libs/registry/src/styles/style-vega.css
+++ b/libs/registry/src/styles/style-vega.css
@@ -1219,11 +1219,11 @@
 
 	/* MARK: Switch */
 	.spartan-switch {
-		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent shadow-xs focus-visible:ring-3 data-[matches-spartan-invalid=true]:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px];
+		@apply data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive dark:data-[matches-spartan-invalid=true]:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent shadow-xs focus-visible:ring-3 data-[matches-spartan-invalid=true]:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=lg]:h-6 data-[size=lg]:w-10 data-[size=md]:h-5 data-[size=md]:w-8 data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[size=xl]:h-7 data-[size=xl]:w-12;
 	}
 
 	.spartan-switch-thumb {
-		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
+		@apply bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=lg]/switch:size-5 group-data-[size=md]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=xl]/switch:size-6 data-unchecked:translate-x-0 data-checked:ltr:translate-x-[calc(100%-2px)] data-checked:rtl:-translate-x-[calc(100%-2px)];
 	}
 
 	/* MARK: Table */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] switch

### Others

- [x] cli

## What is the current behavior?

The switch primitive only accepts `sm` and `default` size values, so consumers cannot opt into larger switch presentations through the component API.

Closes N/A

## What is the new behavior?

Adds explicit `md`, `lg`, and `xl` switch sizes for `brn-switch` and `hlm-switch`.

The existing `default` value remains the component default and continues to map to the legacy registry dimensions, so existing apps that do not specify a size keep their current rendered switch size. The new `md` size intentionally aliases those same legacy `default` dimensions in every theme, so `default` and `md` render the same while giving consumers an explicit medium size name.

The switch sizes example now documents `sm`, `md`, `lg`, and `xl`.

shadcn/ui, the reference library, only has the two existing switch sizes, so this is intentionally not a parity feature.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Existing legacy `default` dimensions are preserved for compatibility, and `md` mirrors them. The added larger sizes use the registry theme geometry for `lg` and `xl`.

Review feedback addressed:

- Preserved the legacy `default` component default to avoid a silent visual size change on upgrade.
- Made `md` match legacy `default` dimensions across themes so medium and default are not visually different.
- Restored CLI template import ordering so generated `hlm-switch` code matches the published library source ordering.

Validation performed:

- `pnpm nx test brain -- --run switch/src/lib/brn-switch.spec.ts` passed; Nx ran the full brain suite: 44 files, 420 tests.
- `pnpm nx build brain` passed.
- `pnpm nx build helm` passed.
- `NODE_OPTIONS=--max-old-space-size=6000 pnpm nx build app` passed before the final review cleanup.
- `git diff --check` passed after the final review cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the Switch size options to support Medium, Large, and Extra large (in addition to Small and default).
  - Updated the Switch sizing example layout and option labels to reflect the new sizes.
- **Bug Fixes**
  - Updated Switch track and thumb dimensions so sizing renders consistently across supported themes.
- **Tests**
  - Enhanced Switch size test coverage to validate the correct reported value for all supported sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->