### PR TITLE
fix(cli): cap typescript dependency below 7.0.0. Closes #1637

### DIFF
--- a/libs/cli/package.json
+++ b/libs/cli/package.json
@@ -25,7 +25,7 @@
 		"semver": "7.5.4",
 		"tailwind-merge": "^3.3.1",
 		"ts-morph": "25.0.1",
-		"typescript": ">=5.0.0",
+		"typescript": ">=5.0.0 <7.0.0",
 		"zod": "^3.25.76"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
The @phenomnomnominal/tsquery peer package breaks on TypeScript 7.0 (go rewrite), causing the CLI to crash with "Cannot convert undefined or null to object" when generating UI components in fresh Angular 22 projects.

Closes #1637

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

libs/cli

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] menubar
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [x] cli
- [ ] mcp

## What is the current behavior?

Check #1637 for current behavior

Closes #1637 

## What is the new behavior?

The cli can now install component without the error that was being shown previously. This is the expected behavior

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

How did I test changes ?  
- forked and downloaded source. 
- capped the dependency, 
- build the cli, 
- packed the build,
- created fresh app with ng v22
- installed my local build
- tried to add a component (Success)
- tried to build (failed) noticed that brain was using the wrong path (same as my local cli)
- installed brain again from the right path . retried ng build. success

Why do I believe this is the right fix ?
I did some research with AI and apparently @phenomnomnominal/tsquery is using an API that does not exist on v7. forgot to append the whole conversation here. let me know if you need it. since both v5 and v6 still expose the API the way @phenomnomnominal/tsquery expects it, I chose to cap ts .  According to claude (in the research) the API was moved into  **/unstable/** which made me think that we could wait a bit more before thinking on support ts7

Trying to support ts7 in the current state would require fixing upstream, which is out of scope. 
There were also other libs given as alternative, but the fix would be now changing dependencies and rewriting some code in the cli to use the new dep, which seemed more problematic than the current one

I'm open to suggestions if you believe something else needs to be done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CLI’s supported TypeScript version range to narrow compatibility to a more defined window, improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->