### PR TITLE
chore(repo): resolve api-docs references via ts-morph instead of a name registry

### DIFF
--- a/libs/tools/src/executors/docs/generate-ui-docs/executor.ts
+++ b/libs/tools/src/executors/docs/generate-ui-docs/executor.ts
@@ -1,8 +1,15 @@
 import type { ExecutorContext } from '@nx/devkit';
 import fs from 'fs';
 import path from 'path';
-import type { ClassDeclaration, Decorator, Node, SourceFile } from 'ts-morph';
-import { ArrayLiteralExpression, CallExpression, ObjectLiteralExpression, Project, PropertyAssignment } from 'ts-morph';
+import type { ClassDeclaration, Decorator } from 'ts-morph';
+import {
+	ArrayLiteralExpression,
+	CallExpression,
+	Node,
+	ObjectLiteralExpression,
+	Project,
+	PropertyAssignment,
+} from 'ts-morph';
 import { writePerComponentData } from '../../../write-per-component-data';
 import type { GenerateUiDocsExecutorSchema } from './schema';
 
@@ -16,7 +23,11 @@ export default async function runExecutor(options: GenerateUiDocsExecutorSchema,
 		fs.mkdirSync(outputDir, { recursive: true });
 	}
 
-	const project = new Project();
+	// Load the workspace tsconfig so `@spartan-ng/*` imports resolve via its `paths` map.
+	const project = new Project({
+		tsConfigFilePath: path.join(context.root, 'tsconfig.base.json'),
+		skipAddingFilesFromTsConfig: true,
+	});
 	project.addSourceFilesAtPaths([
 		`${brainDir}/**/*.ts`,
 		`${helmDir}/**/*.ts`,
@@ -36,25 +47,7 @@ export default async function runExecutor(options: GenerateUiDocsExecutorSchema,
 }
 
 export function extractInputsOutputs(project: Project, workspaceRoot: string) {
-	const inputsOutputs = {};
-
-	// Build a registry of every class by name so we can resolve base classes and
-	// host directives even when they are imported via TS path aliases (which the
-	// type checker can't resolve without a tsconfig). Multiple classes may share a
-	// name across packages, so we keep a list per name and disambiguate later.
-	const classRegistry = new Map<string, ClassDeclaration[]>();
-	project.getSourceFiles().forEach((sourceFile) => {
-		sourceFile.getClasses().forEach((cls) => {
-			const name = cls.getName();
-			if (!name) return;
-			const existing = classRegistry.get(name);
-			if (existing) {
-				existing.push(cls);
-			} else {
-				classRegistry.set(name, [cls]);
-			}
-		});
-	});
+	const inputsOutputs: NestedStructure = {};
 
 	project.getSourceFiles().forEach((sourceFile) => {
 		// if the source file is a .spec.ts file then skip
@@ -67,7 +60,7 @@ export function extractInputsOutputs(project: Project, workspaceRoot: string) {
 			// Get the full file path and make it relative to workspace root
 			const fullPath = sourceFile.getFilePath();
 			const relativeFilePath = path.relative(workspaceRoot, fullPath);
-			const componentInfo = {
+			const componentInfo: ComponentInfo = {
 				file: relativeFilePath,
 				inputs: [],
 				outputs: [],
@@ -95,11 +88,11 @@ export function extractInputsOutputs(project: Project, workspaceRoot: string) {
 			// Collect members from the class itself and every ancestor it extends,
 			// so inherited inputs/outputs/models show up in the generated docs.
 			const seenMembers = new Set<string>();
-			collectAllMembers(cls, componentInfo, classRegistry, seenMembers);
+			collectAllMembers(cls, componentInfo, seenMembers);
 
 			// Collect inputs and outputs exposed through `hostDirectives`, applying the
 			// renaming declared in the decorator (e.g. 'brnTabsContent: hlmTabsContent').
-			collectHostDirectiveMembers(cls, componentInfo, classRegistry, seenMembers);
+			collectHostDirectiveMembers(cls, componentInfo, seenMembers);
 
 			if (
 				componentInfo.inputs.length ||
@@ -116,27 +109,39 @@ export function extractInputsOutputs(project: Project, workspaceRoot: string) {
 	return inputsOutputs;
 }
 
-function collectAllMembers(
-	cls: ClassDeclaration,
-	componentInfo,
-	classRegistry: Map<string, ClassDeclaration[]>,
-	seen: Set<string>,
-) {
+interface Member {
+	name: string;
+	type: string;
+	description: string;
+	defaultValue?: string | null;
+	required?: boolean;
+}
+
+interface MemberCollection {
+	inputs: Member[];
+	outputs: Member[];
+	models: Member[];
+}
+
+interface ComponentInfo extends MemberCollection {
+	file: string;
+	selector?: string | null;
+	exportAs?: string | null;
+}
+
+type NestedStructure = Record<string, Record<string, Record<string, ComponentInfo>>>;
+
+function collectAllMembers(cls: ClassDeclaration, componentInfo: MemberCollection, seen: Set<string>) {
 	const visitedClasses = new Set<ClassDeclaration>();
 	let currentClass: ClassDeclaration | undefined = cls;
 	while (currentClass && !visitedClasses.has(currentClass)) {
 		visitedClasses.add(currentClass);
 		collectMembers(currentClass, componentInfo, seen);
-		currentClass = resolveBaseClass(currentClass, classRegistry);
+		currentClass = currentClass.getBaseClass();
 	}
 }
 
-function collectHostDirectiveMembers(
-	cls: ClassDeclaration,
-	componentInfo,
-	classRegistry: Map<string, ClassDeclaration[]>,
-	seen: Set<string>,
-) {
+function collectHostDirectiveMembers(cls: ClassDeclaration, componentInfo: MemberCollection, seen: Set<string>) {
 	const decorator = cls.getDecorator((d) => d.getName() === 'Component' || d.getName() === 'Directive');
 	if (!decorator) return;
 
@@ -156,27 +161,16 @@ function collectHostDirectiveMembers(
 		const directiveProp = element.getProperty('directive');
 		if (!(directiveProp instanceof PropertyAssignment)) return;
 
-		const directiveName = directiveProp.getInitializer().getText().replace(/<.*>$/s, '').trim();
-		const directiveClass = resolveClassByName(directiveName, cls.getSourceFile(), classRegistry);
+		const directiveClass = resolveClass(directiveProp.getInitializer());
 		if (!directiveClass) return;
 
 		// Resolve the referenced directive's members (including inherited ones) so the
 		// exposed mappings can be matched by their public name.
-		const directiveInfo = { inputs: [], outputs: [], models: [] };
-		collectAllMembers(directiveClass, directiveInfo, classRegistry, new Set<string>());
+		const directiveInfo: MemberCollection = { inputs: [], outputs: [], models: [] };
+		collectAllMembers(directiveClass, directiveInfo, new Set<string>());
 
-		// A signal `model()` is exposed as an input plus a `<name>Change` output, so
-		// include models as candidates for both the input and output mappings.
-		const inputCandidates = [
-			...directiveInfo.inputs,
-			...directiveInfo.models.map((model) => ({
-				name: model.name,
-				type: model.type,
-				description: model.description,
-				defaultValue: model.defaultValue,
-				required: model.required,
-			})),
-		];
+		// A signal `model()` is exposed as an input plus a `<name>Change` output.
+		const inputCandidates = [...directiveInfo.inputs, ...directiveInfo.models];
 		const outputCandidates = [
 			...directiveInfo.outputs,
 			...directiveInfo.models.map((model) => ({
@@ -191,7 +185,13 @@ function collectHostDirectiveMembers(
 	});
 }
 
-function mapHostDirectiveMembers(memberProp, directiveMembers, kind: 'input' | 'output', seen: Set<string>, target) {
+function mapHostDirectiveMembers(
+	memberProp: Node | undefined,
+	directiveMembers: Member[],
+	kind: 'input' | 'output',
+	seen: Set<string>,
+	target: Member[],
+) {
 	if (!(memberProp instanceof PropertyAssignment)) return;
 	const init = memberProp.getInitializer();
 	if (!(init instanceof ArrayLiteralExpression)) return;
@@ -207,7 +207,7 @@ function mapHostDirectiveMembers(memberProp, directiveMembers, kind: 'input' | '
 			.map((part) => part.trim());
 		const publicName = alias || originalName;
 
-		const resolved = membersByName.get(originalName) as object;
+		const resolved = membersByName.get(originalName);
 		if (!resolved) return;
 		if (seen.has(`${kind}:${publicName}`)) return;
 		seen.add(`${kind}:${publicName}`);
@@ -215,70 +215,13 @@ function mapHostDirectiveMembers(memberProp, directiveMembers, kind: 'input' | '
 	});
 }
 
-function resolveBaseClass(
-	cls: ClassDeclaration,
-	classRegistry: Map<string, ClassDeclaration[]>,
-): ClassDeclaration | undefined {
-	// Try the type-checker first (works when the base class is in the same file
-	// or resolvable without path aliases).
-	const resolved = cls.getBaseClass();
-	if (resolved) {
-		return resolved;
-	}
-
-	// Fall back to resolving by the written name of the `extends` expression,
-	// stripping any generic type arguments (e.g. `BrnDialog<T>` -> `BrnDialog`).
-	const extendsExpr = cls.getExtends();
-	if (!extendsExpr) {
-		return undefined;
-	}
-	const baseName = extendsExpr.getExpression().getText().replace(/<.*>$/s, '').trim();
-	return resolveClassByName(baseName, cls.getSourceFile(), classRegistry);
-}
-
-function resolveClassByName(
-	name: string,
-	fromSourceFile: SourceFile,
-	classRegistry: Map<string, ClassDeclaration[]>,
-): ClassDeclaration | undefined {
-	const candidates = classRegistry.get(name);
-	if (!candidates || candidates.length === 0) {
-		return undefined;
-	}
-	if (candidates.length === 1) {
-		return candidates[0];
-	}
-
-	// Multiple classes share this name; disambiguate using the import declaration
-	// in the referencing file so inheritance/host-directive lookups don't silently
-	// resolve to the wrong package.
-	const importDecl = fromSourceFile
-		.getImportDeclarations()
-		.find((imp) =>
-			imp.getNamedImports().some((named) => (named.getAliasNode()?.getText() ?? named.getName()) === name),
-		);
-	if (importDecl) {
-		// Prefer the file the module resolver points to (works for relative imports).
-		const resolvedSourceFile = importDecl.getModuleSpecifierSourceFile();
-		if (resolvedSourceFile) {
-			const match = candidates.find((candidate) => candidate.getSourceFile() === resolvedSourceFile);
-			if (match) return match;
-		}
-		// Otherwise match the module specifier tail against candidate file paths,
-		// e.g. '@spartan-ng/brain/dialog' -> a file under '.../brain/dialog/...'.
-		const specifierTail = importDecl
-			.getModuleSpecifierValue()
-			.replace(/^@[^/]+\//, '')
-			.replace(/^[./]+/, '');
-		if (specifierTail) {
-			const match = candidates.find((candidate) =>
-				candidate.getSourceFile().getFilePath().includes(`/${specifierTail}`),
-			);
-			if (match) return match;
-		}
-	}
-
-	return candidates[0];
+function resolveClass(expr: Node | undefined): ClassDeclaration | undefined {
+	const declaration = expr
+		?.getType()
+		.getSymbol()
+		?.getDeclarations()
+		.find((decl): decl is ClassDeclaration => Node.isClassDeclaration(decl));
+	return declaration;
 }
 
 function readAliasFromOptions(optionsArg: Node | undefined): string | undefined {
@@ -308,7 +251,7 @@ function readDecoratorAlias(decorator: Decorator): string | undefined {
 	return undefined;
 }
 
-function collectMembers(cls: ClassDeclaration, componentInfo, seen: Set<string>) {
+function collectMembers(cls: ClassDeclaration, componentInfo: MemberCollection, seen: Set<string>) {
 	cls.getProperties().forEach((prop) => {
 		// Prefer the type as written in the code (without import path)
 		const type = prop.getTypeNode()?.getText() || prop.getType().getText();
@@ -350,18 +293,11 @@ function collectMembers(cls: ClassDeclaration, componentInfo, seen: Set<string>)
 
 				const callArgs = callExpr.getArguments();
 
-				// Extract the default value from signal-based input/model. The `*.required`
-				// forms take their options object as the first argument, so they have none.
-				let defaultValue = null;
-				if (!isRequired && (exprText === 'input' || exprText === 'model') && callArgs.length > 0) {
-					const argText = callArgs[0].getText();
-					const match = argText.match(/\(([^()]*)\)$/);
-					if (match && match[1]) {
-						defaultValue = match[1].replace(/['"]/g, '');
-					} else {
-						defaultValue = argText.replace(/['"]/g, '');
-					}
-				}
+				// Only the plain `input`/`model` forms carry a default; the `*.required`
+				// forms take their options object as the first argument instead. Keep the
+				// default exactly as written so strings stay quoted and expressions intact.
+				const hasDefault = !isRequired && (exprText === 'input' || exprText === 'model') && callArgs.length > 0;
+				const defaultValue = hasDefault ? callArgs[0].getText() : null;
 
 				// Options object is the first arg for the `*.required(opts)` forms and the
 				// last arg for the `input(default, opts)` / `model(default, opts)` forms.
@@ -401,7 +337,14 @@ function collectMembers(cls: ClassDeclaration, componentInfo, seen: Set<string>)
 	});
 }
 
-function addToNestedStructure(rootObject, relativeFilePath, className, componentInfo) {
+function addToNestedStructure(
+	rootObject: NestedStructure,
+	relativeFilePath: string,
+	className: string | undefined,
+	componentInfo: ComponentInfo,
+) {
+	if (!className) return;
+
 	// Split path and remove 'src' and 'lib' segments
 	const pathSegments = relativeFilePath.split(path.sep).filter((segment) => segment !== 'src' && segment !== 'lib');
 

--- a/libs/tools/src/executors/docs/generate-ui-docs/executor.ts
+++ b/libs/tools/src/executors/docs/generate-ui-docs/executor.ts
@@ -109,7 +109,7 @@ export function extractInputsOutputs(project: Project, workspaceRoot: string) {
 	return inputsOutputs;
 }
 
-interface Member {
+export interface Member {
 	name: string;
 	type: string;
 	description: string;
@@ -117,19 +117,19 @@ interface Member {
 	required?: boolean;
 }
 
-interface MemberCollection {
+export interface MemberCollection {
 	inputs: Member[];
 	outputs: Member[];
 	models: Member[];
 }
 
-interface ComponentInfo extends MemberCollection {
+export interface ComponentInfo extends MemberCollection {
 	file: string;
 	selector?: string | null;
 	exportAs?: string | null;
 }
 
-type NestedStructure = Record<string, Record<string, Record<string, ComponentInfo>>>;
+export type NestedStructure = Record<string, Record<string, Record<string, ComponentInfo>>>;
 
 function collectAllMembers(cls: ClassDeclaration, componentInfo: MemberCollection, seen: Set<string>) {
 	const visitedClasses = new Set<ClassDeclaration>();

--- a/libs/tools/src/executors/docs/generate-ui-docs/extract-inputs-outputs.spec.ts
+++ b/libs/tools/src/executors/docs/generate-ui-docs/extract-inputs-outputs.spec.ts
@@ -1,4 +1,4 @@
-import { Project } from 'ts-morph';
+import { Project, ts } from 'ts-morph';
 import { describe, expect, it } from 'vitest';
 import { extractInputsOutputs } from './executor';
 
@@ -13,12 +13,47 @@ type ComponentInfo = {
 };
 
 /**
+ * Mirrors the real workspace layout so `@spartan-ng/*` imports resolve exactly as
+ * they do at runtime: every `libs/<scope>/<pkg>` gets a barrel `src/index.ts` that
+ * re-exports its lib files, and a matching `paths` entry. The extractor then relies
+ * on the type checker for base-class/host-directive resolution — no name registry.
+ */
+function buildBarrelsAndPaths(files: Record<string, string>): {
+	barrels: Record<string, string>;
+	paths: Record<string, string[]>;
+} {
+	const libFilesByPackage = new Map<string, string[]>();
+	for (const filePath of Object.keys(files)) {
+		const match = filePath.match(/^(libs\/(?:brain|helm)\/[^/]+)\/src\/lib\/(.+)\.ts$/);
+		if (!match) continue;
+		const [, packageRoot, libName] = match;
+		const existing = libFilesByPackage.get(packageRoot);
+		if (existing) existing.push(libName);
+		else libFilesByPackage.set(packageRoot, [libName]);
+	}
+
+	const barrels: Record<string, string> = {};
+	const paths: Record<string, string[]> = {};
+	for (const [packageRoot, libNames] of libFilesByPackage) {
+		const indexPath = `${packageRoot}/src/index.ts`;
+		barrels[indexPath] = libNames.map((name) => `export * from './lib/${name}';`).join('\n');
+		const alias = packageRoot.replace('libs/', '@spartan-ng/');
+		paths[alias] = [indexPath];
+	}
+	return { barrels, paths };
+}
+
+/**
  * Runs the extractor against a set of in-memory source files and returns a flat
  * map keyed by class name for convenient assertions.
  */
 function extract(files: Record<string, string>): Record<string, ComponentInfo> {
-	const project = new Project({ useInMemoryFileSystem: true });
-	for (const [filePath, content] of Object.entries(files)) {
+	const { barrels, paths } = buildBarrelsAndPaths(files);
+	const project = new Project({
+		useInMemoryFileSystem: true,
+		compilerOptions: { baseUrl: '/', paths, moduleResolution: ts.ModuleResolutionKind.Bundler },
+	});
+	for (const [filePath, content] of Object.entries({ ...barrels, ...files })) {
 		project.createSourceFile(filePath, content);
 	}
 
@@ -116,6 +151,38 @@ describe('extractInputsOutputs', () => {
 				{ name: 'size', type: 'number', description: '', defaultValue: null, required: true },
 			]);
 		});
+
+		it('keeps default values exactly as written, including string quotes and expressions', () => {
+			const result = extract({
+				'libs/brain/foo/src/lib/brn-foo.ts': `
+					import { Directive, input, signal } from '@angular/core';
+					@Directive({ selector: '[brnFoo]' })
+					export class BrnFoo {
+						public readonly label = input<string>('dialog');
+						public readonly count = input<number>(signal(5));
+					}
+				`,
+			});
+
+			const byName = Object.fromEntries(result['BrnFoo'].inputs.map((i) => [i.name, i.defaultValue]));
+			expect(byName['label']).toBe("'dialog'");
+			expect(byName['count']).toBe('signal(5)');
+		});
+
+		it('captures the JSDoc comment of a member as its description', () => {
+			const result = extract({
+				'libs/brain/foo/src/lib/brn-foo.ts': `
+					import { Directive, input } from '@angular/core';
+					@Directive({ selector: '[brnFoo]' })
+					export class BrnFoo {
+						/** The size of the thing. */
+						public readonly size = input<number>(1);
+					}
+				`,
+			});
+
+			expect(result['BrnFoo'].inputs[0].description).toBe('The size of the thing.');
+		});
 	});
 
 	describe('decorator-based members', () => {
@@ -163,6 +230,23 @@ describe('extractInputsOutputs', () => {
 			});
 
 			expect(names(result['BrnFoo'].inputs)).toEqual(['plain']);
+		});
+	});
+
+	describe('selector and exportAs', () => {
+		it('leaves exportAs undefined when the decorator omits it, so it is dropped from the JSON', () => {
+			const result = extract({
+				'libs/brain/foo/src/lib/brn-foo.ts': `
+					import { Directive, input } from '@angular/core';
+					@Directive({ selector: '[brnFoo]' })
+					export class BrnFoo {
+						public readonly size = input<number>(1);
+					}
+				`,
+			});
+
+			expect(result['BrnFoo'].selector).toBe('[brnFoo]');
+			expect(result['BrnFoo'].exportAs).toBeUndefined();
 		});
 	});
 
@@ -394,6 +478,34 @@ describe('extractInputsOutputs', () => {
 			// beyond its selector.
 			expect(result['HlmDialogClose'].inputs).toEqual([]);
 		});
+
+		it('keeps the own member when a host directive re-exposes the same public name', () => {
+			const result = extract({
+				'libs/brain/button/src/lib/brn-button.ts': `
+					import { Directive, input } from '@angular/core';
+					@Directive({ selector: '[brnBtn]' })
+					export class BrnButton {
+						public readonly variant = input<string>('brain');
+					}
+				`,
+				'libs/helm/button/src/lib/hlm-button.ts': `
+					import { Directive, input } from '@angular/core';
+					import { BrnButton } from '@spartan-ng/brain/button';
+					@Directive({
+						selector: '[hlmBtn]',
+						hostDirectives: [{ directive: BrnButton, inputs: ['variant'] }],
+					})
+					export class HlmButton {
+						public readonly variant = input<string>('helm');
+					}
+				`,
+			});
+
+			// The class's own `variant` is collected first, so the host-directive copy is deduped away.
+			const variants = result['HlmButton'].inputs.filter((i) => i.name === 'variant');
+			expect(variants).toHaveLength(1);
+			expect(variants[0].defaultValue).toBe("'helm'");
+		});
 	});
 
 	describe('class-name collisions', () => {
@@ -425,6 +537,39 @@ describe('extractInputsOutputs', () => {
 
 			// Must inherit from the brain Base, not the helm one that shares the name.
 			expect(names(result['BrnDialog'].inputs)).toEqual(['own', 'fromBrain']);
+		});
+
+		it('does not resolve to a sibling package whose path is a prefix substring', () => {
+			const result = extract({
+				// Declared first so it wins any array-order fallback. Its path
+				// ('.../brain/dialog-content/...') contains '/brain/dialog' as a substring.
+				'libs/brain/dialog-content/src/lib/base.ts': `
+					import { Directive, input } from '@angular/core';
+					@Directive()
+					export class Base {
+						public readonly fromContent = input<string>('content');
+					}
+				`,
+				'libs/brain/dialog/src/lib/base.ts': `
+					import { Directive, input } from '@angular/core';
+					@Directive()
+					export class Base {
+						public readonly fromDialog = input<string>('dialog');
+					}
+				`,
+				'libs/brain/dialog/src/lib/brn-dialog.ts': `
+					import { Directive, input } from '@angular/core';
+					import { Base } from '@spartan-ng/brain/dialog';
+					@Directive({ selector: '[brnDialog]' })
+					export class BrnDialog extends Base {
+						public readonly own = input<string>('x');
+					}
+				`,
+			});
+
+			// '@spartan-ng/brain/dialog' must resolve to the dialog Base, not the
+			// dialog-content sibling that merely shares a path prefix.
+			expect(names(result['BrnDialog'].inputs)).toEqual(['own', 'fromDialog']);
 		});
 	});
 });

--- a/libs/tools/src/executors/docs/generate-ui-docs/extract-inputs-outputs.spec.ts
+++ b/libs/tools/src/executors/docs/generate-ui-docs/extract-inputs-outputs.spec.ts
@@ -1,16 +1,6 @@
 import { Project, ts } from 'ts-morph';
 import { describe, expect, it } from 'vitest';
-import { extractInputsOutputs } from './executor';
-
-type Member = { name: string; type?: string; description?: string; defaultValue?: string | null; required?: boolean };
-type ComponentInfo = {
-	file: string;
-	inputs: Member[];
-	outputs: Member[];
-	models: Member[];
-	selector?: string | null;
-	exportAs?: string | null;
-};
+import { extractInputsOutputs, type ComponentInfo, type Member } from './executor';
 
 /**
  * Mirrors the real workspace layout so `@spartan-ng/*` imports resolve exactly as
@@ -57,7 +47,7 @@ function extract(files: Record<string, string>): Record<string, ComponentInfo> {
 		project.createSourceFile(filePath, content);
 	}
 
-	const nested = extractInputsOutputs(project, '/') as Record<string, Record<string, Record<string, ComponentInfo>>>;
+	const nested = extractInputsOutputs(project, '/');
 
 	const flat: Record<string, ComponentInfo> = {};
 	for (const componentType of Object.values(nested)) {

--- a/libs/tools/src/executors/docs/generate-ui-docs/extract-inputs-outputs.spec.ts
+++ b/libs/tools/src/executors/docs/generate-ui-docs/extract-inputs-outputs.spec.ts
@@ -8,8 +8,8 @@ type ComponentInfo = {
 	inputs: Member[];
 	outputs: Member[];
 	models: Member[];
-	selector: string | null;
-	exportAs: string | null;
+	selector?: string | null;
+	exportAs?: string | null;
 };
 
 /**
@@ -24,7 +24,7 @@ function buildBarrelsAndPaths(files: Record<string, string>): {
 } {
 	const libFilesByPackage = new Map<string, string[]>();
 	for (const filePath of Object.keys(files)) {
-		const match = filePath.match(/^(libs\/(?:brain|helm)\/[^/]+)\/src\/lib\/(.+)\.ts$/);
+		const match = filePath.match(/^(libs\/[^/]+\/[^/]+)\/src\/lib\/(.+)\.ts$/);
 		if (!match) continue;
 		const [, packageRoot, libName] = match;
 		const existing = libFilesByPackage.get(packageRoot);


### PR DESCRIPTION
> **Stacked on top of #1617** (base branch: `api-docs-generator-fix`). This is a
> friendly review-follow-up to your extractor work — it keeps all of your new
> behavior (inheritance + host directives + alias handling) and the same public
> output, but leans on `ts-morph`'s type checker to do the resolution your
> registry was doing by hand. Net **−57 lines** in `executor.ts`. Happy to adjust
> anything or split it up.

## TL;DR

PR added the right *behavior*. This keeps behavior but swaps the
**mechanism**: instead of building a name→class registry and matching packages by
string heuristics, we load the workspace `tsconfig.base.json` into the `Project`
and let `getBaseClass()` / symbol resolution follow the real imports (barrels
included). 

## Why — the problems this fixes

**1. The name registry could silently resolve to the wrong class.**
`resolveClassByName` disambiguated same-named classes by matching the import's
module-specifier *tail* against candidate file paths with `includes()`:

```ts
// '@spartan-ng/brain/dialog' -> look for a path containing '/brain/dialog'
candidate.getSourceFile().getFilePath().includes(`/${specifierTail}`)
```

`'/brain/dialog'` is a substring of `'/brain/dialog-content'`, so an import of
`@spartan-ng/brain/dialog` can match a **different package** and, when the tail
match fails, it falls back to `candidates[0]` — an arbitrary pick by file order.
The extractor then documents the wrong class's inputs with no error. There's a
regression test for exactly this (`does not resolve to a sibling package whose
path is a prefix substring`) — it fails on the registry approach and passes here.

**2. Default values were mangled by a regex heuristic.**

```ts
const match = argText.match(/\(([^()]*)\)$/);
if (match && match[1]) defaultValue = match[1].replace(/['"]/g, '');
else defaultValue = argText.replace(/['"]/g, '');
```

- `input(signal(5))` was documented as `5` (the regex reached *into* the
  expression and grabbed the paren contents).
- `replace(/['"]/g, '')` stripped quotes indiscriminately: `input('')` became
  `""` (indistinguishable from "no default") and `{ label: 'x' }` became
  `{ label: x }`.

Now the default is taken **verbatim** from the argument node, so strings keep
their quotes (`'bottom'`, `''`) and expressions stay intact (`signal(5)`).

**3. The new helpers were untyped.** `componentInfo`, `target`,
`directiveMembers` were implicit `any`, with an `as object` cast to make the
spread compile.

## What changed

- **Deleted** `classRegistry`, `resolveClassByName`, and the name-based half of
  `resolveBaseClass` (~80 lines).
- **Added** a 6-line `resolveClass(expr)` that asks the type system for the
  declaration behind an `extends` / `directive:` reference.
- `resolveBaseClass` → just `cls.getBaseClass()`.
- Default-value extraction → verbatim `getText()` (see #2).
- Introduced `Member` / `MemberCollection` / `ComponentInfo` / `NestedStructure`
  types across the extractor; removed all `any` and the cast.
- Tests: the in-memory harness now mirrors the real workspace (barrel
  `index.ts` + `paths`), plus new cases for the collision fix, default-value
  formatting, JSDoc descriptions, and own-vs-host dedup.

## How — leaning on `ts-morph` instead of hand-wiring

The one enabling change:

```ts
const project = new Project({
  tsConfigFilePath: path.join(context.root, 'tsconfig.base.json'),
  skipAddingFilesFromTsConfig: true, // still only load brain/helm sources
});
```

Loading the tsconfig gives the checker the `paths` map, so `@spartan-ng/*`
imports resolve natively through the barrel re-exports. Everything the registry
was reconstructing — "which class does this name refer to, in which package" —
is now answered by the compiler that already knows. `getBaseClass()` walks
inheritance across packages; symbol resolution finds host-directive classes; the
same-name collision problem disappears because we resolve *symbols*, not strings.

## Behavior notes for reviewers

- **Public JSON shape is unchanged**; the `executor.spec.ts` snapshot regenerates
  identically (it strips `defaultValue`, so #2 doesn't move it).
- The **emitted `defaultValue` strings do change** for string/expression defaults
  (now quoted / verbatim). The docs table renders the value as-is, so e.g.
  `side` now shows `'bottom'` instead of `bottom`. This is intentional — see #2.

## Testing

- `nx test tools` — 23 passing (17 of yours + 6 added).
- Ran the real `nx run tools:generate-ui-docs` against the workspace; snapshot
  matches byte-for-byte.
- `tsc` + `eslint` clean.

---

## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated (docs *output* changes; no doc pages)

## PR Type

- [x] Bugfix
- [x] Refactoring (no api changes)

## Which package are you modifying?

- [x] repo

## What is the current behavior?

The extractor (as of #1617) resolves base classes / host directives via a
name→class registry with module-specifier string matching, extracts default
values with a regex, and leaves the new helpers untyped.

## What is the new behavior?

Resolution is delegated to `ts-morph` via the workspace tsconfig, default values
are kept verbatim, the extractor is fully typed, and the name-collision +
default-value bugs are fixed. See details above.

## Does this PR introduce a breaking change?

- [x] No (public JSON shape unchanged; `defaultValue` string formatting differs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI docs generation to honor workspace module resolution via `tsconfig` path mappings.
  * Refined host directive extraction and inheritance traversal for more accurate member resolution, including safer collision handling.
  * Updated `input()`/`model()` default handling to preserve the first argument exactly as written.
  * Ensured member descriptions from inline documentation are captured, and omitted `exportAs` when not provided.

* **Tests**
  * Expanded extraction tests to validate path resolution, default preservation, host-directive de-duplication, inheritance lookup behavior, and description/exportAs output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->