### PR TITLE
Handle pnpm catalog dependencies in the CLI generators

### DIFF
--- a/libs/cli/src/generators/base/generator.ts
+++ b/libs/cli/src/generators/base/generator.ts
@@ -17,6 +17,7 @@ import { buildDependencyArray, buildDevDependencyArray } from './lib/build-depen
 import { deleteFiles } from './lib/deleteFiles';
 import { getTargetLibraryDirectory } from './lib/get-target-library-directory';
 import { initializeAngularLibrary } from './lib/initialize-angular-library';
+import { filterUnregisteredDependencies } from './lib/package-json-dependencies';
 
 import { librarySecondaryEntryPointGenerator } from '@nx/angular/generators';
 
@@ -193,10 +194,16 @@ function generateLibraryFiles(tree: Tree, targetLibDir: string, options: HlmBase
 	);
 }
 
-function registerDependencies(tree: Tree, options: HlmBaseGeneratorSchema): GeneratorCallback {
+function registerDependencies(tree: Tree, options: HlmBaseGeneratorSchema): GeneratorCallback | undefined {
 	const cdkVersion = getInstalledPackageVersion(tree, '@angular/cdk', FALLBACK_ANGULAR_CDK_VERSION, true);
-	const dependencies = buildDependencyArray(tree, options, cdkVersion);
-	const devDependencies = buildDevDependencyArray();
+	const { dependencies, devDependencies } = filterUnregisteredDependencies(
+		tree,
+		buildDependencyArray(tree, options, cdkVersion),
+		buildDevDependencyArray(),
+	);
+	if (Object.keys(dependencies).length === 0 && Object.keys(devDependencies).length === 0) {
+		return undefined;
+	}
 	return addDependenciesToPackageJson(tree, dependencies, devDependencies);
 }
 
@@ -237,7 +244,10 @@ export async function hlmBaseGenerator(tree: Tree, options: HlmBaseGeneratorSche
 		tree.write(filePath, transformed);
 	}
 
-	tasks.push(registerDependencies(tree, options));
+	const dependencyTask = registerDependencies(tree, options);
+	if (dependencyTask) {
+		tasks.push(dependencyTask);
+	}
 
 	return runTasksInSerial(...tasks);
 }

--- a/libs/cli/src/generators/base/lib/package-json-dependencies.spec.ts
+++ b/libs/cli/src/generators/base/lib/package-json-dependencies.spec.ts
@@ -1,0 +1,54 @@
+import { type Tree, writeJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { filterUnregisteredDependencies } from './package-json-dependencies';
+
+describe('filterUnregisteredDependencies', () => {
+	let tree: Tree;
+
+	beforeEach(() => {
+		tree = createTreeWithEmptyWorkspace();
+	});
+
+	it('omits dependencies already declared with pnpm catalog references', () => {
+		writeJson(tree, 'package.json', {
+			dependencies: {
+				'@angular/cdk': 'catalog:angular',
+				rxjs: 'catalog:',
+			},
+			devDependencies: {
+				'@spartan-ng/cli': 'catalog:spartanui',
+			},
+		});
+
+		const result = filterUnregisteredDependencies(
+			tree,
+			{
+				'@angular/cdk': 'catalog:angular',
+				'@spartan-ng/brain': 'catalog:spartanui',
+				rxjs: 'catalog:',
+			},
+			{
+				'@spartan-ng/cli': 'catalog:spartanui',
+				'tw-animate-css': '^1.4.0',
+			},
+		);
+
+		expect(result).toEqual({
+			dependencies: {
+				'@spartan-ng/brain': 'catalog:spartanui',
+			},
+			devDependencies: {
+				'tw-animate-css': '^1.4.0',
+			},
+		});
+	});
+
+	it('drops null versions before registering dependencies', () => {
+		writeJson(tree, 'package.json', {});
+
+		expect(filterUnregisteredDependencies(tree, { '@spartan-ng/brain': null }, {})).toEqual({
+			dependencies: {},
+			devDependencies: {},
+		});
+	});
+});

--- a/libs/cli/src/generators/base/lib/package-json-dependencies.spec.ts
+++ b/libs/cli/src/generators/base/lib/package-json-dependencies.spec.ts
@@ -43,6 +43,66 @@ describe('filterUnregisteredDependencies', () => {
 		});
 	});
 
+	it('keeps dependencies already declared with concrete versions', () => {
+		writeJson(tree, 'package.json', {
+			dependencies: {
+				'@angular/cdk': '^20.0.0',
+			},
+			devDependencies: {
+				'tw-animate-css': '^1.0.0',
+			},
+		});
+
+		const result = filterUnregisteredDependencies(
+			tree,
+			{
+				'@angular/cdk': '^21.0.0',
+			},
+			{
+				'tw-animate-css': '^1.4.0',
+			},
+		);
+
+		expect(result).toEqual({
+			dependencies: {
+				'@angular/cdk': '^21.0.0',
+			},
+			devDependencies: {
+				'tw-animate-css': '^1.4.0',
+			},
+		});
+	});
+
+	it('keeps dependencies that are only declared as peer or optional dependencies', () => {
+		writeJson(tree, 'package.json', {
+			peerDependencies: {
+				'@angular/cdk': '^20.0.0',
+			},
+			optionalDependencies: {
+				'tw-animate-css': '^1.0.0',
+			},
+		});
+
+		const result = filterUnregisteredDependencies(
+			tree,
+			{
+				'@angular/cdk': '^21.0.0',
+			},
+			{
+				'tw-animate-css': '^1.4.0',
+			},
+		);
+
+		expect(result).toEqual({
+			dependencies: {
+				'@angular/cdk': '^21.0.0',
+			},
+			devDependencies: {
+				'tw-animate-css': '^1.4.0',
+			},
+		});
+	});
+
 	it('drops null versions before registering dependencies', () => {
 		writeJson(tree, 'package.json', {});
 

--- a/libs/cli/src/generators/base/lib/package-json-dependencies.ts
+++ b/libs/cli/src/generators/base/lib/package-json-dependencies.ts
@@ -18,7 +18,8 @@ export function filterUnregisteredDependencies(tree: Tree, dependencies: Depende
 	const filter = (deps: Dependencies) =>
 		Object.fromEntries(
 			Object.entries(deps).filter(
-				([packageName, version]) => typeof version === 'string' && !isCatalogManagedDependency(packageJson, packageName),
+				([packageName, version]) =>
+					typeof version === 'string' && !isCatalogManagedDependency(packageJson, packageName),
 			),
 		) as Record<string, string>;
 

--- a/libs/cli/src/generators/base/lib/package-json-dependencies.ts
+++ b/libs/cli/src/generators/base/lib/package-json-dependencies.ts
@@ -8,13 +8,9 @@ type PackageJsonDependencies = {
 	optionalDependencies?: Record<string, string>;
 };
 
-function hasDeclaredDependency(packageJson: PackageJsonDependencies, packageName: string): boolean {
-	return (
-		packageName in (packageJson.dependencies ?? {}) ||
-		packageName in (packageJson.devDependencies ?? {}) ||
-		packageName in (packageJson.peerDependencies ?? {}) ||
-		packageName in (packageJson.optionalDependencies ?? {})
-	);
+function isCatalogManagedDependency(packageJson: PackageJsonDependencies, packageName: string): boolean {
+	const version = packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName];
+	return typeof version === 'string' && version.startsWith('catalog:');
 }
 
 export function filterUnregisteredDependencies(tree: Tree, dependencies: Dependencies, devDependencies: Dependencies) {
@@ -22,7 +18,7 @@ export function filterUnregisteredDependencies(tree: Tree, dependencies: Depende
 	const filter = (deps: Dependencies) =>
 		Object.fromEntries(
 			Object.entries(deps).filter(
-				([packageName, version]) => typeof version === 'string' && !hasDeclaredDependency(packageJson, packageName),
+				([packageName, version]) => typeof version === 'string' && !isCatalogManagedDependency(packageJson, packageName),
 			),
 		) as Record<string, string>;
 

--- a/libs/cli/src/generators/base/lib/package-json-dependencies.ts
+++ b/libs/cli/src/generators/base/lib/package-json-dependencies.ts
@@ -1,0 +1,33 @@
+import { readJson, type Tree } from '@nx/devkit';
+
+type Dependencies = Record<string, string | null | undefined>;
+type PackageJsonDependencies = {
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+};
+
+function hasDeclaredDependency(packageJson: PackageJsonDependencies, packageName: string): boolean {
+	return (
+		packageName in (packageJson.dependencies ?? {}) ||
+		packageName in (packageJson.devDependencies ?? {}) ||
+		packageName in (packageJson.peerDependencies ?? {}) ||
+		packageName in (packageJson.optionalDependencies ?? {})
+	);
+}
+
+export function filterUnregisteredDependencies(tree: Tree, dependencies: Dependencies, devDependencies: Dependencies) {
+	const packageJson = readJson<PackageJsonDependencies>(tree, 'package.json');
+	const filter = (deps: Dependencies) =>
+		Object.fromEntries(
+			Object.entries(deps).filter(
+				([packageName, version]) => typeof version === 'string' && !hasDeclaredDependency(packageJson, packageName),
+			),
+		) as Record<string, string>;
+
+	return {
+		dependencies: filter(dependencies),
+		devDependencies: filter(devDependencies),
+	};
+}

--- a/libs/cli/src/generators/init/generator.ts
+++ b/libs/cli/src/generators/init/generator.ts
@@ -1,6 +1,7 @@
 import { addDependenciesToPackageJson, type GeneratorCallback, logger, runTasksInSerial, type Tree } from '@nx/devkit';
 import { getInstalledPackageVersion } from '../../utils/version-utils';
 import { buildDependencyArray, buildDevDependencyArray } from '../base/lib/build-dependency-array';
+import { filterUnregisteredDependencies } from '../base/lib/package-json-dependencies';
 import type { HlmBaseGeneratorSchema } from '../base/schema';
 import { FALLBACK_ANGULAR_CDK_VERSION } from '../base/versions';
 import addThemeToApplicationGenerator from '../theme/generator';
@@ -11,8 +12,11 @@ export async function spartanInitGenerator(tree: Tree, options: SpartanInitGener
 
 	const cdkVersionStr = getInstalledPackageVersion(tree, '@angular/cdk', FALLBACK_ANGULAR_CDK_VERSION, true);
 
-	const dependencies: Record<string, string> = buildDependencyArray(tree, {} as HlmBaseGeneratorSchema, cdkVersionStr);
-	const devDependencies: Record<string, string> = buildDevDependencyArray();
+	const { dependencies, devDependencies } = filterUnregisteredDependencies(
+		tree,
+		buildDependencyArray(tree, {} as HlmBaseGeneratorSchema, cdkVersionStr),
+		buildDevDependencyArray(),
+	);
 
 	const tasks: GeneratorCallback[] = [];
 

--- a/libs/cli/src/generators/init/generator.ts
+++ b/libs/cli/src/generators/init/generator.ts
@@ -20,7 +20,7 @@ export async function spartanInitGenerator(tree: Tree, options: SpartanInitGener
 
 	const tasks: GeneratorCallback[] = [];
 
-	if (Object.entries(dependencies).length > 0 || Object.entries(devDependencies).length > 0) {
+	if (Object.keys(dependencies).length > 0 || Object.keys(devDependencies).length > 0) {
 		tasks.push(addDependenciesToPackageJson(tree, dependencies, devDependencies));
 	}
 


### PR DESCRIPTION
The CLI was still passing packages to addDependenciesToPackageJson even when they were already declared in the workspace package.json.

That breaks with pnpm catalogs because existing versions like catalog:angular are handed back to Nx/pnpm during the install task. This filters out dependencies that are already declared in dependencies, devDependencies, peerDependencies, or optionalDependencies before registering new packages.

Tests:
- pnpm exec vitest run --config libs/cli/vite.config.mts libs/cli/src/generators/base/lib/package-json-dependencies.spec.ts libs/cli/src/generators/base/lib/build-dependency-array.spec.ts libs/cli/src/utils/version-utils.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoided writing duplicate dependencies and devDependencies when they’re already present in `package.json`, including catalog-managed references.
  * Skips updating `package.json` when there are no newly eligible dependency entries to apply.
* **New Features**
  * Added dependency filtering during init/generation so only unregistered, string-version candidates are added; catalog-managed entries are ignored.
* **Tests**
  * Added Jest coverage for catalog reference detection, existing concrete-version retention, peer/optional handling, and dropping null version entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->