### PR TITLE
fix: avoid inline style attributes blocked by strict CSP

### DIFF
--- a/libs/brain/accordion/src/lib/brn-accordion-content.ts
+++ b/libs/brain/accordion/src/lib/brn-accordion-content.ts
@@ -12,7 +12,7 @@ import { injectBrnAccordionItem } from './brn-accordion-token';
 		'[style.--brn-accordion-content-width.px]': '_dimensions.width()',
 		'[style.--brn-accordion-content-height.px]': '_dimensions.height()',
 		'[attr.inert]': '_inert()',
-		'[attr.style]': 'style()',
+		'[style]': 'style()',
 	},
 })
 export class BrnAccordionContent {

--- a/libs/brain/checkbox/src/lib/brn-checkbox.ts
+++ b/libs/brain/checkbox/src/lib/brn-checkbox.ts
@@ -45,7 +45,7 @@ const CONTAINER_POST_FIX = '-checkbox';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	hostDirectives: [BrnFieldControl],
 	host: {
-		'[style]': '{display: "contents"}',
+		'[style]': 'hostStyles()',
 		'[attr.id]': '_state().id',
 		'[attr.name]': '_state().name',
 		'[attr.aria-labelledby]': 'null',
@@ -155,6 +155,12 @@ export class BrnCheckbox implements ControlValueAccessor, AfterContentInit, OnDe
 	 * CSS classes applied to inner button element.
 	 */
 	public readonly class = input<string | null>(null);
+
+	/**
+	 * Styles applied to the host element. Bound via `[style]` so they apply through the CSSOM and are
+	 * not blocked by a strict Content-Security-Policy.
+	 */
+	public readonly hostStyles = input<string>('display: contents');
 
 	/**
 	 * Accessibility label for screen readers.

--- a/libs/brain/radio-group/src/lib/brn-radio.ts
+++ b/libs/brain/radio-group/src/lib/brn-radio.ts
@@ -53,7 +53,7 @@ const INPUT_POST_FIX = '-input';
 		</div>
 		<input
 			#input
-			[style]="'position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;'"
+			[style]="inputStyles()"
 			type="radio"
 			[attr.id]="_inputId()"
 			[checked]="_checked()"
@@ -108,6 +108,14 @@ export class BrnRadio<T = unknown> implements OnDestroy {
 	 * The value this radio button represents.
 	 */
 	public readonly value = input.required<T>();
+
+	/**
+	 * Styles applied to the visually hidden native input element. Bound via `[style]` so they apply
+	 * through the CSSOM and are not blocked by a strict Content-Security-Policy.
+	 */
+	public readonly inputStyles = input<string>(
+		'position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;',
+	);
 
 	/**
 	 * Whether the radio button is required.

--- a/libs/brain/radio-group/src/lib/brn-radio.ts
+++ b/libs/brain/radio-group/src/lib/brn-radio.ts
@@ -53,7 +53,7 @@ const INPUT_POST_FIX = '-input';
 		</div>
 		<input
 			#input
-			style="position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;"
+			[style]="'position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;'"
 			type="radio"
 			[attr.id]="_inputId()"
 			[checked]="_checked()"

--- a/libs/brain/switch/src/lib/brn-switch.ts
+++ b/libs/brain/switch/src/lib/brn-switch.ts
@@ -47,7 +47,7 @@ let uniqueIdCounter = 0;
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	hostDirectives: [BrnFieldControl],
 	host: {
-		'[style]': '{display: "contents"}',
+		'[style]': 'hostStyles()',
 		'[attr.id]': '_state().id',
 		'[attr.name]': '_state().name',
 		'[attr.aria-labelledby]': 'null',
@@ -132,6 +132,12 @@ export class BrnSwitch implements AfterContentInit, OnDestroy, ControlValueAcces
 	 * CSS classes applied to inner button element.
 	 */
 	public readonly class = input<string | null>(null);
+
+	/**
+	 * Styles applied to the host element. Bound via `[style]` so they apply through the CSSOM and are
+	 * not blocked by a strict Content-Security-Policy.
+	 */
+	public readonly hostStyles = input<string>('display: contents');
 
 	/**
 	 * Size of the switch.

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -1901,6 +1901,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "type": "string | null",
           },
           {
+            "name": "hostStyles",
+            "required": false,
+            "type": "string",
+          },
+          {
             "name": "aria-label",
             "required": false,
             "type": "string | null",
@@ -6042,6 +6047,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "type": "T",
           },
           {
+            "name": "inputStyles",
+            "required": false,
+            "type": "string",
+          },
+          {
             "name": "required",
             "required": false,
             "type": "boolean",
@@ -8064,6 +8074,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "name": "class",
             "required": false,
             "type": "string | null",
+          },
+          {
+            "name": "hostStyles",
+            "required": false,
+            "type": "string",
           },
           {
             "name": "size",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [x] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [x] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [x] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1584

Under a strict Content-Security-Policy whose `style-src` has no `'unsafe-inline'`, browsers
strip inline `style` **attributes**. Two brain primitives relied on that attribute form:

- `brn-radio` hid its native `<input type="radio">` via a literal `style="…"` attribute, so the
  input became visible → **two radio controls per option**.
- `brn-accordion-content` applied its host style via `[attr.style]` (the attribute form), so its
  `overflow: hidden` was stripped and the collapsing content no longer clipped.

A CSP nonce cannot whitelist a style *attribute*, and `style-src-attr 'unsafe-inline'` is
unimplemented in Firefox, so there is no CSP-only fix that is correct across browsers.

## What is the new behavior?

- Both offenders now apply their styles through an Angular `[style]` binding, which sets styles via
  the CSSOM (`renderer.setStyle`) rather than writing a `style` attribute. CSP does not govern the
  CSSOM, so the styles apply under a strict policy — matching the approach already used by
  `brn-input-otp`, `brn-checkbox`, and `brn-switch`. Defaults are unchanged.
- The previously hard-coded styles are now overridable inputs, so consumers who need a different
  hiding technique can supply their own (also `[style]`-bound, so they stay CSP-safe):
  - `brn-radio` → `inputStyles` (visually-hidden native input)
  - `brn-checkbox` → `hostStyles` (defaults to `display: contents`)
  - `brn-switch` → `hostStyles` (defaults to `display: contents`)

Split into two commits: a `fix` (CSP repair, no new API — safe to cherry-pick) and a `feat`
(the configurable inputs).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Defaults are unchanged for every component, so existing usage is unaffected.

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable host styling for checkbox and switch components, allowing their wrapper styles to be adjusted more easily.
  * Improved radio button and accordion styling handling so host styles are applied consistently through supported bindings.

* **Bug Fixes**
  * Updated several components to use a more reliable style application approach, improving compatibility in environments with stricter security policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->