### PR TITLE
fix(resizable): stop NG0103 feedback loop from non-idempotent layout sync

### DIFF
--- a/libs/brain/resizable/src/lib/brn-resizable-group.spec.ts
+++ b/libs/brain/resizable/src/lib/brn-resizable-group.spec.ts
@@ -273,6 +273,28 @@ describe('BrnResizableGroup', () => {
 		expect(flexValues).toEqual(['25 1 0', '75 1 0']);
 	});
 
+	it('is idempotent when re-applying the already-applied fractional layout (no NG0103 feedback)', async () => {
+		// A drag frame that computes the same percentages as the last one re-sets the model to a
+		// value that already equals the applied layout. Re-synchronizing must be a no-op: the
+		// proportional-rescale branch round-trips through x/total*100, which is not bit-identical for
+		// these fractions, and any drift feeds back into the model and can loop until Angular throws
+		// NG0103 in zoneless apps.
+		const fractional = [50.669642857142854, 49.330357142857146];
+		const view = await render(DynamicResizableHost);
+		view.fixture.componentInstance.layout.set([...fractional]);
+		view.detectChanges();
+		await view.fixture.whenStable();
+		expect(view.fixture.componentInstance.layout()).toEqual(fractional);
+
+		// Re-apply the identical percentages via a fresh array reference (a zero-velocity drag frame).
+		view.fixture.componentInstance.layout.set([...fractional]);
+		view.detectChanges();
+		await view.fixture.whenStable();
+
+		// No floating-point drift leaked back into the model.
+		expect(view.fixture.componentInstance.layout()).toEqual(fractional);
+	});
+
 	it('applies an external layout update without a panel membership change', async () => {
 		const view = await render(DynamicResizableHost);
 		view.fixture.componentInstance.layout.set([35, 65]);

--- a/libs/brain/resizable/src/lib/brn-resizable-group.ts
+++ b/libs/brain/resizable/src/lib/brn-resizable-group.ts
@@ -96,7 +96,16 @@ export class BrnResizableGroup {
 		const hasCompleteExternalLayout =
 			!isInitialLayout &&
 			currentLayout.length === totalPanels &&
-			!this._layoutsEqual(currentLayout, this._appliedLayout);
+			!this._layoutsEquivalent(currentLayout, this._appliedLayout);
+		const membershipChanged = !isInitialLayout && !this._panelsEqual(panels, this._knownPanels);
+
+		// Nothing external changed and the same panels are still mounted: the applied layout is already
+		// correct. Falling through to the proportional-rescale branch would round-trip each size through
+		// x/total*100, which is not bit-identical for fractional layouts; the drift feeds back into the
+		// model and can loop until Angular throws NG0103 in zoneless apps.
+		if (!isInitialLayout && !hasCompleteExternalLayout && !membershipChanged) {
+			return;
+		}
 
 		let sizes: number[];
 		if (isInitialLayout) {
@@ -134,13 +143,20 @@ export class BrnResizableGroup {
 		this._knownPanels = panels;
 		this._appliedLayout = [...sizes];
 
-		if (!this._layoutsEqual(currentLayout, sizes)) {
+		if (!this._layoutsEquivalent(currentLayout, sizes)) {
 			this._setLayout(sizes);
 		}
 	}
 
-	private _layoutsEqual(first: readonly number[], second: readonly number[]): boolean {
-		return first.length === second.length && first.every((size, index) => size === second[index]);
+	// Percentages within this tolerance render identically; treat them as the same layout so
+	// floating-point drift from a rescale round-trip can't feed back into the model (NG0103).
+	private _layoutsEquivalent(first: readonly number[], second: readonly number[]): boolean {
+		const epsilon = 1e-9;
+		return first.length === second.length && first.every((size, index) => Math.abs(size - second[index]) < epsilon);
+	}
+
+	private _panelsEqual(first: readonly BrnResizablePanel[], second: readonly BrnResizablePanel[]): boolean {
+		return first.length === second.length && first.every((panel, index) => panel === second[index]);
 	}
 
 	public startResize(handleIndex: number, event: MouseEvent | TouchEvent): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] resizable

## What is the current behavior?

Closes #1614

Dragging a `hlm-resizable-handle` in a zoneless app (Angular's default) intermittently throws
`NG0103: Infinite change detection while refreshing application views`, sometimes snapping panels to
an extreme.

Root cause is in `BrnResizableGroup._synchronizePanelSizes()`. The `afterRenderEffect` re-runs
whenever `layout()` changes. During a drag, `_setLayout()` sets both `layout` and `_appliedLayout`
to the same value, so the effect re-fires with `currentLayout` already equal to `_appliedLayout`.
`hasCompleteExternalLayout` is therefore `false`, and — because it is not the initial render —
control falls into the "membership changed" branch even though membership did **not** change. That
branch recomputes every size via `size / total * 100`, which is **not bit-identical** for fractional
layouts:

```
50.669642857142854 / 100 * 100  →  50.66964285714285   // differs in the last digit
```

The drifted result differs from `currentLayout` under the exact (`===`) guard, so `_setLayout()`
runs again, re-triggering the effect. This normally converges in one extra pass, but occasionally
does not converge within Angular's zoneless retry budget → `NG0103`. Reproduces with the official
docs example (nested horizontal/vertical group), most reliably when the drag momentarily pauses
(mouse velocity ~0, so two consecutive frames compute identical percentages).

## What is the new behavior?

Two independent layers of protection:

1. **Membership guard** — `_synchronizePanelSizes` now short-circuits as a no-op when neither the
   external layout nor the panel membership changed, so it never enters the proportional-rescale
   branch spuriously. That branch now runs only on a genuine membership change, which is what its
   comment always described.
2. **Tolerance-based comparison** — `_layoutsEqual` is renamed to `_layoutsEquivalent` and compares
   with an epsilon (`1e-9`) instead of exact `===`. Percentages this close render identically, so
   sub-nanopercent floating-point drift from the rescale round-trip can no longer register as a
   change and feed back into the model — even inside the legitimate membership-change branch.

Added a regression test that re-applies an already-applied fractional layout (a zero-velocity drag
frame) and asserts the model does not drift. It fails on `main` (`50.66964285714285` leaks back) and
passes with this change. All 417 brain tests pass; lint, format, and build are green.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The membership guard alone fixes the reported loop; the epsilon comparison is defense-in-depth for
the same class of floating-point feedback in the rescale branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout stability when reapplying the same resize proportions, preventing tiny floating-point shifts.
  * Fixed cases where resizing panels could unexpectedly drift or trigger repeated update loops in complex rendering setups.
  * Kept panel layouts unchanged when no meaningful change was detected, making resizable areas more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->