### PR TITLE
fix(cli): handle pnpm catalog deps without disabling version bumping

### DIFF
--- a/libs/cli/src/generators/base/generator.ts
+++ b/libs/cli/src/generators/base/generator.ts
@@ -17,7 +17,7 @@ import { buildDependencyArray, buildDevDependencyArray } from './lib/build-depen
 import { deleteFiles } from './lib/deleteFiles';
 import { getTargetLibraryDirectory } from './lib/get-target-library-directory';
 import { initializeAngularLibrary } from './lib/initialize-angular-library';
-import { filterUnregisteredDependencies } from './lib/package-json-dependencies';
+import { removeCatalogManagedDependencies } from './lib/package-json-dependencies';
 
 import { librarySecondaryEntryPointGenerator } from '@nx/angular/generators';
 
@@ -196,7 +196,7 @@ function generateLibraryFiles(tree: Tree, targetLibDir: string, options: HlmBase
 
 function registerDependencies(tree: Tree, options: HlmBaseGeneratorSchema): GeneratorCallback | undefined {
 	const cdkVersion = getInstalledPackageVersion(tree, '@angular/cdk', FALLBACK_ANGULAR_CDK_VERSION, true);
-	const { dependencies, devDependencies } = filterUnregisteredDependencies(
+	const { dependencies, devDependencies } = removeCatalogManagedDependencies(
 		tree,
 		buildDependencyArray(tree, options, cdkVersion),
 		buildDevDependencyArray(),

--- a/libs/cli/src/generators/base/generator.ts
+++ b/libs/cli/src/generators/base/generator.ts
@@ -17,6 +17,7 @@ import { buildDependencyArray, buildDevDependencyArray } from './lib/build-depen
 import { deleteFiles } from './lib/deleteFiles';
 import { getTargetLibraryDirectory } from './lib/get-target-library-directory';
 import { initializeAngularLibrary } from './lib/initialize-angular-library';
+import { filterUnregisteredDependencies } from './lib/package-json-dependencies';
 
 import { librarySecondaryEntryPointGenerator } from '@nx/angular/generators';
 
@@ -193,10 +194,16 @@ function generateLibraryFiles(tree: Tree, targetLibDir: string, options: HlmBase
 	);
 }
 
-function registerDependencies(tree: Tree, options: HlmBaseGeneratorSchema): GeneratorCallback {
+function registerDependencies(tree: Tree, options: HlmBaseGeneratorSchema): GeneratorCallback | undefined {
 	const cdkVersion = getInstalledPackageVersion(tree, '@angular/cdk', FALLBACK_ANGULAR_CDK_VERSION, true);
-	const dependencies = buildDependencyArray(tree, options, cdkVersion);
-	const devDependencies = buildDevDependencyArray();
+	const { dependencies, devDependencies } = filterUnregisteredDependencies(
+		tree,
+		buildDependencyArray(tree, options, cdkVersion),
+		buildDevDependencyArray(),
+	);
+	if (Object.keys(dependencies).length === 0 && Object.keys(devDependencies).length === 0) {
+		return undefined;
+	}
 	return addDependenciesToPackageJson(tree, dependencies, devDependencies);
 }
 
@@ -237,7 +244,10 @@ export async function hlmBaseGenerator(tree: Tree, options: HlmBaseGeneratorSche
 		tree.write(filePath, transformed);
 	}
 
-	tasks.push(registerDependencies(tree, options));
+	const dependencyTask = registerDependencies(tree, options);
+	if (dependencyTask) {
+		tasks.push(dependencyTask);
+	}
 
 	return runTasksInSerial(...tasks);
 }

--- a/libs/cli/src/generators/base/lib/package-json-dependencies.spec.ts
+++ b/libs/cli/src/generators/base/lib/package-json-dependencies.spec.ts
@@ -1,0 +1,54 @@
+import { type Tree, writeJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { filterUnregisteredDependencies } from './package-json-dependencies';
+
+describe('filterUnregisteredDependencies', () => {
+	let tree: Tree;
+
+	beforeEach(() => {
+		tree = createTreeWithEmptyWorkspace();
+	});
+
+	it('omits dependencies already declared with pnpm catalog references', () => {
+		writeJson(tree, 'package.json', {
+			dependencies: {
+				'@angular/cdk': 'catalog:angular',
+				rxjs: 'catalog:',
+			},
+			devDependencies: {
+				'@spartan-ng/cli': 'catalog:spartanui',
+			},
+		});
+
+		const result = filterUnregisteredDependencies(
+			tree,
+			{
+				'@angular/cdk': 'catalog:angular',
+				'@spartan-ng/brain': 'catalog:spartanui',
+				rxjs: 'catalog:',
+			},
+			{
+				'@spartan-ng/cli': 'catalog:spartanui',
+				'tw-animate-css': '^1.4.0',
+			},
+		);
+
+		expect(result).toEqual({
+			dependencies: {
+				'@spartan-ng/brain': 'catalog:spartanui',
+			},
+			devDependencies: {
+				'tw-animate-css': '^1.4.0',
+			},
+		});
+	});
+
+	it('drops null versions before registering dependencies', () => {
+		writeJson(tree, 'package.json', {});
+
+		expect(filterUnregisteredDependencies(tree, { '@spartan-ng/brain': null }, {})).toEqual({
+			dependencies: {},
+			devDependencies: {},
+		});
+	});
+});

--- a/libs/cli/src/generators/base/lib/package-json-dependencies.spec.ts
+++ b/libs/cli/src/generators/base/lib/package-json-dependencies.spec.ts
@@ -1,8 +1,8 @@
 import { type Tree, writeJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { filterUnregisteredDependencies } from './package-json-dependencies';
+import { removeCatalogManagedDependencies } from './package-json-dependencies';
 
-describe('filterUnregisteredDependencies', () => {
+describe('removeCatalogManagedDependencies', () => {
 	let tree: Tree;
 
 	beforeEach(() => {
@@ -20,7 +20,7 @@ describe('filterUnregisteredDependencies', () => {
 			},
 		});
 
-		const result = filterUnregisteredDependencies(
+		const result = removeCatalogManagedDependencies(
 			tree,
 			{
 				'@angular/cdk': 'catalog:angular',
@@ -35,6 +35,7 @@ describe('filterUnregisteredDependencies', () => {
 
 		expect(result).toEqual({
 			dependencies: {
+				// kept: not installed yet, so it is a new dependency (even as a catalog ref)
 				'@spartan-ng/brain': 'catalog:spartanui',
 			},
 			devDependencies: {
@@ -43,10 +44,20 @@ describe('filterUnregisteredDependencies', () => {
 		});
 	});
 
+	it('keeps a concrete already-declared dependency so nx can still bump it', () => {
+		writeJson(tree, 'package.json', {
+			dependencies: { 'tailwind-merge': '^3.0.0' },
+		});
+
+		const result = removeCatalogManagedDependencies(tree, { 'tailwind-merge': '^3.5.0' }, {});
+
+		expect(result.dependencies).toEqual({ 'tailwind-merge': '^3.5.0' });
+	});
+
 	it('drops null versions before registering dependencies', () => {
 		writeJson(tree, 'package.json', {});
 
-		expect(filterUnregisteredDependencies(tree, { '@spartan-ng/brain': null }, {})).toEqual({
+		expect(removeCatalogManagedDependencies(tree, { '@spartan-ng/brain': null }, {})).toEqual({
 			dependencies: {},
 			devDependencies: {},
 		});

--- a/libs/cli/src/generators/base/lib/package-json-dependencies.ts
+++ b/libs/cli/src/generators/base/lib/package-json-dependencies.ts
@@ -1,28 +1,29 @@
 import { readJson, type Tree } from '@nx/devkit';
 
 type Dependencies = Record<string, string | null | undefined>;
-type PackageJsonDependencies = {
+type InstalledDependencies = {
 	dependencies?: Record<string, string>;
 	devDependencies?: Record<string, string>;
-	peerDependencies?: Record<string, string>;
-	optionalDependencies?: Record<string, string>;
 };
 
-function hasDeclaredDependency(packageJson: PackageJsonDependencies, packageName: string): boolean {
-	return (
-		packageName in (packageJson.dependencies ?? {}) ||
-		packageName in (packageJson.devDependencies ?? {}) ||
-		packageName in (packageJson.peerDependencies ?? {}) ||
-		packageName in (packageJson.optionalDependencies ?? {})
-	);
+// A pnpm/yarn catalog reference ("catalog:" / "catalog:name") is resolved from the workspace catalog,
+// not a semver range. Re-declaring one makes nx try to resolve the existing reference and throw (#1597).
+// We drop only these, so ordinary concrete deps are still handed to nx and bumped to our supported minimum.
+function isCatalogManaged(installed: InstalledDependencies, packageName: string): boolean {
+	const existing = installed.dependencies?.[packageName] ?? installed.devDependencies?.[packageName];
+	return typeof existing === 'string' && existing.startsWith('catalog:');
 }
 
-export function filterUnregisteredDependencies(tree: Tree, dependencies: Dependencies, devDependencies: Dependencies) {
-	const packageJson = readJson<PackageJsonDependencies>(tree, 'package.json');
+export function removeCatalogManagedDependencies(
+	tree: Tree,
+	dependencies: Dependencies,
+	devDependencies: Dependencies,
+) {
+	const installed = readJson<InstalledDependencies>(tree, 'package.json');
 	const filter = (deps: Dependencies) =>
 		Object.fromEntries(
 			Object.entries(deps).filter(
-				([packageName, version]) => typeof version === 'string' && !hasDeclaredDependency(packageJson, packageName),
+				([packageName, version]) => typeof version === 'string' && !isCatalogManaged(installed, packageName),
 			),
 		) as Record<string, string>;
 

--- a/libs/cli/src/generators/base/lib/package-json-dependencies.ts
+++ b/libs/cli/src/generators/base/lib/package-json-dependencies.ts
@@ -1,0 +1,33 @@
+import { readJson, type Tree } from '@nx/devkit';
+
+type Dependencies = Record<string, string | null | undefined>;
+type PackageJsonDependencies = {
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+};
+
+function hasDeclaredDependency(packageJson: PackageJsonDependencies, packageName: string): boolean {
+	return (
+		packageName in (packageJson.dependencies ?? {}) ||
+		packageName in (packageJson.devDependencies ?? {}) ||
+		packageName in (packageJson.peerDependencies ?? {}) ||
+		packageName in (packageJson.optionalDependencies ?? {})
+	);
+}
+
+export function filterUnregisteredDependencies(tree: Tree, dependencies: Dependencies, devDependencies: Dependencies) {
+	const packageJson = readJson<PackageJsonDependencies>(tree, 'package.json');
+	const filter = (deps: Dependencies) =>
+		Object.fromEntries(
+			Object.entries(deps).filter(
+				([packageName, version]) => typeof version === 'string' && !hasDeclaredDependency(packageJson, packageName),
+			),
+		) as Record<string, string>;
+
+	return {
+		dependencies: filter(dependencies),
+		devDependencies: filter(devDependencies),
+	};
+}

--- a/libs/cli/src/generators/init/generator.ts
+++ b/libs/cli/src/generators/init/generator.ts
@@ -1,7 +1,7 @@
 import { addDependenciesToPackageJson, type GeneratorCallback, logger, runTasksInSerial, type Tree } from '@nx/devkit';
 import { getInstalledPackageVersion } from '../../utils/version-utils';
 import { buildDependencyArray, buildDevDependencyArray } from '../base/lib/build-dependency-array';
-import { filterUnregisteredDependencies } from '../base/lib/package-json-dependencies';
+import { removeCatalogManagedDependencies } from '../base/lib/package-json-dependencies';
 import type { HlmBaseGeneratorSchema } from '../base/schema';
 import { FALLBACK_ANGULAR_CDK_VERSION } from '../base/versions';
 import addThemeToApplicationGenerator from '../theme/generator';
@@ -12,7 +12,7 @@ export async function spartanInitGenerator(tree: Tree, options: SpartanInitGener
 
 	const cdkVersionStr = getInstalledPackageVersion(tree, '@angular/cdk', FALLBACK_ANGULAR_CDK_VERSION, true);
 
-	const { dependencies, devDependencies } = filterUnregisteredDependencies(
+	const { dependencies, devDependencies } = removeCatalogManagedDependencies(
 		tree,
 		buildDependencyArray(tree, {} as HlmBaseGeneratorSchema, cdkVersionStr),
 		buildDevDependencyArray(),

--- a/libs/cli/src/generators/init/generator.ts
+++ b/libs/cli/src/generators/init/generator.ts
@@ -1,6 +1,7 @@
 import { addDependenciesToPackageJson, type GeneratorCallback, logger, runTasksInSerial, type Tree } from '@nx/devkit';
 import { getInstalledPackageVersion } from '../../utils/version-utils';
 import { buildDependencyArray, buildDevDependencyArray } from '../base/lib/build-dependency-array';
+import { filterUnregisteredDependencies } from '../base/lib/package-json-dependencies';
 import type { HlmBaseGeneratorSchema } from '../base/schema';
 import { FALLBACK_ANGULAR_CDK_VERSION } from '../base/versions';
 import addThemeToApplicationGenerator from '../theme/generator';
@@ -11,8 +12,11 @@ export async function spartanInitGenerator(tree: Tree, options: SpartanInitGener
 
 	const cdkVersionStr = getInstalledPackageVersion(tree, '@angular/cdk', FALLBACK_ANGULAR_CDK_VERSION, true);
 
-	const dependencies: Record<string, string> = buildDependencyArray(tree, {} as HlmBaseGeneratorSchema, cdkVersionStr);
-	const devDependencies: Record<string, string> = buildDevDependencyArray();
+	const { dependencies, devDependencies } = filterUnregisteredDependencies(
+		tree,
+		buildDependencyArray(tree, {} as HlmBaseGeneratorSchema, cdkVersionStr),
+		buildDevDependencyArray(),
+	);
 
 	const tasks: GeneratorCallback[] = [];
 


### PR DESCRIPTION
> **Draft / fallback for #1610.** This builds directly on @xonaib's work in
> #1610 (their commit is included here) and applies the one refinement discussed
> in that PR's review. It's staged so we have a ready-to-merge end state **only if
> #1610 stalls** — the preferred path is still to land the change on #1610 itself.
> Closes #1597.

## Why this exists

#1610 correctly fixes the `catalog:` crash (#1597), but its filter skips **every
already-declared dependency** — concrete ranges included. That has a side effect
beyond the bug: spartan relies on nx's `addDependenciesToPackageJson` to raise an
already-present concrete dep (e.g. `tailwind-merge`) to its supported minimum, and
skipping all declared deps turns that bumping **off for every consumer**, not just
catalog users.

## The delta on top of #1610

Narrow the skip to **catalog-managed installs only**:

```ts
function isCatalogManaged(installed, packageName) {
  const existing = installed.dependencies?.[packageName] ?? installed.devDependencies?.[packageName];
  return typeof existing === 'string' && existing.startsWith('catalog:');
}
```

- **Concrete already-declared deps are kept** → nx still bumps them (new regression test covers this).
- Only `dependencies` / `devDependencies` are inspected — a `catalog:` value can't
  cause the crash from `peer`/`optionalDependencies`, so those are no longer
  consulted (avoids wrongly skipping a dep a library declares as a peer).
- **Keeps @xonaib's null-version drop** (`@spartan-ng/brain` is `null` when
  `@spartan-ng/cli` isn't installed) — that part was already correct.
- Renamed the helper to `removeCatalogManagedDependencies` so the name matches the
  narrowed behavior.

A `--skip-existing` flag / prompt to *opt out* of bumping would be a clean
follow-up, but is intentionally out of scope here.

## Testing

- `nx test cli` — `package-json-dependencies` (3, incl. the concrete-keep
  differentiator) + base/init generator specs (20) all green.
- lint + format clean.

---

## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added

## PR Type

- [x] Bugfix

## Which package are you modifying?

- [x] cli

## What is the current behavior?

Running `ng g @spartan-ng/cli:ui` / `:init` in a workspace using pnpm catalog
references crashes (#1597). #1610 fixes the crash but stops nx from bumping any
already-declared dependency.

## What is the new behavior?

Only catalog-referenced deps are skipped; concrete deps are still added/bumped as
before. `null` versions are dropped.

## Does this PR introduce a breaking change?

- [x] No
