### PR TITLE
docs: add signal custom control examples

### DIFF
--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/custom-control/country-picker.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/custom-control/country-picker.ts
@@ -17,8 +17,8 @@ export type Country = {
 	template: `
 		<hlm-combobox
 			[value]="_displayValue()"
-			(valueChange)="updateValue($event)"
 			[disabled]="disabled()"
+			(valueChange)="updateValue($event)"
 			(closed)="touchedChange.emit(true)"
 		>
 			<hlm-combobox-input [inputId]="inputId()" placeholder="Select a country" showClear />
@@ -48,7 +48,7 @@ export class CountryPicker implements FormValueControl<string | null> {
 
 	protected readonly _displayValue = linkedSignal(() => {
 		const country = this.countries.find((c) => c.code === this.value());
-		return country ? `${country.flag} ${country.label}` : '';
+		return country ? `${country.flag} ${country.label}` : null;
 	});
 
 	public readonly countries: Country[] = [
@@ -133,8 +133,8 @@ export type Country = {
 	template: \`
 		<hlm-combobox
 			[value]="_displayValue()"
-			(valueChange)="updateValue($event)"
 			[disabled]="disabled()"
+			(valueChange)="updateValue($event)"
 			(closed)="touchedChange.emit(true)"
 		>
 			<hlm-combobox-input [inputId]="inputId()" placeholder="Select a country" showClear />
@@ -151,24 +151,25 @@ export type Country = {
 })
 export class CountryPicker implements FormValueControl<string | null> {
 	private static _id = 0;
-
 	public readonly value = model<string | null>(null);
 	public readonly disabled = input<boolean>(false);
 	public readonly readonly = input<boolean>(false);
 
+	// use touchedChange with Angular v21
+	public readonly touchedChange = output<boolean>();
 	// use touch output in starting with Angular v22
-	public readonly touch = output<void>();
+	// public readonly touch = output<void>();
 
 	public readonly inputId = input<string>(\`country-picker-\${CountryPicker._id++}\`);
 
 	protected readonly _displayValue = linkedSignal(() => {
 		const country = this.countries.find((c) => c.code === this.value());
-		return country ? \`\${country.flag} \${country.label}\` : '';
+		return country ? \`\${country.flag} \${country.label}\` : null;
 	});
 
 	public readonly countries: Country[] = [
 		{ code: 'af', value: 'afghanistan', label: 'Afghanistan', continent: 'Asia', flag: '🇦🇫' },
-		// ... full country list ...
+		// full country list ...
 	];
 
 	public updateValue(value: string | null | undefined): void {

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/custom-control/country-picker.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/custom-control/country-picker.ts
@@ -1,0 +1,178 @@
+import { ChangeDetectionStrategy, Component, input, linkedSignal, model, output } from '@angular/core';
+import { FormValueControl } from '@angular/forms/signals';
+import { HlmComboboxImports } from '@spartan-ng/helm/combobox';
+
+export type Country = {
+	code: string;
+	value: string;
+	label: string;
+	continent: string;
+	flag: string;
+};
+
+@Component({
+	selector: 'spartan-country-picker',
+	imports: [HlmComboboxImports],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<hlm-combobox
+			[value]="_displayValue()"
+			(valueChange)="updateValue($event)"
+			[disabled]="disabled()"
+			(closed)="touchedChange.emit(true)"
+		>
+			<hlm-combobox-input [inputId]="inputId()" placeholder="Select a country" showClear />
+			<hlm-combobox-content *hlmComboboxPortal>
+				<hlm-combobox-empty>No items found.</hlm-combobox-empty>
+				<div hlmComboboxList>
+					@for (country of countries; track country.code) {
+						<hlm-combobox-item [value]="country.code">{{ country.flag }} {{ country.label }}</hlm-combobox-item>
+					}
+				</div>
+			</hlm-combobox-content>
+		</hlm-combobox>
+	`,
+})
+export class CountryPicker implements FormValueControl<string | null> {
+	private static _id = 0;
+	public readonly value = model<string | null>(null);
+	public readonly disabled = input<boolean>(false);
+	public readonly readonly = input<boolean>(false);
+
+	// use touchedChange with Angular v21
+	public readonly touchedChange = output<boolean>();
+	// use touch output in starting with Angular v22
+	// public readonly touch = output<void>();
+
+	public readonly inputId = input<string>(`country-picker-${CountryPicker._id++}`);
+
+	protected readonly _displayValue = linkedSignal(() => {
+		const country = this.countries.find((c) => c.code === this.value());
+		return country ? `${country.flag} ${country.label}` : '';
+	});
+
+	public readonly countries: Country[] = [
+		{ code: 'af', value: 'afghanistan', label: 'Afghanistan', continent: 'Asia', flag: '🇦🇫' },
+		{ code: 'al', value: 'albania', label: 'Albania', continent: 'Europe', flag: '🇦🇱' },
+		{ code: 'dz', value: 'algeria', label: 'Algeria', continent: 'Africa', flag: '🇩🇿' },
+		{ code: 'ad', value: 'andorra', label: 'Andorra', continent: 'Europe', flag: '🇦🇩' },
+		{ code: 'ao', value: 'angola', label: 'Angola', continent: 'Africa', flag: '🇦🇴' },
+		{ code: 'ar', value: 'argentina', label: 'Argentina', continent: 'South America', flag: '🇦🇷' },
+		{ code: 'am', value: 'armenia', label: 'Armenia', continent: 'Asia', flag: '🇦🇲' },
+		{ code: 'au', value: 'australia', label: 'Australia', continent: 'Oceania', flag: '🇦🇺' },
+		{ code: 'at', value: 'austria', label: 'Austria', continent: 'Europe', flag: '🇦🇹' },
+		{ code: 'az', value: 'azerbaijan', label: 'Azerbaijan', continent: 'Asia', flag: '🇦🇿' },
+		{ code: 'bs', value: 'bahamas', label: 'Bahamas', continent: 'North America', flag: '🇧🇸' },
+		{ code: 'bh', value: 'bahrain', label: 'Bahrain', continent: 'Asia', flag: '🇧🇭' },
+		{ code: 'bd', value: 'bangladesh', label: 'Bangladesh', continent: 'Asia', flag: '🇧🇩' },
+		{ code: 'bb', value: 'barbados', label: 'Barbados', continent: 'North America', flag: '🇧🇧' },
+		{ code: 'by', value: 'belarus', label: 'Belarus', continent: 'Europe', flag: '🇧🇾' },
+		{ code: 'be', value: 'belgium', label: 'Belgium', continent: 'Europe', flag: '🇧🇪' },
+		{ code: 'bz', value: 'belize', label: 'Belize', continent: 'North America', flag: '🇧🇿' },
+		{ code: 'bj', value: 'benin', label: 'Benin', continent: 'Africa', flag: '🇧🇯' },
+		{ code: 'bt', value: 'bhutan', label: 'Bhutan', continent: 'Asia', flag: '🇧🇹' },
+		{ code: 'bo', value: 'bolivia', label: 'Bolivia', continent: 'South America', flag: '🇧🇴' },
+		{ code: 'ba', value: 'bosnia-and-herzegovina', label: 'Bosnia and Herzegovina', continent: 'Europe', flag: '🇧🇦' },
+		{ code: 'bw', value: 'botswana', label: 'Botswana', continent: 'Africa', flag: '🇧🇼' },
+		{ code: 'br', value: 'brazil', label: 'Brazil', continent: 'South America', flag: '🇧🇷' },
+		{ code: 'bn', value: 'brunei', label: 'Brunei', continent: 'Asia', flag: '🇧🇳' },
+		{ code: 'bg', value: 'bulgaria', label: 'Bulgaria', continent: 'Europe', flag: '🇧🇬' },
+		{ code: 'bf', value: 'burkina-faso', label: 'Burkina Faso', continent: 'Africa', flag: '🇧🇫' },
+		{ code: 'bi', value: 'burundi', label: 'Burundi', continent: 'Africa', flag: '🇧🇮' },
+		{ code: 'kh', value: 'cambodia', label: 'Cambodia', continent: 'Asia', flag: '🇰🇭' },
+		{ code: 'cm', value: 'cameroon', label: 'Cameroon', continent: 'Africa', flag: '🇨🇲' },
+		{ code: 'ca', value: 'canada', label: 'Canada', continent: 'North America', flag: '🇨🇦' },
+		{ code: 'cv', value: 'cape-verde', label: 'Cape Verde', continent: 'Africa', flag: '🇨🇻' },
+		{
+			code: 'cf',
+			value: 'central-african-republic',
+			label: 'Central African Republic',
+			continent: 'Africa',
+			flag: '🇨🇫',
+		},
+		{ code: 'td', value: 'chad', label: 'Chad', continent: 'Africa', flag: '🇹🇩' },
+		{ code: 'cl', value: 'chile', label: 'Chile', continent: 'South America', flag: '🇨🇱' },
+		{ code: 'cn', value: 'china', label: 'China', continent: 'Asia', flag: '🇨🇳' },
+		{ code: 'co', value: 'colombia', label: 'Colombia', continent: 'South America', flag: '🇨🇴' },
+		{ code: 'km', value: 'comoros', label: 'Comoros', continent: 'Africa', flag: '🇰🇲' },
+		{ code: 'cg', value: 'congo', label: 'Congo', continent: 'Africa', flag: '🇨🇬' },
+		{ code: 'cr', value: 'costa-rica', label: 'Costa Rica', continent: 'North America', flag: '🇨🇷' },
+		{ code: 'hr', value: 'croatia', label: 'Croatia', continent: 'Europe', flag: '🇭🇷' },
+		{ code: 'cu', value: 'cuba', label: 'Cuba', continent: 'North America', flag: '🇨🇺' },
+		{ code: 'cy', value: 'cyprus', label: 'Cyprus', continent: 'Asia', flag: '🇨🇾' },
+		{ code: 'cz', value: 'czech-republic', label: 'Czech Republic', continent: 'Europe', flag: '🇨🇿' },
+		{ code: 'dk', value: 'denmark', label: 'Denmark', continent: 'Europe', flag: '🇩🇰' },
+		{ code: 'dj', value: 'djibouti', label: 'Djibouti', continent: 'Africa', flag: '🇩🇯' },
+		{ code: 'dm', value: 'dominica', label: 'Dominica', continent: 'North America', flag: '🇩🇲' },
+		{ code: 'do', value: 'dominican-republic', label: 'Dominican Republic', continent: 'North America', flag: '🇩🇴' },
+	];
+
+	public updateValue(value: string | null | undefined): void {
+		this.value.set(value ?? null);
+	}
+}
+
+export const countryPickerCode = `
+// country-picker.ts
+import { ChangeDetectionStrategy, Component, input, linkedSignal, model, output } from '@angular/core';
+import { FormValueControl } from '@angular/forms/signals';
+import { HlmComboboxImports } from '@spartan-ng/helm/combobox';
+
+export type Country = {
+	code: string;
+	value: string;
+	label: string;
+	continent: string;
+	flag: string;
+};
+
+@Component({
+	selector: 'spartan-country-picker',
+	imports: [HlmComboboxImports],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: \`
+		<hlm-combobox
+			[value]="_displayValue()"
+			(valueChange)="updateValue($event)"
+			[disabled]="disabled()"
+			(closed)="touchedChange.emit(true)"
+		>
+			<hlm-combobox-input [inputId]="inputId()" placeholder="Select a country" showClear />
+			<hlm-combobox-content *hlmComboboxPortal>
+				<hlm-combobox-empty>No items found.</hlm-combobox-empty>
+				<div hlmComboboxList>
+					@for (country of countries; track country.code) {
+						<hlm-combobox-item [value]="country.code">{{ country.flag }} {{ country.label }}</hlm-combobox-item>
+					}
+				</div>
+			</hlm-combobox-content>
+		</hlm-combobox>
+	\`,
+})
+export class CountryPicker implements FormValueControl<string | null> {
+	private static _id = 0;
+
+	public readonly value = model<string | null>(null);
+	public readonly disabled = input<boolean>(false);
+	public readonly readonly = input<boolean>(false);
+
+	// use touch output in starting with Angular v22
+	public readonly touch = output<void>();
+
+	public readonly inputId = input<string>(\`country-picker-\${CountryPicker._id++}\`);
+
+	protected readonly _displayValue = linkedSignal(() => {
+		const country = this.countries.find((c) => c.code === this.value());
+		return country ? \`\${country.flag} \${country.label}\` : '';
+	});
+
+	public readonly countries: Country[] = [
+		{ code: 'af', value: 'afghanistan', label: 'Afghanistan', continent: 'Asia', flag: '🇦🇫' },
+		// ... full country list ...
+	];
+
+	public updateValue(value: string | null | undefined): void {
+		this.value.set(value ?? null);
+	}
+}
+`;

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/custom-control/password-input.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/custom-control/password-input.ts
@@ -77,7 +77,7 @@ import { HlmInputGroup, HlmInputGroupImports } from '@spartan-ng/helm/input-grou
 			autoComplete="current-password"
 			[type]="_inputType()"
 			(input)="value.set($event.target.value)"
-			(blur)="touch.emit()"
+			(blur)="touchedChange.emit(true)"
 		/>
 		<hlm-input-group-addon align="inline-end">
 			<button hlmInputGroupButton size="icon-xs" (click)="togglePasswordVisibility()">
@@ -91,8 +91,10 @@ export class PasswordInput implements FormValueControl<string> {
 	public readonly disabled = input<boolean>(false);
 	public readonly readonly = input<boolean>(false);
 
+	// use touchedChange with Angular v21
+	public readonly touchedChange = output<boolean>();
 	// use touch output in starting with Angular v22
-	public readonly touch = output<void>();
+	// public readonly touch = output<void>();
 
 	public readonly inputId = input<string>();
 	public readonly placeholder = input<string>('********');

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/custom-control/password-input.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/custom-control/password-input.ts
@@ -21,7 +21,7 @@ import { HlmInputGroup, HlmInputGroupImports } from '@spartan-ng/helm/input-grou
 			autoComplete="current-password"
 			[type]="_inputType()"
 			(input)="value.set($event.target.value)"
-			(blur)="touch.emit()"
+			(blur)="touchedChange.emit(true)"
 		/>
 		<hlm-input-group-addon align="inline-end">
 			<button hlmInputGroupButton size="icon-xs" (click)="togglePasswordVisibility()">
@@ -35,8 +35,10 @@ export class PasswordInput implements FormValueControl<string> {
 	public readonly disabled = input<boolean>(false);
 	public readonly readonly = input<boolean>(false);
 
+	// use touchedChange with Angular v21
+	public readonly touchedChange = output<boolean>();
 	// use touch output in starting with Angular v22
-	public readonly touch = output<void>();
+	// public readonly touch = output<void>();
 
 	public readonly inputId = input<string>();
 	public readonly placeholder = input<string>('********');

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/custom-control/password-input.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/custom-control/password-input.ts
@@ -1,0 +1,106 @@
+import { ChangeDetectionStrategy, Component, computed, input, model, output, signal } from '@angular/core';
+import { FormValueControl } from '@angular/forms/signals';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideEye, lucideEyeOff } from '@ng-icons/lucide';
+import { HlmInputGroup, HlmInputGroupImports } from '@spartan-ng/helm/input-group';
+
+@Component({
+	selector: 'spartan-password-input',
+	imports: [HlmInputGroupImports, NgIcon],
+	providers: [provideIcons({ lucideEye, lucideEyeOff })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	hostDirectives: [HlmInputGroup],
+	template: `
+		<input
+			hlmInputGroupInput
+			[id]="inputId()"
+			[placeholder]="placeholder()"
+			[value]="value()"
+			[disabled]="disabled()"
+			[readonly]="readonly()"
+			autoComplete="current-password"
+			[type]="_inputType()"
+			(input)="value.set($event.target.value)"
+			(blur)="touch.emit()"
+		/>
+		<hlm-input-group-addon align="inline-end">
+			<button hlmInputGroupButton size="icon-xs" (click)="togglePasswordVisibility()">
+				<ng-icon [name]="_icon()" />
+			</button>
+		</hlm-input-group-addon>
+	`,
+})
+export class PasswordInput implements FormValueControl<string> {
+	public readonly value = model<string>('');
+	public readonly disabled = input<boolean>(false);
+	public readonly readonly = input<boolean>(false);
+
+	// use touch output in starting with Angular v22
+	public readonly touch = output<void>();
+
+	public readonly inputId = input<string>();
+	public readonly placeholder = input<string>('********');
+
+	protected readonly _inputType = signal<'text' | 'password'>('password');
+
+	protected readonly _icon = computed(() => (this._inputType() === 'password' ? 'lucideEye' : 'lucideEyeOff'));
+
+	public togglePasswordVisibility() {
+		this._inputType.set(this._inputType() === 'password' ? 'text' : 'password');
+	}
+}
+
+export const passwordInputCode = `
+// password-input.ts
+import { ChangeDetectionStrategy, Component, computed, input, model, output, signal } from '@angular/core';
+import { FormValueControl } from '@angular/forms/signals';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideEye, lucideEyeOff } from '@ng-icons/lucide';
+import { HlmInputGroup, HlmInputGroupImports } from '@spartan-ng/helm/input-group';
+
+@Component({
+	selector: 'spartan-password-input',
+	imports: [HlmInputGroupImports, NgIcon],
+	providers: [provideIcons({ lucideEye, lucideEyeOff })],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	hostDirectives: [HlmInputGroup],
+	template: \`
+		<input
+			hlmInputGroupInput
+			[id]="inputId()"
+			[placeholder]="placeholder()"
+			[value]="value()"
+			[disabled]="disabled()"
+			[readonly]="readonly()"
+			autoComplete="current-password"
+			[type]="_inputType()"
+			(input)="value.set($event.target.value)"
+			(blur)="touch.emit()"
+		/>
+		<hlm-input-group-addon align="inline-end">
+			<button hlmInputGroupButton size="icon-xs" (click)="togglePasswordVisibility()">
+				<ng-icon [name]="_icon()" />
+			</button>
+		</hlm-input-group-addon>
+	\`,
+})
+export class PasswordInput implements FormValueControl<string> {
+	public readonly value = model<string>('');
+	public readonly disabled = input<boolean>(false);
+	public readonly readonly = input<boolean>(false);
+
+	// use touch output in starting with Angular v22
+	public readonly touch = output<void>();
+
+	public readonly inputId = input<string>();
+	public readonly placeholder = input<string>('********');
+
+	protected readonly _inputType = signal<'text' | 'password'>('password');
+
+	protected readonly _icon = computed(() => (this._inputType() === 'password' ? 'lucideEye' : 'lucideEyeOff'));
+
+	public togglePasswordVisibility() {
+		this._inputType.set(this._inputType() === 'password' ? 'text' : 'password');
+	}
+}
+`;

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms--custom-control.demo.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms--custom-control.demo.ts
@@ -1,0 +1,203 @@
+import { Component, signal } from '@angular/core';
+import { email, form, FormField, FormRoot, minLength, required } from '@angular/forms/signals';
+import { HlmButtonImports } from '@spartan-ng/helm/button';
+import { HlmCardImports } from '@spartan-ng/helm/card';
+import { HlmFieldImports } from '@spartan-ng/helm/field';
+import { HlmInputImports } from '@spartan-ng/helm/input';
+import { PasswordInput, passwordInputCode } from './custom-control/password-input';
+
+@Component({
+	selector: 'spartan-signal-form-custom-control-demo',
+	imports: [FormRoot, FormField, HlmCardImports, HlmFieldImports, HlmInputImports, HlmButtonImports, PasswordInput],
+	host: { class: 'w-full sm:max-w-md' },
+	template: `
+		<hlm-card>
+			<hlm-card-header>
+				<h3 hlmCardTitle>Login to your account</h3>
+				<p hlmCardDescription>Enter your email below to login to your account</p>
+			</hlm-card-header>
+			<div hlmCardContent>
+				<form [formRoot]="form" id="form-custom-control-demo">
+					<hlm-field-group>
+						<hlm-field>
+							<label hlmFieldLabel for="email">Email</label>
+							<input
+								hlmInput
+								id="email"
+								placeholder="spartan@example.com"
+								autoComplete="email"
+								[formField]="form.email"
+							/>
+
+							@for (error of form.email().errors(); track error.kind) {
+								<hlm-field-error [validator]="error.kind">
+									{{ error.message }}
+								</hlm-field-error>
+							}
+						</hlm-field>
+						<hlm-field>
+							<label hlmFieldLabel for="password">Password</label>
+							<spartan-password-input inputId="password" [formField]="form.password" />
+							@for (error of form.password().errors(); track error.kind) {
+								<hlm-field-error [validator]="error.kind">
+									{{ error.message }}
+								</hlm-field-error>
+							}
+						</hlm-field>
+					</hlm-field-group>
+				</form>
+			</div>
+			<hlm-card-footer>
+				<hlm-field>
+					<button hlmBtn type="submit" form="form-custom-control-demo">Login</button>
+					<button hlmBtn variant="outline" type="button" (click)="reset()">Reset</button>
+					<hlm-field-description class="text-center">
+						Don't have an account?
+						<a href="#">Sign up</a>
+					</hlm-field-description>
+				</hlm-field>
+			</hlm-card-footer>
+		</hlm-card>
+	`,
+})
+export class SignalFormCustomControlDemo {
+	protected readonly _model = signal({
+		email: '',
+		password: '',
+	});
+
+	public readonly form = form(
+		this._model,
+		(schemaPath) => {
+			required(schemaPath.email, { message: 'Email is a required field.' });
+			email(schemaPath.email, { message: 'Email must be a valid email address.' });
+			required(schemaPath.password, { message: 'Password is a required field.' });
+			minLength(schemaPath.password, 8, { message: 'Password must be at least 8 characters long.' });
+		},
+		{
+			// triggers the submission flow by calling `submit()` - marks all fields as touched, revealing validation errors
+			submission: {
+				action: async () => {
+					const model = this._model();
+
+					console.log('You submitted the following values:', JSON.stringify(model, null, 2));
+
+					// submit to api
+				},
+			},
+		},
+	);
+
+	reset() {
+		this.form().reset({
+			email: '',
+			password: '',
+		});
+	}
+}
+
+export const signalFormsCustomControlDemoCode = `
+${passwordInputCode}
+
+// login-form.ts
+import { Component, signal } from '@angular/core';
+import { email, form, FormField, FormRoot, minLength, required } from '@angular/forms/signals';
+import { HlmButtonImports } from '@spartan-ng/helm/button';
+import { HlmCardImports } from '@spartan-ng/helm/card';
+import { HlmFieldImports } from '@spartan-ng/helm/field';
+import { HlmInputImports } from '@spartan-ng/helm/input';
+import { PasswordInput } from './custom-control/password-input';
+
+@Component({
+	selector: 'spartan-signal-form-custom-control-demo',
+	imports: [FormRoot, FormField, HlmCardImports, HlmFieldImports, HlmInputImports, HlmButtonImports, PasswordInput],
+	host: { class: 'w-full sm:max-w-md' },
+	template: \`
+		<hlm-card>
+			<hlm-card-header>
+				<h3 hlmCardTitle>Login to your account</h3>
+				<p hlmCardDescription>Enter your email below to login to your account</p>
+			</hlm-card-header>
+			<div hlmCardContent>
+				<form [formRoot]="form" id="form-custom-control-demo">
+					<hlm-field-group>
+						<hlm-field>
+							<label hlmFieldLabel for="email">Email</label>
+							<input
+								hlmInput
+								id="email"
+								placeholder="spartan@example.com"
+								autoComplete="email"
+								[formField]="form.email"
+							/>
+
+							@for (error of form.email().errors(); track error.kind) {
+								<hlm-field-error [validator]="error.kind">
+									{{ error.message }}
+								</hlm-field-error>
+							}
+						</hlm-field>
+						<hlm-field>
+							<label hlmFieldLabel for="password">Password</label>
+							<spartan-password-input inputId="password" [formField]="form.password" />
+							@for (error of form.password().errors(); track error.kind) {
+								<hlm-field-error [validator]="error.kind">
+									{{ error.message }}
+								</hlm-field-error>
+							}
+						</hlm-field>
+					</hlm-field-group>
+				</form>
+			</div>
+			<hlm-card-footer>
+				<hlm-field>
+					<button hlmBtn type="submit" form="form-custom-control-demo">Login</button>
+					<button hlmBtn variant="outline" type="button" (click)="reset()">Reset</button>
+					<hlm-field-description class="text-center">
+						Don't have an account?
+						<a href="#">Sign up</a>
+					</hlm-field-description>
+				</hlm-field>
+			</hlm-card-footer>
+		</hlm-card>
+	\`,
+})
+export class SignalFormCustomControlDemo {
+	protected readonly _model = signal({
+		email: '',
+		password: '',
+	});
+
+	public readonly form = form(
+		this._model,
+		(schemaPath) => {
+			required(schemaPath.email, { message: 'Email is a required field.' });
+			email(schemaPath.email, { message: 'Email must be a valid email address.' });
+			required(schemaPath.password, { message: 'Password is a required field.' });
+			minLength(schemaPath.password, 8, { message: 'Password must be at least 8 characters long.' });
+		},
+		{
+			// triggers the submission flow by calling \`submit()\` - marks all fields as touched, revealing validation errors
+			submission: {
+				action: async () => {
+					const model = this._model();
+
+					console.log('You submitted the following values:', JSON.stringify(model, null, 2));
+
+					// submit to api
+				},
+			},
+		},
+	);
+
+	reset() {
+		this.form().reset({
+			email: '',
+			password: '',
+		});
+	}
+}
+`;
+
+
+export const demoPasswordInputGroupCode = ``

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms--custom-control.demo.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms--custom-control.demo.ts
@@ -199,5 +199,37 @@ export class SignalFormCustomControlDemo {
 }
 `;
 
+export const demoPasswordInputGroupCode = `
+<!-- Password field with input group -->
+<hlm-field>
+	<label hlmFieldLabel for="password">Password</label>
+	<hlm-input-group>
+		<input 
+			hlmInputGroupInput 
+			id="password" 
+			autoComplete="current-password" 
+			[type]="_inputType()" 
+			[formField]="form.password" />
+		<hlm-input-group-addon align="inline-end">
+			<button hlmInputGroupButton size="icon-xs" (click)="togglePasswordVisibility()">
+				<ng-icon [name]="_icon()" />
+				<span class="sr-only">Toggle password visibility</span>
+			</button>
+		</hlm-input-group-addon>
+	</hlm-input-group>
+	@for (error of form.password().errors(); track error.kind) {
+		<hlm-field-error [validator]="error.kind">
+			{{ error.message }}
+		</hlm-field-error>
+	}
+</hlm-field>
 
-export const demoPasswordInputGroupCode = ``
+// Component logic
+protected readonly _inputType = signal<'text' | 'password'>('password');
+
+protected readonly _icon = computed(() => (this._inputType() === 'password' ? 'lucideEye' : 'lucideEyeOff'));
+
+public togglePasswordVisibility() {
+	this._inputType.set(this._inputType() === 'password' ? 'text' : 'password');
+}
+`;

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms--custom-control.demo.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms--custom-control.demo.ts
@@ -4,6 +4,7 @@ import { HlmButtonImports } from '@spartan-ng/helm/button';
 import { HlmCardImports } from '@spartan-ng/helm/card';
 import { HlmFieldImports } from '@spartan-ng/helm/field';
 import { HlmInputImports } from '@spartan-ng/helm/input';
+import { CountryPicker, countryPickerCode } from './custom-control/country-picker';
 import { PasswordInput, passwordInputCode } from './custom-control/password-input';
 
 @Component({
@@ -195,6 +196,137 @@ export class SignalFormCustomControlDemo {
 			email: '',
 			password: '',
 		});
+	}
+}
+`;
+
+@Component({
+	selector: 'spartan-signal-form-country-picker-demo',
+	imports: [FormRoot, FormField, HlmCardImports, HlmFieldImports, HlmInputImports, HlmButtonImports, CountryPicker],
+	host: { class: 'w-full sm:max-w-sm' },
+	template: `
+		<hlm-card>
+			<hlm-card-header>
+				<h3 hlmCardTitle>Shipping information</h3>
+				<p hlmCardDescription>Where should we ship your order?</p>
+			</hlm-card-header>
+			<div hlmCardContent>
+				<form [formRoot]="form" id="form-country-picker-demo">
+					<hlm-field-group>
+						<hlm-field>
+							<label hlmFieldLabel for="country">Country</label>
+							<spartan-country-picker inputId="country" [formField]="form.country" />
+							@for (error of form.country().errors(); track error.kind) {
+								<hlm-field-error [validator]="error.kind">
+									{{ error.message }}
+								</hlm-field-error>
+							}
+						</hlm-field>
+					</hlm-field-group>
+				</form>
+			</div>
+			<hlm-card-footer>
+				<hlm-field>
+					<button hlmBtn type="submit" form="form-country-picker-demo">Submit</button>
+					<button hlmBtn variant="outline" type="button" (click)="reset()">Reset</button>
+				</hlm-field>
+			</hlm-card-footer>
+		</hlm-card>
+	`,
+})
+export class SignalFormCountryPickerDemo {
+	protected readonly _model = signal<{ country: string | null }>({
+		country: null,
+	});
+
+	public readonly form = form(
+		this._model,
+		(schemaPath) => {
+			required(schemaPath.country, { message: 'Please select a country.' });
+		},
+		{
+			submission: {
+				action: async () => {
+					const model = this._model();
+					console.log('You submitted the following values:', JSON.stringify(model, null, 2));
+				},
+			},
+		},
+	);
+
+	reset() {
+		this.form().reset({ country: null });
+	}
+}
+
+export const signalFormsCountryPickerDemoCode = `
+${countryPickerCode}
+
+// shipping-form.ts
+import { Component, signal } from '@angular/core';
+import { form, FormField, FormRoot, required } from '@angular/forms/signals';
+import { HlmButtonImports } from '@spartan-ng/helm/button';
+import { HlmCardImports } from '@spartan-ng/helm/card';
+import { HlmFieldImports } from '@spartan-ng/helm/field';
+import { HlmInputImports } from '@spartan-ng/helm/input';
+import { CountryPicker } from './custom-control/country-picker';
+
+@Component({
+	selector: 'app-shipping-form',
+	imports: [FormRoot, FormField, HlmCardImports, HlmFieldImports, HlmInputImports, HlmButtonImports, CountryPicker],
+	host: { class: 'w-full sm:max-w-sm' },
+	template: \`
+		<hlm-card>
+			<hlm-card-header>
+				<h3 hlmCardTitle>Shipping information</h3>
+				<p hlmCardDescription>Where should we ship your order?</p>
+			</hlm-card-header>
+			<div hlmCardContent>
+				<form [formRoot]="form" id="form-country-picker-demo">
+					<hlm-field-group>
+						<hlm-field>
+							<label hlmFieldLabel for="country">Country</label>
+							<spartan-country-picker inputId="country" [formField]="form.country" />
+							@for (error of form.country().errors(); track error.kind) {
+								<hlm-field-error [validator]="error.kind">
+									{{ error.message }}
+								</hlm-field-error>
+							}
+						</hlm-field>
+					</hlm-field-group>
+				</form>
+			</div>
+			<hlm-card-footer>
+				<hlm-field>
+					<button hlmBtn type="submit" form="form-country-picker-demo">Submit</button>
+					<button hlmBtn variant="outline" type="button" (click)="reset()">Reset</button>
+				</hlm-field>
+			</hlm-card-footer>
+		</hlm-card>
+	\`,
+})
+export class ShippingForm {
+	protected readonly _model = signal<{ country: string | null }>({
+		country: null,
+	});
+
+	public readonly form = form(
+		this._model,
+		(schemaPath) => {
+			required(schemaPath.country, { message: 'Please select a country.' });
+		},
+		{
+			submission: {
+				action: async () => {
+					const model = this._model();
+					console.log('You submitted the following values:', JSON.stringify(model, null, 2));
+				},
+			},
+		},
+	);
+
+	reset() {
+		this.form().reset({ country: null });
 	}
 }
 `;

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms.page.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms.page.ts
@@ -15,6 +15,11 @@ import { link } from '@spartan-ng/app/app/shared/typography/link';
 import { hlmCode, hlmP, hlmUl } from '@spartan-ng/helm/typography';
 import { SignalFormCheckboxDemo, signalFormsCheckboxDemoCode } from './signal-forms--checkbox.demo';
 import { SignalFormComplexDemo, signalFormsComplexDemoCode } from './signal-forms--complex.demo';
+import {
+	demoPasswordInputGroupCode,
+	SignalFormCustomControlDemo,
+	signalFormsCustomControlDemoCode,
+} from './signal-forms--custom-control.demo';
 import { SignalFormInputDemo, signalFormsInputDemoCode } from './signal-forms--input.demo';
 import { SignalFormRadioGroupDemo, signalFormsRadioGroupDemoCode } from './signal-forms--radio-group.demo';
 import { SignalFormSelectDemo, signalFormsSelectDemoCode } from './signal-forms--select.demo';
@@ -59,6 +64,7 @@ export const routeMeta: RouteMeta = {
 		SignalFormRadioGroupDemo,
 		SignalFormSwitchDemo,
 		SignalFormComplexDemo,
+		SignalFormCustomControlDemo,
 	],
 	template: `
 		<section spartanMainSection>
@@ -69,6 +75,38 @@ export const routeMeta: RouteMeta = {
 				<code class="${hlmCode}">HlmField</code>
 				component, how to handle validation and how to display errors.
 			</p>
+
+			<spartan-section-sub-heading id="custom-control">Custom Control</spartan-section-sub-heading>
+
+			<p class="${hlmP}">
+				Signal Forms allows you to build
+				<a
+					href="https://angular.dev/guide/forms/signals/custom-controls"
+					class="underline"
+					target="_blank"
+					rel="noopener"
+				>
+					custom form controls
+				</a>
+				using the
+				<code class="${hlmCode}">FormValueControl</code>
+				interface.
+			</p>
+
+			<p class="${hlmP}">
+				In this example, we are going to build a custom password input control that toggles visibility and integrates
+				seamlessly with Signal Forms.
+			</p>
+
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-signal-form-custom-control-demo />
+				</div>
+				<spartan-code secondTab [code]="_signalFormsCustomControlDemoCode" />
+			</spartan-tabs>
+
+			<h3 id="create-password-input-group" spartanH4>Create password input group</h3>
+			<spartan-code class="mt-6" fileName="login-form.ts" [code]="_demoPasswordInputGroupCode" />
 
 			<spartan-section-sub-heading id="demo">Demo</spartan-section-sub-heading>
 			<p class="${hlmP}">
@@ -469,4 +507,7 @@ export default class SignalFormsPage {
 	protected readonly _signalFormsSelectDemoCode = signalFormsSelectDemoCode;
 	protected readonly _signalFormsSwitchDemoCode = signalFormsSwitchDemoCode;
 	protected readonly _signalFormsComplexDemoCode = signalFormsComplexDemoCode;
+
+	protected readonly _signalFormsCustomControlDemoCode = signalFormsCustomControlDemoCode;
+	protected readonly _demoPasswordInputGroupCode = demoPasswordInputGroupCode;
 }

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms.page.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms.page.ts
@@ -13,6 +13,7 @@ import { Tabs } from '@spartan-ng/app/app/shared/layout/tabs';
 import { metaWith } from '@spartan-ng/app/app/shared/meta/meta.util';
 import { link } from '@spartan-ng/app/app/shared/typography/link';
 import { hlmCode, hlmP, hlmUl } from '@spartan-ng/helm/typography';
+import { passwordInputCode } from './custom-control/password-input';
 import { SignalFormCheckboxDemo, signalFormsCheckboxDemoCode } from './signal-forms--checkbox.demo';
 import { SignalFormComplexDemo, signalFormsComplexDemoCode } from './signal-forms--complex.demo';
 import {
@@ -105,8 +106,89 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_signalFormsCustomControlDemoCode" />
 			</spartan-tabs>
 
-			<h3 id="create-password-input-group" spartanH4>Create password input group</h3>
+			<h3 id="inline-input-group" spartanH4>Inline input group</h3>
+
+			<p class="${hlmP}">
+				The example below builds an inline input group with a password field and a visibility toggle
+				<code class="${hlmCode}">button</code>
+				. You can customize your form fields and inputs directly inline. This is useful for one-off inputs where
+				creating a dedicated component would be overkill.
+			</p>
+
 			<spartan-code class="mt-6" fileName="login-form.ts" [code]="_demoPasswordInputGroupCode" />
+
+			<h3 id="custom-control-component" spartanH4>Custom control component</h3>
+
+			<p class="${hlmP}">
+				When you want to reuse a custom input across your app — like a password input used in login, register, and
+				password reset forms — extract it into a standalone component that implements the
+				<code class="${hlmCode}">FormValueControl</code>
+				interface. This lets your component integrate natively with Signal Forms, just like any built-in form control.
+			</p>
+
+			<p class="${hlmP}">
+				When implementing
+				<code class="${hlmCode}">FormValueControl</code>
+				there are a few things to wire up:
+			</p>
+			<ul class="${hlmUl}">
+				<li>
+					Set up a
+					<code class="${hlmCode}">value</code>
+					model and bind it to the input with
+					<code class="${hlmCode}">[value]="value()"</code>
+					and
+					<code class="${hlmCode}">(input)="value.set($event.target.value)"</code>
+					, as shown in the password input example below.
+				</li>
+				<li>
+					Add
+					<a
+						class="${link}"
+						href="https://angular.dev/guide/forms/signals/custom-controls#adding-state-signals"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						state signals
+					</a>
+					(
+					<code class="${hlmCode}">disabled</code>
+					,
+					<code class="${hlmCode}">readonly</code>
+					etc.) to make your control react to the form control state changes.
+				</li>
+				<li>
+					Call
+					<code class="${hlmCode}">touch()</code>
+					on your input's blur event (
+					<a
+						href="https://agoge.spartan.ng/forms/signal-forms#custom-control"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Angular v22+
+					</a>
+					). In Angular v21, use
+					<code class="${hlmCode}">touchedChange</code>
+					instead — see
+					<a
+						class="${link}"
+						href="https://angular.dev/guide/forms/signals/custom-controls#working-with-debounceblur"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						debounce / blur
+					</a>
+					for details.
+				</li>
+				<li>
+					Form components (like Input, Autocomplete, Select) use
+					<code class="${hlmCode}">BrnFieldControl</code>
+					and receive automatically invalid states from the form control.
+				</li>
+			</ul>
+
+			<spartan-code class="mt-6" fileName="password-input.ts" [code]="_demoPasswordInputComponentCode" />
 
 			<spartan-section-sub-heading id="demo">Demo</spartan-section-sub-heading>
 			<p class="${hlmP}">
@@ -510,4 +592,5 @@ export default class SignalFormsPage {
 
 	protected readonly _signalFormsCustomControlDemoCode = signalFormsCustomControlDemoCode;
 	protected readonly _demoPasswordInputGroupCode = demoPasswordInputGroupCode;
+	protected readonly _demoPasswordInputComponentCode = passwordInputCode;
 }

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms.page.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms.page.ts
@@ -18,7 +18,9 @@ import { SignalFormCheckboxDemo, signalFormsCheckboxDemoCode } from './signal-fo
 import { SignalFormComplexDemo, signalFormsComplexDemoCode } from './signal-forms--complex.demo';
 import {
 	demoPasswordInputGroupCode,
+	SignalFormCountryPickerDemo,
 	SignalFormCustomControlDemo,
+	signalFormsCountryPickerDemoCode,
 	signalFormsCustomControlDemoCode,
 } from './signal-forms--custom-control.demo';
 import { SignalFormInputDemo, signalFormsInputDemoCode } from './signal-forms--input.demo';
@@ -66,6 +68,7 @@ export const routeMeta: RouteMeta = {
 		SignalFormSwitchDemo,
 		SignalFormComplexDemo,
 		SignalFormCustomControlDemo,
+		SignalFormCountryPickerDemo,
 	],
 	template: `
 		<section spartanMainSection>
@@ -189,6 +192,24 @@ export const routeMeta: RouteMeta = {
 			</ul>
 
 			<spartan-code class="mt-6" fileName="password-input.ts" [code]="_demoPasswordInputComponentCode" />
+
+			<h3 id="country-picker" spartanH4>Country picker</h3>
+
+			<p class="${hlmP}">
+				For more complex custom controls, you can wrap components like the combobox. The example below builds a country
+				picker by wrapping
+				<code class="${hlmCode}">HlmCombobox</code>
+				with a
+				<code class="${hlmCode}">FormValueControl</code>
+				interface.
+			</p>
+
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-signal-form-country-picker-demo />
+				</div>
+				<spartan-code secondTab [code]="_signalFormsCountryPickerDemoCode" />
+			</spartan-tabs>
 
 			<spartan-section-sub-heading id="demo">Demo</spartan-section-sub-heading>
 			<p class="${hlmP}">
@@ -591,6 +612,7 @@ export default class SignalFormsPage {
 	protected readonly _signalFormsComplexDemoCode = signalFormsComplexDemoCode;
 
 	protected readonly _signalFormsCustomControlDemoCode = signalFormsCustomControlDemoCode;
+	protected readonly _signalFormsCountryPickerDemoCode = signalFormsCountryPickerDemoCode;
 	protected readonly _demoPasswordInputGroupCode = demoPasswordInputGroupCode;
 	protected readonly _demoPasswordInputComponentCode = passwordInputCode;
 }

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms.page.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms.page.ts
@@ -80,144 +80,6 @@ export const routeMeta: RouteMeta = {
 				component, how to handle validation and how to display errors.
 			</p>
 
-			<spartan-section-sub-heading id="custom-control">Custom Control</spartan-section-sub-heading>
-
-			<p class="${hlmP}">
-				Signal Forms allows you to build
-				<a
-					href="https://angular.dev/guide/forms/signals/custom-controls"
-					class="underline"
-					target="_blank"
-					rel="noopener"
-				>
-					custom form controls
-				</a>
-				using the
-				<code class="${hlmCode}">FormValueControl</code>
-				interface.
-			</p>
-
-			<p class="${hlmP}">
-				In this example, we are going to build a custom password input control that toggles visibility and integrates
-				seamlessly with Signal Forms.
-			</p>
-
-			<spartan-tabs firstTab="Preview" secondTab="Code">
-				<div spartanCodePreview firstTab>
-					<spartan-signal-form-custom-control-demo />
-				</div>
-				<spartan-code secondTab [code]="_signalFormsCustomControlDemoCode" />
-			</spartan-tabs>
-
-			<h3 id="inline-input-group" spartanH4>Inline input group</h3>
-
-			<p class="${hlmP}">
-				The example below builds an inline input group with a password field and a visibility toggle
-				<code class="${hlmCode}">button</code>
-				. You can customize your form fields and inputs directly inline. This is useful for one-off inputs where
-				creating a dedicated component would be overkill.
-			</p>
-
-			<spartan-code class="mt-6" fileName="login-form.ts" [code]="_demoPasswordInputGroupCode" />
-
-			<h3 id="custom-control-component" spartanH4>Custom control component</h3>
-
-			<p class="${hlmP}">
-				When you want to reuse a custom input across your app — like a password input used in login, register, and
-				password reset forms — extract it into a standalone component that implements the
-				<code class="${hlmCode}">FormValueControl</code>
-				interface. This lets your component integrate natively with Signal Forms, just like any built-in form control.
-			</p>
-
-			<p class="${hlmP}">
-				When implementing
-				<code class="${hlmCode}">FormValueControl</code>
-				there are a few things to wire up:
-			</p>
-			<ul class="${hlmUl}">
-				<li>
-					Set up a
-					<code class="${hlmCode}">value</code>
-					model and bind it to the input with
-					<code class="${hlmCode}">[value]="value()"</code>
-					and
-					<code class="${hlmCode}">(input)="value.set($event.target.value)"</code>
-					, as shown in the password input example below.
-				</li>
-				<li>
-					Add
-					<a
-						class="${link}"
-						href="https://angular.dev/guide/forms/signals/custom-controls#adding-state-signals"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						state signals
-					</a>
-					(
-					<code class="${hlmCode}">disabled</code>
-					,
-					<code class="${hlmCode}">readonly</code>
-					etc.) to make your control react to the form control state changes.
-				</li>
-				<li>
-					Call
-					<code class="${hlmCode}">touch()</code>
-					on your input's blur event (
-					<a
-						href="https://agoge.spartan.ng/forms/signal-forms#custom-control"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Angular v22+
-					</a>
-					). In Angular v21, use
-					<code class="${hlmCode}">touchedChange</code>
-					instead — see
-					<a
-						class="${link}"
-						href="https://angular.dev/guide/forms/signals/custom-controls#working-with-debounceblur"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						debounce / blur
-					</a>
-					for details.
-				</li>
-				<li>
-					Form components (like Input, Autocomplete, Select) use
-					<code class="${hlmCode}">BrnFieldControl</code>
-					and receive automatically invalid states from the form control.
-				</li>
-			</ul>
-
-			<spartan-code class="mt-6" fileName="password-input.ts" [code]="_demoPasswordInputComponentCode" />
-
-			<h3 id="value-transformation" spartanH4>Value transformation</h3>
-
-			<p class="${hlmP}">
-				For more complex custom controls, you can wrap components like the combobox. This example builds a country
-				picker that performs
-				<a
-					class="${link}"
-					href="https://angular.dev/guide/forms/signals/custom-controls#value-transformation"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					value transformation
-				</a>
-				to map a country code to its display label. The form stores the country code string, while the combobox uses
-				<code class="${hlmCode}">linkedSignal</code>
-				to transform it into the flag and label for display.
-			</p>
-
-			<spartan-tabs firstTab="Preview" secondTab="Code">
-				<div spartanCodePreview firstTab>
-					<spartan-signal-form-country-picker-demo />
-				</div>
-				<spartan-code secondTab [code]="_signalFormsCountryPickerDemoCode" />
-			</spartan-tabs>
-
 			<spartan-section-sub-heading id="demo">Demo</spartan-section-sub-heading>
 			<p class="${hlmP}">
 				We are going to build the following form. It has a simple text input and a textarea. On submit, we'll validate
@@ -587,6 +449,144 @@ export const routeMeta: RouteMeta = {
 				to reset the form to its default values and mark all controls as pristine and untouched.
 			</p>
 			<spartan-code class="mt-6" [code]="_demoResetForm" />
+
+			<spartan-section-sub-heading id="custom-control">Custom Control</spartan-section-sub-heading>
+
+			<p class="${hlmP}">
+				Signal Forms allows you to build
+				<a
+					href="https://angular.dev/guide/forms/signals/custom-controls"
+					class="underline"
+					target="_blank"
+					rel="noopener"
+				>
+					custom form controls
+				</a>
+				using the
+				<code class="${hlmCode}">FormValueControl</code>
+				interface.
+			</p>
+
+			<p class="${hlmP}">
+				In this example, we are going to build a custom password input control that toggles visibility and integrates
+				seamlessly with Signal Forms.
+			</p>
+
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-signal-form-custom-control-demo />
+				</div>
+				<spartan-code secondTab [code]="_signalFormsCustomControlDemoCode" />
+			</spartan-tabs>
+
+			<h3 id="inline-input-group" spartanH4>Inline input group</h3>
+
+			<p class="${hlmP}">
+				The example below builds an inline input group with a password field and a visibility toggle
+				<code class="${hlmCode}">button</code>
+				. You can customize your form fields and inputs directly inline. This is useful for one-off inputs where
+				creating a dedicated component would be overkill.
+			</p>
+
+			<spartan-code class="mt-6" fileName="login-form.ts" [code]="_demoPasswordInputGroupCode" />
+
+			<h3 id="custom-control-component" spartanH4>Custom control component</h3>
+
+			<p class="${hlmP}">
+				When you want to reuse a custom input across your app — like a password input used in login, register, and
+				password reset forms — extract it into a standalone component that implements the
+				<code class="${hlmCode}">FormValueControl</code>
+				interface. This lets your component integrate natively with Signal Forms, just like any built-in form control.
+			</p>
+
+			<p class="${hlmP}">
+				When implementing
+				<code class="${hlmCode}">FormValueControl</code>
+				there are a few things to wire up:
+			</p>
+			<ul class="${hlmUl}">
+				<li>
+					Set up a
+					<code class="${hlmCode}">value</code>
+					model and bind it to the input with
+					<code class="${hlmCode}">[value]="value()"</code>
+					and
+					<code class="${hlmCode}">(input)="value.set($event.target.value)"</code>
+					, as shown in the password input example below.
+				</li>
+				<li>
+					Add
+					<a
+						class="${link}"
+						href="https://angular.dev/guide/forms/signals/custom-controls#adding-state-signals"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						state signals
+					</a>
+					(
+					<code class="${hlmCode}">disabled</code>
+					,
+					<code class="${hlmCode}">readonly</code>
+					etc.) to make your control react to the form control state changes.
+				</li>
+				<li>
+					Call
+					<code class="${hlmCode}">touch()</code>
+					on your input's blur event (
+					<a
+						href="https://agoge.spartan.ng/forms/signal-forms#custom-control"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Angular v22+
+					</a>
+					). In Angular v21, use
+					<code class="${hlmCode}">touchedChange</code>
+					instead — see
+					<a
+						class="${link}"
+						href="https://angular.dev/guide/forms/signals/custom-controls#working-with-debounceblur"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						debounce / blur
+					</a>
+					for details.
+				</li>
+				<li>
+					Form components (like Input, Autocomplete, Select) use
+					<code class="${hlmCode}">BrnFieldControl</code>
+					and receive automatically invalid states from the form control.
+				</li>
+			</ul>
+
+			<spartan-code class="mt-6" fileName="password-input.ts" [code]="_demoPasswordInputComponentCode" />
+
+			<h3 id="value-transformation" spartanH4>Value transformation</h3>
+
+			<p class="${hlmP}">
+				For more complex custom controls, you can wrap components like the combobox. This example builds a country
+				picker that performs
+				<a
+					class="${link}"
+					href="https://angular.dev/guide/forms/signals/custom-controls#value-transformation"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					value transformation
+				</a>
+				to map a country code to its display label. The form stores the country code string, while the combobox uses
+				<code class="${hlmCode}">linkedSignal</code>
+				to transform it into the flag and label for display.
+			</p>
+
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-signal-form-country-picker-demo />
+				</div>
+				<spartan-code secondTab [code]="_signalFormsCountryPickerDemoCode" />
+			</spartan-tabs>
 
 			<spartan-page-bottom-nav>
 				<spartan-page-bottom-nav-link href="/stack/overview" label="Stack" />

--- a/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms.page.ts
+++ b/apps/app/src/app/pages/(forms)/forms/(signal-forms)/signal-forms.page.ts
@@ -193,15 +193,22 @@ export const routeMeta: RouteMeta = {
 
 			<spartan-code class="mt-6" fileName="password-input.ts" [code]="_demoPasswordInputComponentCode" />
 
-			<h3 id="country-picker" spartanH4>Country picker</h3>
+			<h3 id="value-transformation" spartanH4>Value transformation</h3>
 
 			<p class="${hlmP}">
-				For more complex custom controls, you can wrap components like the combobox. The example below builds a country
-				picker by wrapping
-				<code class="${hlmCode}">HlmCombobox</code>
-				with a
-				<code class="${hlmCode}">FormValueControl</code>
-				interface.
+				For more complex custom controls, you can wrap components like the combobox. This example builds a country
+				picker that performs
+				<a
+					class="${link}"
+					href="https://angular.dev/guide/forms/signals/custom-controls#value-transformation"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					value transformation
+				</a>
+				to map a country code to its display label. The form stores the country code string, while the combobox uses
+				<code class="${hlmCode}">linkedSignal</code>
+				to transform it into the flag and label for display.
 			</p>
 
 			<spartan-tabs firstTab="Preview" secondTab="Code">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1571

## What is the new behavior?

Add a new section about [Custom control](http://localhost:4200/forms/signal-forms#custom-control) to Signal Forms docs. Section includes a Password Input and Country Picker example using `FormValueControl`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive signal-based form demos for login and shipping workflows, including validation feedback and submission logging.
  * Introduced a reusable country picker control with searchable selection and nullable value handling.
  * Added a password input control with show/hide visibility, integrated into signal form examples.
  * Expanded the Signal Forms page with new custom control documentation and value-transformation examples, plus reset actions for the demo forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->