### PR TITLE
fix(checkbox): guard deferred blur after destruction

### DIFF
--- a/libs/brain/checkbox/src/lib/brn-checkbox.spec.ts
+++ b/libs/brain/checkbox/src/lib/brn-checkbox.spec.ts
@@ -202,6 +202,22 @@ describe('BrnCheckboxComponent', () => {
 			await user.keyboard('[Space]');
 			await validateCheckboxOn(options);
 		});
+		it('does not emit touched after destruction while blur handling is deferred', async () => {
+			const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+			try {
+				const { container, checkboxElement } = await setup();
+
+				checkboxElement.focus();
+				checkboxElement.blur();
+				container.fixture.destroy();
+				await Promise.resolve();
+
+				expect(consoleWarn).not.toHaveBeenCalledWith(expect.stringContaining('NG0953'));
+			} finally {
+				consoleWarn.mockRestore();
+			}
+		});
 	});
 
 	describe('inside <label>', () => {

--- a/libs/brain/checkbox/src/lib/brn-checkbox.ts
+++ b/libs/brain/checkbox/src/lib/brn-checkbox.ts
@@ -294,20 +294,22 @@ export class BrnCheckbox implements ControlValueAccessor, AfterContentInit, OnDe
 					this._cdr.markForCheck();
 				}
 				if (!focusOrigin) {
-					// When a focused element becomes disabled, the browser *immediately* fires a blur event.
-					// Angular does not expect events to be raised during change detection, so any state
-					// change (such as a form control's ng-touched) will cause a changed-after-checked error.
-					// See https://github.com/angular/angular/issues/17793. To work around this, we defer
-					// telling the form control it has been touched until the next tick.
-					Promise.resolve().then(() => {
-						this._focusVisible.set(false);
-						this._focused.set(false);
-						this._onTouched();
-						this.touched.emit();
-						this._cdr.markForCheck();
-					});
+					// A focused element can blur synchronously while Angular is rendering when it becomes disabled,
+					// so defer form-state writes until the next microtask. See angular/angular#17793.
+					// The checkbox may be destroyed before that microtask runs. See spartan-ng/spartan#1630.
+					Promise.resolve().then(() => this._handleBlur());
 				}
 			});
+	}
+
+	private _handleBlur(): void {
+		if (this._destroyRef.destroyed) return;
+
+		this._focusVisible.set(false);
+		this._focused.set(false);
+		this._onTouched();
+		this.touched.emit();
+		this._cdr.markForCheck();
 	}
 
 	ngOnDestroy() {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added/updated where required

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package is being modified?

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] button
- [ ] calendar
- [ ] card
- [ ] carousel
- [x] checkbox
- [ ] collapsible
- [ ] command
- [ ] context-menu
- [ ] dialog
- [ ] dropdown-menu
- [ ] form-field
- [ ] hover-card
- [ ] input
- [ ] input-otp
- [ ] label
- [ ] menu
- [ ] menubar
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toast
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip

## Current behavior

Checkbox blur handling is deferred to a microtask so that a synchronous blur caused by disabling a focused element does not update form state during Angular change detection. If the checkbox is destroyed before that microtask runs—for example, while a dialog is closing—the callback still emits `touched`, producing an `NG0953` warning because the output has already been destroyed.

Closes #1630

## New behavior

Deferred blur work is routed through a dedicated `_handleBlur()` method that exits when the checkbox has already been destroyed. Normal blur behavior remains unchanged, and a regression test covers the focus → blur → destroy → microtask sequence.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No public API or documentation changes are required. The inline comments document why blur processing is deferred (angular/angular#17793) and why the destruction guard is necessary (spartan-ng/spartan#1630).

Validation:

- `pnpm nx test brain --testFiles=checkbox/src/lib`
- `pnpm exec eslint libs/brain/checkbox/src/lib/brn-checkbox.ts libs/brain/checkbox/src/lib/brn-checkbox.spec.ts`
- `pnpm exec prettier --check libs/brain/checkbox/src/lib/brn-checkbox.ts libs/brain/checkbox/src/lib/brn-checkbox.spec.ts`
- `pnpm nx build brain`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkbox blur handling to prevent warnings when the component is removed immediately after losing focus.
  * Ensured focus and touched states remain stable during deferred updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->