### PR TITLE
Add explicit titles for docs routes used in search

### DIFF
--- a/apps/app/src/app/pages/(blocks)/blocks.page.ts
+++ b/apps/app/src/app/pages/(blocks)/blocks.page.ts
@@ -6,7 +6,8 @@ import { HlmButton } from '@spartan-ng/helm/button';
 import { HlmTabsImports } from '@spartan-ng/helm/tabs';
 
 export const routeMeta: RouteMeta = {
-	meta: metaWith('Blocks - spartan', 'Blocks built with the spartan/ui'),
+	meta: metaWith('spartan/blocks - Blocks', 'Blocks built with the spartan/ui'),
+	title: 'spartan/blocks - Blocks',
 };
 
 @Component({

--- a/apps/app/src/app/pages/(documentation)/documentation.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation.page.ts
@@ -1,11 +1,14 @@
 import type { RouteMeta } from '@analogjs/router';
 import { Component } from '@angular/core';
 import { Page } from '@spartan-ng/app/app/shared/layout/page';
+import { metaWith } from '@spartan-ng/app/app/shared/meta/meta.util';
 
 export const routeMeta: RouteMeta = {
 	data: {
 		breadcrumb: 'Docs',
 	},
+	meta: metaWith('spartan - Documentation', 'Learn how to install, configure, and customize spartan/ui.'),
+	title: 'spartan - Documentation',
 };
 @Component({
 	selector: 'spartan-documentation',

--- a/apps/app/src/app/pages/(forms)/forms.page.ts
+++ b/apps/app/src/app/pages/(forms)/forms.page.ts
@@ -1,5 +1,15 @@
+import type { RouteMeta } from '@analogjs/router';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Page } from '../../shared/layout/page';
+import { metaWith } from '../../shared/meta/meta.util';
+
+export const routeMeta: RouteMeta = {
+	data: {
+		breadcrumb: 'Forms',
+	},
+	meta: metaWith('spartan/ui - Forms', 'Build forms with Angular and spartan/ui.'),
+	title: 'spartan/ui - Forms',
+};
 
 @Component({
 	selector: 'spartan-forms',


### PR DESCRIPTION
A few docs parent and redirect routes did not define their own route title, so indexed search results could fall back to the site default title.

This adds explicit titles to those routes and fills in missing metadata for the parent docs/forms routes.

Tests:
- pnpm nx test app --run
- checked route metadata exports locally; no routeMeta page is missing a title now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added page metadata and titles for the Blocks, Documentation, and Forms pages.
  * Improved breadcrumb support on the Forms and Documentation pages.
  * Updated page titles to be more descriptive and consistent across these sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->