### PR TITLE
feat(input-otp): improve  compatibility w/ signal forms, update invalid styles

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--disabled.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--disabled.preview.ts
@@ -6,7 +6,7 @@ import { HlmInputOtp, HlmInputOtpGroup, HlmInputOtpSeparator, HlmInputOtpSlot } 
 	selector: 'spartan-input-otp-disabled',
 	imports: [HlmInputOtp, HlmInputOtpGroup, HlmInputOtpSeparator, HlmInputOtpSlot, BrnInputOtp],
 	template: `
-		<brn-input-otp hlmInputOtp value="123456" disabled maxLength="6" inputClass="disabled:cursor-not-allowed">
+		<brn-input-otp hlmInputOtp value="123456" disabled length="6" inputClass="disabled:cursor-not-allowed">
 			<hlm-input-otp-group>
 				<hlm-input-otp-slot index="0" />
 				<hlm-input-otp-slot index="1" />

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--form.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--form.example.ts
@@ -42,7 +42,7 @@ import { HlmToasterImports } from '@spartan-ng/helm/sonner';
 			<form hlmCardContent id="otp-form" [formRoot]="form">
 				<hlm-field>
 					<div class="flex items-center justify-between">
-						<label hlmFieldLabel for="otp-verification">Verification code</label>
+						<label hlmFieldLabel>Verification code</label>
 						<button hlmBtn variant="outline" size="xs" [disabled]="isResendDisabled()" (click)="resendOtp()">
 							<ng-icon name="lucideRefreshCw" />
 							Resend code
@@ -54,6 +54,7 @@ import { HlmToasterImports } from '@spartan-ng/helm/sonner';
 					<brn-input-otp
 						hlmInputOtp
 						[length]="maxLength"
+						inputId="otp-verification"
 						inputClass="disabled:cursor-not-allowed"
 						[formField]="form.otp"
 						[transformPaste]="transformPaste"

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--form.example.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--form.example.ts
@@ -1,5 +1,5 @@
-import { afterNextRender, Component, computed, inject, type OnDestroy, signal } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { afterNextRender, Component, computed, type OnDestroy, signal } from '@angular/core';
+import { form, FormField, FormRoot, maxLength, minLength, required, submit } from '@angular/forms/signals';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideRefreshCw } from '@ng-icons/lucide';
 import { BrnInputOtpImports } from '@spartan-ng/brain/input-otp';
@@ -13,12 +13,13 @@ import { HlmToasterImports } from '@spartan-ng/helm/sonner';
 @Component({
 	selector: 'spartan-input-otp-form',
 	imports: [
-		ReactiveFormsModule,
+		FormRoot,
+		FormField,
+		NgIcon,
 		HlmButtonImports,
 		HlmToasterImports,
 		HlmCardImports,
 		HlmFieldImports,
-		NgIcon,
 		BrnInputOtpImports,
 		HlmInputOtpImports,
 	],
@@ -38,7 +39,7 @@ import { HlmToasterImports } from '@spartan-ng/helm/sonner';
 				</div>
 			</hlm-card-header>
 
-			<form hlmCardContent id="otp-form" [formGroup]="form" (ngSubmit)="submit()">
+			<form hlmCardContent id="otp-form" [formRoot]="form">
 				<hlm-field>
 					<div class="flex items-center justify-between">
 						<label hlmFieldLabel for="otp-verification">Verification code</label>
@@ -52,9 +53,9 @@ import { HlmToasterImports } from '@spartan-ng/helm/sonner';
 					</div>
 					<brn-input-otp
 						hlmInputOtp
-						[maxLength]="maxLength"
+						[length]="maxLength"
 						inputClass="disabled:cursor-not-allowed"
-						formControlName="otp"
+						[formField]="form.otp"
 						[transformPaste]="transformPaste"
 						(completed)="submit()"
 					>
@@ -81,7 +82,7 @@ import { HlmToasterImports } from '@spartan-ng/helm/sonner';
 			</form>
 			<hlm-card-footer>
 				<hlm-field>
-					<button type="submit" form="otp-form" hlmBtn [disabled]="form.invalid">Verify</button>
+					<button type="submit" form="otp-form" hlmBtn [disabled]="form().invalid()">Verify</button>
 					<div class="text-muted-foreground text-sm">
 						Having trouble signing in?
 						<a href="#" class="hover:text-primary underline underline-offset-4 transition-colors">Contact support</a>
@@ -92,7 +93,6 @@ import { HlmToasterImports } from '@spartan-ng/helm/sonner';
 	`,
 })
 export class InputOtpFormExample implements OnDestroy {
-	private readonly _formBuilder = inject(FormBuilder);
 	private _intervalId?: NodeJS.Timeout;
 
 	public readonly countdown = signal(60);
@@ -103,19 +103,36 @@ export class InputOtpFormExample implements OnDestroy {
 	/** Overrides global formatDate  */
 	public transformPaste = (pastedText: string) => pastedText.replaceAll('-', '');
 
-	public form = this._formBuilder.group({
-		otp: [null, [Validators.required, Validators.minLength(this.maxLength), Validators.maxLength(this.maxLength)]],
+	private readonly _model = signal({
+		otp: '',
 	});
+
+	public readonly form = form(
+		this._model,
+		(schemaPath) => {
+			required(schemaPath.otp, { message: 'OTP is required' });
+			minLength(schemaPath.otp, this.maxLength, { message: `OTP must be ${this.maxLength} characters` });
+			maxLength(schemaPath.otp, this.maxLength, { message: `OTP must be ${this.maxLength} characters` });
+		},
+		{
+			submission: {
+				action: async () => {
+					const model = this._model();
+					console.log(model);
+					toast('OTP submitted', {
+						description: `Your OTP ${model.otp} has been submitted`,
+					});
+				},
+			},
+		},
+	);
 
 	constructor() {
 		afterNextRender(() => this.startCountdown());
 	}
 
 	submit() {
-		console.log(this.form.value);
-		toast('OTP submitted', {
-			description: `Your OTP ${this.form.value.otp} has been submitted`,
-		});
+		submit(this.form);
 	}
 
 	resendOtp() {

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--invalid.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--invalid.preview.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { BrnInputOtpImports } from '@spartan-ng/brain/input-otp';
+import { HlmInputOtpImports } from '@spartan-ng/helm/input-otp';
+
+@Component({
+	selector: 'spartan-input-otp-invalid',
+	imports: [HlmInputOtpImports, BrnInputOtpImports],
+	template: `
+		<brn-input-otp hlmInputOtp length="6" inputClass="disabled:cursor-not-allowed">
+			<hlm-input-otp-group>
+				<hlm-input-otp-slot index="0" forceInvalid />
+				<hlm-input-otp-slot index="1" forceInvalid />
+				<hlm-input-otp-slot index="2" forceInvalid />
+			</hlm-input-otp-group>
+			<hlm-input-otp-separator />
+			<hlm-input-otp-group>
+				<hlm-input-otp-slot index="3" forceInvalid />
+				<hlm-input-otp-slot index="4" forceInvalid />
+				<hlm-input-otp-slot index="5" forceInvalid />
+			</hlm-input-otp-group>
+		</brn-input-otp>
+	`,
+})
+export class InputOtpInvalid {}

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--rtl.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--rtl.preview.ts
@@ -14,7 +14,7 @@ import { HlmInputOtpImports } from '@spartan-ng/helm/input-otp';
 				inputId="input-otp-rtl"
 				hlmInputOtp
 				value="123456"
-				maxLength="6"
+				length="6"
 				inputClass="disabled:cursor-not-allowed"
 			>
 				<hlm-input-otp-group>

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--separator.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp--separator.preview.ts
@@ -6,7 +6,7 @@ import { HlmInputOtpImports } from '@spartan-ng/helm/input-otp';
 	selector: 'spartan-input-otp-separator',
 	imports: [HlmInputOtpImports, BrnInputOtpImports],
 	template: `
-		<brn-input-otp hlmInputOtp maxLength="6" inputClass="disabled:cursor-not-allowed">
+		<brn-input-otp hlmInputOtp length="6" inputClass="disabled:cursor-not-allowed">
 			<hlm-input-otp-group>
 				<hlm-input-otp-slot index="0" />
 				<hlm-input-otp-slot index="1" />

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp.page.ts
@@ -21,6 +21,7 @@ import { Tabs } from '../../../../shared/layout/tabs';
 import { metaWith } from '../../../../shared/meta/meta.util';
 import { InputOtpDisabled } from './input-otp--disabled.preview';
 import { InputOtpFormExample } from './input-otp--form.example';
+import { InputOtpInvalid } from './input-otp--invalid.preview';
 import { InputOtpRtl } from './input-otp--rtl.preview';
 import { InputOtpSeparator } from './input-otp--separator.preview';
 import { defaultImports, defaultSkeleton, InputOtpPreview } from './input-otp.preview';
@@ -52,6 +53,7 @@ export const routeMeta: RouteMeta = {
 		InputOtpPreview,
 		InputOtpSeparator,
 		InputOtpDisabled,
+		InputOtpInvalid,
 		InputOtpFormExample,
 		InputOtpRtl,
 	],
@@ -136,7 +138,7 @@ export const routeMeta: RouteMeta = {
 
 			<spartan-section-sub-heading id="examples">Examples</spartan-section-sub-heading>
 
-			<h3 id="examples__separator" spartanH4>Separator</h3>
+			<h3 id="separator" spartanH4>Separator</h3>
 			<p class="${hlmP} mb-6">
 				Use the
 				<code class="${hlmCode}">hlm-input-otp-separator</code>
@@ -149,7 +151,7 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_separatorCode()" />
 			</spartan-tabs>
 
-			<h3 id="examples__disabled" spartanH4>Disabled</h3>
+			<h3 id="disabled" spartanH4>Disabled</h3>
 			<p class="${hlmP} mb-6">
 				Use the
 				<code class="${hlmCode}">disabled</code>
@@ -162,7 +164,20 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_disabledCode()" />
 			</spartan-tabs>
 
-			<h3 id="examples__form" spartanH4>Form</h3>
+			<h3 id="invalid" spartanH4>Invalid</h3>
+			<p class="${hlmP} mb-6">
+				Use the
+				<code class="${hlmCode}">forceInvalid</code>
+				prop to mark the slots as invalid.
+			</p>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-input-otp-invalid />
+				</div>
+				<spartan-code secondTab [code]="_invalidCode()" />
+			</spartan-tabs>
+
+			<h3 id="form" spartanH4>Form</h3>
 			<p class="${hlmP} mb-6">
 				Sync the otp to a form by adding
 				<code class="${hlmCode}">formControlName</code>
@@ -208,6 +223,7 @@ export default class InputOtpPage {
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
 	protected readonly _separatorCode = computed(() => this._snippets()['separator']);
 	protected readonly _disabledCode = computed(() => this._snippets()['disabled']);
+	protected readonly _invalidCode = computed(() => this._snippets()['invalid']);
 	protected readonly _formCode = computed(() => this._snippets()['form']);
 	protected readonly _rtlCode = computed(() => this._snippets()['rtl']);
 	protected readonly _defaultSkeleton = defaultSkeleton;

--- a/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(input-otp)/input-otp.preview.ts
@@ -6,7 +6,7 @@ import { HlmInputOtpImports } from '@spartan-ng/helm/input-otp';
 	selector: 'spartan-input-otp-preview',
 	imports: [HlmInputOtpImports, BrnInputOtpImports],
 	template: `
-		<brn-input-otp hlmInputOtp maxLength="6" inputClass="disabled:cursor-not-allowed">
+		<brn-input-otp hlmInputOtp length="6" inputClass="disabled:cursor-not-allowed">
 			<hlm-input-otp-group>
 				<hlm-input-otp-slot index="0" />
 				<hlm-input-otp-slot index="1" />
@@ -28,7 +28,7 @@ import { BrnInputOtpImports } from '@spartan-ng/brain/input-otp';
 import { HlmInputOtpImports } from '@spartan-ng/helm/input-otp';
 `;
 export const defaultSkeleton = `
-<brn-input-otp hlmInputOtp maxLength="6" inputClass="disabled:cursor-not-allowed">
+<brn-input-otp hlmInputOtp length="6" inputClass="disabled:cursor-not-allowed">
   <hlm-input-otp-group>
     <hlm-input-otp-slot index="0" />
     <hlm-input-otp-slot index="1" />

--- a/libs/brain/input-otp/src/lib/brn-input-otp-slot.ts
+++ b/libs/brain/input-otp/src/lib/brn-input-otp-slot.ts
@@ -1,5 +1,5 @@
-import type { NumberInput } from '@angular/cdk/coercion';
-import { ChangeDetectionStrategy, Component, computed, input, numberAttribute } from '@angular/core';
+import type { BooleanInput, NumberInput } from '@angular/cdk/coercion';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, numberAttribute } from '@angular/core';
 import { injectBrnInputOtp } from './brn-input-otp.token';
 
 @Component({
@@ -7,6 +7,10 @@ import { injectBrnInputOtp } from './brn-input-otp.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
 		'[attr.data-active]': '_slot().isActive',
+		'[attr.data-invalid]': '_ariaInvalid?.() ? "true" : null',
+		'[attr.data-touched]': '_touched?.() ? "true" : null',
+		'[attr.data-dirty]': '_dirty?.() ? "true" : null',
+		'[attr.data-matches-spartan-invalid]': '_spartanInvalid() ? "true" : null',
 	},
 	template: `
 		{{ _slot().char }}
@@ -23,5 +27,13 @@ export class BrnInputOtpSlot {
 	/** The index of the slot to render the char or a fake caret */
 	public readonly index = input.required<number, NumberInput>({ transform: numberAttribute });
 
+	/** Whether to force the input into an invalid state. */
+	public readonly forceInvalid = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
+
 	protected readonly _slot = computed(() => this._inputOtp.context()[this.index()]);
+
+	protected readonly _ariaInvalid = this._inputOtp.invalid;
+	protected readonly _touched = this._inputOtp.touched;
+	protected readonly _dirty = this._inputOtp.dirty;
+	protected readonly _spartanInvalid = computed(() => this.forceInvalid() || this._inputOtp.spartanInvalid?.());
 }

--- a/libs/brain/input-otp/src/lib/brn-input-otp.spec.ts
+++ b/libs/brain/input-otp/src/lib/brn-input-otp.spec.ts
@@ -7,7 +7,7 @@ import { BrnInputOtpSlot } from './brn-input-otp-slot';
 describe('BrnInputOtp', () => {
 	const setup = async (
 		options: {
-			maxLength?: number;
+			length?: number;
 			disabled?: boolean;
 			inputMode?: InputMode;
 			inputId?: string;
@@ -16,7 +16,7 @@ describe('BrnInputOtp', () => {
 		} = {},
 	) => {
 		const {
-			maxLength = 6,
+			length = 6,
 			disabled = false,
 			inputMode = 'numeric',
 			inputId,
@@ -26,7 +26,7 @@ describe('BrnInputOtp', () => {
 
 		let template = `
       <brn-input-otp
-        [maxLength]="${maxLength}"
+        [length]="${length}"
         data-testid="brnInputOtp"
         ${disabled ? 'disabled' : ''}
         [inputMode]="'${inputMode}'"
@@ -36,7 +36,7 @@ describe('BrnInputOtp', () => {
       >
     `;
 
-		for (let i = 0; i < maxLength; i++) {
+		for (let i = 0; i < length; i++) {
 			template += `
         <brn-input-otp-slot [index]="${i}" data-testid="slot-${i}">
           <div data-testid="caret-${i}" class="caret">|</div>
@@ -64,7 +64,7 @@ describe('BrnInputOtp', () => {
 
 	describe('rendering', () => {
 		it('renders with correct number of slots', async () => {
-			await setup({ maxLength: 6 });
+			await setup({ length: 6 });
 
 			for (let i = 0; i < 6; i++) {
 				expect(screen.getByTestId(`slot-${i}`)).toBeInTheDocument();
@@ -72,7 +72,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('renders input with correct attributes', async () => {
-			const { input } = await setup({ maxLength: 6, inputMode: 'tel', inputId: 'custom-id', inputAutocomplete: 'off' });
+			const { input } = await setup({ length: 6, inputMode: 'tel', inputId: 'custom-id', inputAutocomplete: 'off' });
 
 			expect(input).toBeInTheDocument();
 			expect(input).toHaveAttribute('id', 'custom-id');
@@ -82,7 +82,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('renders with default input mode numeric', async () => {
-			const { input } = await setup({ maxLength: 6 });
+			const { input } = await setup({ length: 6 });
 
 			expect(input).toHaveAttribute('inputMode', 'numeric');
 		});
@@ -90,13 +90,13 @@ describe('BrnInputOtp', () => {
 
 	describe('input behavior', () => {
 		it('starts empty', async () => {
-			const { input } = await setup({ maxLength: 6 });
+			const { input } = await setup({ length: 6 });
 
 			expect(input.value).toBe('');
 		});
 
-		it('accepts typed input up to maxLength', async () => {
-			const { user, input } = await setup({ maxLength: 6 });
+		it('accepts typed input up to length', async () => {
+			const { user, input } = await setup({ length: 6 });
 
 			await user.click(input);
 			await user.keyboard('123456');
@@ -105,7 +105,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('displays characters in slots', async () => {
-			const { user, input, getSlot } = await setup({ maxLength: 4 });
+			const { user, input, getSlot } = await setup({ length: 4 });
 
 			await user.click(input);
 			await user.keyboard('1234');
@@ -116,8 +116,8 @@ describe('BrnInputOtp', () => {
 			expect(getSlot(3)).toHaveTextContent('4');
 		});
 
-		it('enforces maxLength', async () => {
-			const { user, input } = await setup({ maxLength: 4 });
+		it('enforces length', async () => {
+			const { user, input } = await setup({ length: 4 });
 
 			await user.click(input);
 			await user.keyboard('123456789');
@@ -125,8 +125,8 @@ describe('BrnInputOtp', () => {
 			expect(input.value).toBe('1239');
 		});
 
-		it('replaces last character when exceeding maxLength', async () => {
-			const { user, input } = await setup({ maxLength: 4 });
+		it('replaces last character when exceeding length', async () => {
+			const { user, input } = await setup({ length: 4 });
 
 			await user.click(input);
 			await user.keyboard('1234');
@@ -137,7 +137,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('moves caret as user types', async () => {
-			const { user, input, getCaret, getSlot } = await setup({ maxLength: 4 });
+			const { user, input, getCaret, getSlot } = await setup({ length: 4 });
 
 			await user.click(input);
 
@@ -155,7 +155,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('shows caret in last slot when complete', async () => {
-			const { user, input, getSlot, getCaret } = await setup({ maxLength: 4 });
+			const { user, input, getSlot, getCaret } = await setup({ length: 4 });
 
 			await user.click(input);
 			await user.keyboard('1234');
@@ -167,7 +167,7 @@ describe('BrnInputOtp', () => {
 
 	describe('paste behavior', () => {
 		it('handles paste with exact length', async () => {
-			const { input } = await setup({ maxLength: 6 });
+			const { input } = await setup({ length: 6 });
 
 			await userEvent.click(input);
 			await userEvent.paste('123456');
@@ -175,8 +175,8 @@ describe('BrnInputOtp', () => {
 			expect(input.value).toBe('123456');
 		});
 
-		it('handles paste with content longer than maxLength', async () => {
-			const { input } = await setup({ maxLength: 6 });
+		it('handles paste with content longer than length', async () => {
+			const { input } = await setup({ length: 6 });
 
 			await userEvent.click(input);
 			await userEvent.paste('123456789');
@@ -184,8 +184,8 @@ describe('BrnInputOtp', () => {
 			expect(input.value).toBe('123456');
 		});
 
-		it('handles paste with content shorter than maxLength', async () => {
-			const { input } = await setup({ maxLength: 6 });
+		it('handles paste with content shorter than length', async () => {
+			const { input } = await setup({ length: 6 });
 
 			await userEvent.click(input);
 			await userEvent.paste('123');
@@ -194,7 +194,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('displays pasted content in slots', async () => {
-			const { input, getSlot } = await setup({ maxLength: 4 });
+			const { input, getSlot } = await setup({ length: 4 });
 
 			await userEvent.click(input);
 			await userEvent.paste('1234');
@@ -208,13 +208,13 @@ describe('BrnInputOtp', () => {
 
 	describe('disabled state', () => {
 		it('disables input when disabled prop is true', async () => {
-			const { input } = await setup({ maxLength: 6, disabled: true });
+			const { input } = await setup({ length: 6, disabled: true });
 
 			expect(input).toBeDisabled();
 		});
 
 		it('does not accept input when disabled', async () => {
-			const { user, input } = await setup({ maxLength: 6, disabled: true });
+			const { user, input } = await setup({ length: 6, disabled: true });
 
 			await user.click(input);
 			await user.keyboard('123');
@@ -225,7 +225,7 @@ describe('BrnInputOtp', () => {
 
 	describe('focus behavior', () => {
 		it('autofocus input', async () => {
-			const { input } = await setup({ maxLength: 6, autofocus: true });
+			const { input } = await setup({ length: 6, autofocus: true });
 
 			// Wait for afterNextRender to apply the autofocus
 			await new Promise((resolve) => setTimeout(resolve, 0));
@@ -234,13 +234,13 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('input should not be autofocused if not explicitly requested', async () => {
-			const { input } = await setup({ maxLength: 6 });
+			const { input } = await setup({ length: 6 });
 
 			expect(input).not.toHaveFocus();
 		});
 
 		it('applies focus state when focused', async () => {
-			const { user, input } = await setup({ maxLength: 6 });
+			const { user, input } = await setup({ length: 6 });
 
 			await user.click(input);
 
@@ -248,7 +248,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('removes focus state on blur', async () => {
-			const { user, input } = await setup({ maxLength: 6 });
+			const { user, input } = await setup({ length: 6 });
 
 			await user.click(input);
 			expect(input).toHaveFocus();
@@ -260,7 +260,7 @@ describe('BrnInputOtp', () => {
 
 	describe('slot rendering', () => {
 		it('marks active slot correctly', async () => {
-			const { user, input, getSlot } = await setup({ maxLength: 4 });
+			const { user, input, getSlot } = await setup({ length: 4 });
 
 			await user.click(input);
 			expect(getSlot(0)).toHaveAttribute('data-active', 'true');
@@ -272,7 +272,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('shows fake caret only in current slot', async () => {
-			const { user, input, getCaret } = await setup({ maxLength: 4 });
+			const { user, input, getCaret } = await setup({ length: 4 });
 
 			await user.click(input);
 			expect(getCaret(0)).toBeInTheDocument();
@@ -285,7 +285,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('does not show caret when input is complete', async () => {
-			const { user, input, getCaret } = await setup({ maxLength: 4 });
+			const { user, input, getCaret } = await setup({ length: 4 });
 
 			await user.click(input);
 			await user.keyboard('1234');
@@ -297,7 +297,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('renders empty slots correctly', async () => {
-			const { getSlot } = await setup({ maxLength: 4 });
+			const { getSlot } = await setup({ length: 4 });
 
 			expect(getSlot(0)).not.toHaveTextContent(/[0-9]/);
 			expect(getSlot(1)).not.toHaveTextContent(/[0-9]/);
@@ -306,7 +306,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('renders partially filled slots correctly', async () => {
-			const { user, input, getSlot } = await setup({ maxLength: 4 });
+			const { user, input, getSlot } = await setup({ length: 4 });
 
 			await user.click(input);
 			await user.keyboard('12');
@@ -320,19 +320,19 @@ describe('BrnInputOtp', () => {
 
 	describe('input modes', () => {
 		it('supports numeric input mode', async () => {
-			const { input } = await setup({ maxLength: 6, inputMode: 'numeric' });
+			const { input } = await setup({ length: 6, inputMode: 'numeric' });
 
 			expect(input).toHaveAttribute('inputMode', 'numeric');
 		});
 
 		it('supports text input mode', async () => {
-			const { input } = await setup({ maxLength: 6, inputMode: 'text' });
+			const { input } = await setup({ length: 6, inputMode: 'text' });
 
 			expect(input).toHaveAttribute('inputMode', 'text');
 		});
 
 		it('supports tel input mode', async () => {
-			const { input } = await setup({ maxLength: 6, inputMode: 'tel' });
+			const { input } = await setup({ length: 6, inputMode: 'tel' });
 
 			expect(input).toHaveAttribute('inputMode', 'tel');
 		});
@@ -340,7 +340,7 @@ describe('BrnInputOtp', () => {
 
 	describe('different lengths', () => {
 		it('works with 4 digits', async () => {
-			const { user, input } = await setup({ maxLength: 4 });
+			const { user, input } = await setup({ length: 4 });
 
 			await user.click(input);
 			await user.keyboard('1234');
@@ -349,7 +349,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('works with 8 digits', async () => {
-			const { user, input } = await setup({ maxLength: 8 });
+			const { user, input } = await setup({ length: 8 });
 
 			await user.click(input);
 			await user.keyboard('12345678');
@@ -358,7 +358,7 @@ describe('BrnInputOtp', () => {
 		});
 
 		it('creates correct number of slots for different lengths', async () => {
-			const { getSlot } = await setup({ maxLength: 3 });
+			const { getSlot } = await setup({ length: 3 });
 
 			expect(getSlot(0)).toBeInTheDocument();
 			expect(getSlot(1)).toBeInTheDocument();

--- a/libs/brain/input-otp/src/lib/brn-input-otp.ts
+++ b/libs/brain/input-otp/src/lib/brn-input-otp.ts
@@ -7,6 +7,7 @@ import {
 	computed,
 	ElementRef,
 	forwardRef,
+	inject,
 	input,
 	linkedSignal,
 	numberAttribute,
@@ -15,6 +16,7 @@ import {
 	viewChild,
 } from '@angular/core';
 import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { BrnFieldControl, provideBrnLabelable } from '@spartan-ng/brain/field';
 import type { ChangeFn, TouchFn } from '@spartan-ng/brain/forms';
 import type { ClassValue } from 'clsx';
 import { provideBrnInputOtp } from './brn-input-otp.token';
@@ -29,8 +31,9 @@ export type InputMode = 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal'
 
 @Component({
 	selector: 'brn-input-otp',
-	providers: [BRN_INPUT_OTP_VALUE_ACCESSOR, provideBrnInputOtp(BrnInputOtp)],
+	providers: [BRN_INPUT_OTP_VALUE_ACCESSOR, provideBrnInputOtp(BrnInputOtp), provideBrnLabelable(BrnInputOtp)],
 	changeDetection: ChangeDetectionStrategy.OnPush,
+	hostDirectives: [BrnFieldControl],
 	host: {
 		'[style]': 'hostStyles()',
 		'data-input-otp-container': 'true',
@@ -51,13 +54,20 @@ export type InputMode = 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal'
 				(input)="onInputChange($event)"
 				(paste)="onPaste($event)"
 				(focus)="_focused.set(true)"
-				(blur)="_focused.set(false)"
+				(blur)="onBlur()"
 			/>
 		</div>
 	`,
 })
 export class BrnInputOtp implements ControlValueAccessor {
 	private static _id = 0;
+
+	private readonly _fieldControl = inject(BrnFieldControl, { optional: true });
+
+	public readonly invalid = this._fieldControl?.invalid;
+	public readonly touched = this._fieldControl?.touched;
+	public readonly dirty = this._fieldControl?.dirty;
+	public readonly spartanInvalid = this._fieldControl?.spartanInvalid;
 
 	/** Whether the input has focus. */
 	protected readonly _focused = signal<boolean>(false);
@@ -69,6 +79,8 @@ export class BrnInputOtp implements ControlValueAccessor {
 
 	/** Custom id applied to the input element */
 	public readonly inputId = input<string>(`brn-input-otp-${++BrnInputOtp._id}`);
+
+	public readonly labelableId = this.inputId;
 
 	/** Custom autocomplete attribute applied to the input element */
 	public readonly inputAutocomplete = input<'one-time-code' | 'off'>('one-time-code');
@@ -148,6 +160,11 @@ export class BrnInputOtp implements ControlValueAccessor {
 				this._inputComponentRef().nativeElement.focus();
 			}
 		});
+	}
+
+	protected onBlur() {
+		this._focused.set(false);
+		this._onTouched?.();
 	}
 
 	protected onInputChange(event: Event) {

--- a/libs/brain/input-otp/src/lib/brn-input-otp.ts
+++ b/libs/brain/input-otp/src/lib/brn-input-otp.ts
@@ -89,7 +89,7 @@ export class BrnInputOtp implements ControlValueAccessor {
 	protected readonly _disabled = linkedSignal(this.disabled);
 
 	/** The number of slots. */
-	public readonly maxLength = input.required<number, NumberInput>({ transform: numberAttribute });
+	public readonly length = input.required<number, NumberInput>({ transform: numberAttribute });
 
 	/** Virtual keyboard appearance on mobile */
 	public readonly inputMode = input<InputMode>('numeric');
@@ -101,12 +101,12 @@ export class BrnInputOtp implements ControlValueAccessor {
 
 	/**
 	 * Defines how the pasted text should be transformed before saving to model/form.
-	 * Allows pasting text which contains extra characters like spaces, dashes, etc. and are longer than the maxLength.
+	 * Allows pasting text which contains extra characters like spaces, dashes, etc. and are longer than the length.
 	 *
 	 * "XXX-XXX": (pastedText) => pastedText.replaceAll('-', '')
 	 * "XXX XXX": (pastedText) => pastedText.replaceAll(/\s+/g, '')
 	 */
-	public readonly transformPaste = input<(pastedText: string, maxLength: number) => string>((text) => text);
+	public readonly transformPaste = input<(pastedText: string, length: number) => string>((text) => text);
 
 	/** The value controlling the input */
 	public readonly valueInput = input<string | null>(null, { alias: 'value' });
@@ -118,12 +118,11 @@ export class BrnInputOtp implements ControlValueAccessor {
 	public readonly context = computed(() => {
 		const value = this.value() ?? '';
 		const focused = this._focused();
-		const maxLength = this.maxLength();
-		const slots = Array.from({ length: this.maxLength() }).map((_, slotIndex) => {
+		const length = this.length();
+		const slots = Array.from({ length: this.length() }).map((_, slotIndex) => {
 			const char = value[slotIndex] !== undefined ? value[slotIndex] : null;
 
-			const isActive =
-				focused && (value.length === slotIndex || (value.length === maxLength && slotIndex === maxLength - 1));
+			const isActive = focused && (value.length === slotIndex || (value.length === length && slotIndex === length - 1));
 
 			return {
 				char,
@@ -153,32 +152,32 @@ export class BrnInputOtp implements ControlValueAccessor {
 
 	protected onInputChange(event: Event) {
 		let newValue = (event.target as HTMLInputElement).value;
-		const maxLength = this.maxLength();
+		const length = this.length();
 
-		if (newValue.length > maxLength) {
-			// Replace the last character when max length is exceeded
-			newValue = newValue.slice(0, maxLength - 1) + newValue.slice(-1);
+		if (newValue.length > length) {
+			// Replace the last character when length is exceeded
+			newValue = newValue.slice(0, length - 1) + newValue.slice(-1);
 		}
 
-		this.updateValue(newValue, maxLength);
+		this.updateValue(newValue, length);
 	}
 
 	protected onPaste(event: ClipboardEvent) {
 		event.preventDefault();
 		const clipboardData = event.clipboardData?.getData('text/plain') || '';
 
-		const maxLength = this.maxLength();
+		const length = this.length();
 
-		const content = this.transformPaste()(clipboardData, maxLength);
-		const newValue = content.slice(0, maxLength);
+		const content = this.transformPaste()(clipboardData, length);
+		const newValue = content.slice(0, length);
 
-		this.updateValue(newValue, maxLength);
+		this.updateValue(newValue, length);
 	}
 
 	/** CONTROL VALUE ACCESSOR */
 	writeValue(value: string | null): void {
 		this.value.set(value);
-		if (value?.length === this.maxLength()) {
+		if (value?.length === this.length()) {
 			this.completed.emit(value ?? '');
 		}
 	}
@@ -195,18 +194,18 @@ export class BrnInputOtp implements ControlValueAccessor {
 		this._disabled.set(isDisabled);
 	}
 
-	private isCompleted(newValue: string, previousValue: string, maxLength: number) {
-		return newValue !== previousValue && previousValue.length < maxLength && newValue.length === maxLength;
+	private isCompleted(newValue: string, previousValue: string, length: number) {
+		return newValue !== previousValue && previousValue.length < length && newValue.length === length;
 	}
 
-	private updateValue(newValue: string, maxLength: number) {
+	private updateValue(newValue: string, length: number) {
 		const previousValue = this.value() ?? '';
 
 		this.value.set(newValue);
 		this.valueChange.emit(newValue);
 		this._onChange?.(newValue);
 
-		if (this.isCompleted(newValue, previousValue, maxLength)) {
+		if (this.isCompleted(newValue, previousValue, length)) {
 			this.completed.emit(newValue);
 		}
 	}

--- a/libs/cli/generators.json
+++ b/libs/cli/generators.json
@@ -30,6 +30,11 @@
 			"schema": "./src/generators/migrate-brn-checkbox-changed-event/schema.json",
 			"description": "Migrate brn-checkbox changed event to checkedChange"
 		},
+		"migrate-brn-input-otp-max-length": {
+			"factory": "./src/generators/migrate-brn-input-otp-max-length/compat",
+			"schema": "./src/generators/migrate-brn-input-otp-max-length/schema.json",
+			"description": "Migrate brn-input-otp maxLength input to length"
+		},
 		"migrate-brn-switch-changed-event": {
 			"factory": "./src/generators/migrate-brn-switch-changed-event/compat",
 			"schema": "./src/generators/migrate-brn-switch-changed-event/schema.json",
@@ -151,6 +156,11 @@
 			"factory": "./src/generators/migrate-brn-checkbox-changed-event/compat",
 			"schema": "./src/generators/migrate-brn-checkbox-changed-event/schema.json",
 			"description": "Migrate brn-checkbox changed event to checkedChange"
+		},
+		"migrate-brn-input-otp-max-length": {
+			"factory": "./src/generators/migrate-brn-input-otp-max-length/compat",
+			"schema": "./src/generators/migrate-brn-input-otp-max-length/schema.json",
+			"description": "Migrate brn-input-otp maxLength input to length"
 		},
 		"migrate-brn-switch-changed-event": {
 			"factory": "./src/generators/migrate-brn-switch-changed-event/compat",

--- a/libs/cli/src/generators/healthcheck/generator.ts
+++ b/libs/cli/src/generators/healthcheck/generator.ts
@@ -6,6 +6,7 @@ import { brainImportsHealthcheck } from './healthchecks/brain-imports';
 import { brainAccordionTriggerHealthcheck } from './healthchecks/brn-accordion-trigger';
 import { brnCheckboxChangedEventRename } from './healthchecks/brn-checkbox-changed-event-rename';
 import { brainCollapsibleHealthcheck } from './healthchecks/brn-collapsible';
+import { brnInputOtpMaxLengthRename } from './healthchecks/brn-input-otp-max-length-rename';
 import { brainRadioHealthcheck } from './healthchecks/brn-radio';
 import { brnSelectHealthcheck } from './healthchecks/brn-select';
 import { brainSeparatorHealthcheck } from './healthchecks/brn-separator';
@@ -67,6 +68,7 @@ export async function healthcheckGenerator(tree: Tree, options: HealthcheckGener
 		helmFormFieldHealthcheck,
 		sonnerHealthcheck,
 		brnSelectHealthcheck,
+		brnInputOtpMaxLengthRename,
 		scaffoldIntegrityHealthcheck,
 	];
 

--- a/libs/cli/src/generators/healthcheck/healthchecks/brn-input-otp-max-length-rename.ts
+++ b/libs/cli/src/generators/healthcheck/healthchecks/brn-input-otp-max-length-rename.ts
@@ -1,0 +1,30 @@
+import { visitNotIgnoredFiles } from '@nx/devkit';
+import migrateBrnInputOtpMaxLength from '../../migrate-brn-input-otp-max-length/generator';
+import { type Healthcheck, HealthcheckSeverity } from '../healthchecks';
+
+export const brnInputOtpMaxLengthRename: Healthcheck = {
+	name: 'Input OTP maxLength rename',
+	async detect(tree, failure) {
+		visitNotIgnoredFiles(tree, '/', (file) => {
+			if (!file.endsWith('.ts') && !file.endsWith('.html')) {
+				return;
+			}
+
+			const contents = tree.read(file, 'utf-8');
+
+			if (!contents) {
+				return;
+			}
+
+			// matches the legacy maxLength input on a brn-input-otp element ([maxLength] or maxLength=)
+			if (/<brn-input-otp\b[^>]*\bmaxLength\b/g.test(contents)) {
+				failure('brn-input-otp is using the renamed maxLength input.', HealthcheckSeverity.Error, true);
+			}
+		});
+	},
+	fix: async (tree) => {
+		await migrateBrnInputOtpMaxLength(tree, { skipFormat: true });
+		return true;
+	},
+	prompt: 'Would you like to migrate brn-input-otp maxLength input rename?',
+};

--- a/libs/cli/src/generators/migrate-brn-input-otp-max-length/compat.ts
+++ b/libs/cli/src/generators/migrate-brn-input-otp-max-length/compat.ts
@@ -1,0 +1,4 @@
+import { convertNxGenerator } from '@nx/devkit';
+import migrateBrnInputOtpMaxLength from './generator';
+
+export default convertNxGenerator(migrateBrnInputOtpMaxLength);

--- a/libs/cli/src/generators/migrate-brn-input-otp-max-length/generator.spec.ts
+++ b/libs/cli/src/generators/migrate-brn-input-otp-max-length/generator.spec.ts
@@ -1,0 +1,58 @@
+import { applicationGenerator, E2eTestRunner, UnitTestRunner } from '@nx/angular/generators';
+import type { Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { migrateBrnInputOtpMaxLength } from './generator';
+
+// patch some imports to avoid running the actual code
+vi.mock('enquirer');
+vi.mock('@nx/devkit', async (importOriginal) => {
+	const original = await importOriginal<typeof import('@nx/devkit')>();
+	return {
+		...original,
+		ensurePackage: (pkg: string) => require(pkg),
+		createProjectGraphAsync: vi.fn().mockResolvedValue({
+			nodes: {},
+			dependencies: {},
+		}),
+	};
+});
+
+describe('migrate-brn-input-otp-max-length generator', () => {
+	let tree: Tree;
+
+	beforeEach(async () => {
+		tree = createTreeWithEmptyWorkspace();
+
+		await applicationGenerator(tree, {
+			name: 'app',
+			directory: 'app',
+			skipFormat: true,
+			e2eTestRunner: E2eTestRunner.None,
+			unitTestRunner: UnitTestRunner.None,
+			skipPackageJson: true,
+			skipTests: true,
+		});
+	});
+
+	it('should rename maxLength to length on brn-input-otp elements', async () => {
+		tree.write(
+			'app/src/app/app.component.html',
+			`
+				<brn-input-otp [maxLength]="6"></brn-input-otp>
+				<brn-input-otp maxLength="6"></brn-input-otp>
+				<!-- This is not a brn-input-otp, so it should not be changed -->
+				<input [maxLength]="6" />
+			`,
+		);
+
+		await migrateBrnInputOtpMaxLength(tree, { skipFormat: true });
+
+		const content = tree.read('app/src/app/app.component.html', 'utf-8');
+		expect(content).toBe(`
+				<brn-input-otp [length]="6"></brn-input-otp>
+				<brn-input-otp length="6"></brn-input-otp>
+				<!-- This is not a brn-input-otp, so it should not be changed -->
+				<input [maxLength]="6" />
+			`);
+	});
+});

--- a/libs/cli/src/generators/migrate-brn-input-otp-max-length/generator.ts
+++ b/libs/cli/src/generators/migrate-brn-input-otp-max-length/generator.ts
@@ -1,0 +1,38 @@
+import { formatFiles, type Tree } from '@nx/devkit';
+import { visitFiles } from '../../utils/visit-files';
+import type { MigrateBrnInputOtpMaxLength } from './schema';
+
+const inputOtpTagPattern = /<(brn-input-otp)\b[^>]*>/g;
+
+export async function migrateBrnInputOtpMaxLength(tree: Tree, { skipFormat }: MigrateBrnInputOtpMaxLength) {
+	renameMaxLengthInput(tree);
+
+	if (!skipFormat) {
+		await formatFiles(tree);
+	}
+}
+
+function renameMaxLengthInput(tree: Tree) {
+	visitFiles(tree, '.', (path) => {
+		if (!path.endsWith('.html') && !path.endsWith('.ts')) {
+			return;
+		}
+
+		let content = tree.read(path, 'utf-8');
+
+		if (!content) {
+			return;
+		}
+
+		inputOtpTagPattern.lastIndex = 0;
+		content = content.replace(inputOtpTagPattern, (tag) => renameLegacyMaxLengthInput(tag));
+
+		tree.write(path, content);
+	});
+}
+
+function renameLegacyMaxLengthInput(tag: string) {
+	return tag.replace(/(\s)\[maxLength\](\s*=)/g, '$1[length]$2').replace(/(\s)maxLength(\s*=)/g, '$1length$2');
+}
+
+export default migrateBrnInputOtpMaxLength;

--- a/libs/cli/src/generators/migrate-brn-input-otp-max-length/schema.d.ts
+++ b/libs/cli/src/generators/migrate-brn-input-otp-max-length/schema.d.ts
@@ -1,0 +1,3 @@
+export interface MigrateBrnInputOtpMaxLength {
+	skipFormat?: boolean;
+}

--- a/libs/cli/src/generators/migrate-brn-input-otp-max-length/schema.json
+++ b/libs/cli/src/generators/migrate-brn-input-otp-max-length/schema.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"$id": "MigrateBrnInputOtpMaxLength",
+	"title": "",
+	"type": "object",
+	"properties": {
+		"skipFormat": {
+			"type": "boolean",
+			"default": false,
+			"description": "Skip formatting files"
+		}
+	},
+	"required": []
+}

--- a/libs/cli/src/generators/ui/libs/input-otp/files/lib/hlm-input-otp-slot.ts.template
+++ b/libs/cli/src/generators/ui/libs/input-otp/files/lib/hlm-input-otp-slot.ts.template
@@ -1,5 +1,5 @@
-import type { NumberInput } from '@angular/cdk/coercion';
-import { ChangeDetectionStrategy, Component, input, numberAttribute } from '@angular/core';
+import type { BooleanInput, NumberInput } from '@angular/cdk/coercion';
+import { booleanAttribute, ChangeDetectionStrategy, Component, input, numberAttribute } from '@angular/core';
 import { BrnInputOtpSlot } from '@spartan-ng/brain/input-otp';
 import { classes } from '<%- importAlias %>/utils';
 import { HlmInputOtpFakeCaret } from './hlm-input-otp-fake-caret';
@@ -10,7 +10,7 @@ import { HlmInputOtpFakeCaret } from './hlm-input-otp-fake-caret';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { 'data-slot': 'input-otp-slot' },
 	template: `
-		<brn-input-otp-slot [index]="index()">
+		<brn-input-otp-slot [index]="index()" [forceInvalid]="forceInvalid()">
 			<hlm-input-otp-fake-caret />
 		</brn-input-otp-slot>
 	`,
@@ -18,6 +18,9 @@ import { HlmInputOtpFakeCaret } from './hlm-input-otp-fake-caret';
 export class HlmInputOtpSlot {
 	/** The index of the slot to render the char or a fake caret */
 	public readonly index = input.required<number, NumberInput>({ transform: numberAttribute });
+
+	/** Whether to force the input into an invalid state. */
+	public readonly forceInvalid = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 
 	constructor() {
 		classes(

--- a/libs/helm/input-otp/src/lib/hlm-input-otp-slot.ts
+++ b/libs/helm/input-otp/src/lib/hlm-input-otp-slot.ts
@@ -1,5 +1,5 @@
-import type { NumberInput } from '@angular/cdk/coercion';
-import { ChangeDetectionStrategy, Component, input, numberAttribute } from '@angular/core';
+import type { BooleanInput, NumberInput } from '@angular/cdk/coercion';
+import { booleanAttribute, ChangeDetectionStrategy, Component, input, numberAttribute } from '@angular/core';
 import { BrnInputOtpSlot } from '@spartan-ng/brain/input-otp';
 import { classes } from '@spartan-ng/helm/utils';
 import { HlmInputOtpFakeCaret } from './hlm-input-otp-fake-caret';
@@ -10,7 +10,7 @@ import { HlmInputOtpFakeCaret } from './hlm-input-otp-fake-caret';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: { 'data-slot': 'input-otp-slot' },
 	template: `
-		<brn-input-otp-slot [index]="index()">
+		<brn-input-otp-slot [index]="index()" [forceInvalid]="forceInvalid()">
 			<hlm-input-otp-fake-caret />
 		</brn-input-otp-slot>
 	`,
@@ -18,6 +18,9 @@ import { HlmInputOtpFakeCaret } from './hlm-input-otp-fake-caret';
 export class HlmInputOtpSlot {
 	/** The index of the slot to render the char or a fake caret */
 	public readonly index = input.required<number, NumberInput>({ transform: numberAttribute });
+
+	/** Whether to force the input into an invalid state. */
+	public readonly forceInvalid = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 
 	constructor() {
 		classes(

--- a/libs/registry/src/styles/style-luma.css
+++ b/libs/registry/src/styles/style-luma.css
@@ -354,7 +354,7 @@
 	}
 
 	.spartan-input-otp-slot {
-		@apply bg-input/50 border-input has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/30 has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive size-9 border-y border-e text-sm transition-all outline-none first:rounded-s-3xl first:border-s last:rounded-e-3xl has-[brn-input-otp-slot[data-active="true"]]:ring-3;
+		@apply bg-input/50 border-input has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/30 has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:ring-destructive/40 has-data-[matches-spartan-invalid=true]:border-destructive size-9 border-y border-e text-sm transition-all outline-none first:rounded-s-3xl first:border-s last:rounded-e-3xl has-[brn-input-otp-slot[data-active="true"]]:ring-3;
 	}
 
 	.spartan-input-otp-caret-line {

--- a/libs/registry/src/styles/style-lyra.css
+++ b/libs/registry/src/styles/style-lyra.css
@@ -603,11 +603,11 @@
 	}
 
 	.spartan-input-otp-group {
-		@apply data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive rounded-none data-[matches-spartan-invalid=true]:ring-1;
+		@apply has-data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-data-[matches-spartan-invalid=true]:ring-destructive/40 has-data-[matches-spartan-invalid=true]:border-destructive rounded-none has-data-[matches-spartan-invalid=true]:ring-1;
 	}
 
 	.spartan-input-otp-slot {
-		@apply dark:bg-input/30 border-input has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/50 has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:border-destructive size-8 border-y border-e text-xs transition-all outline-none first:rounded-none first:border-s last:rounded-none has-[brn-input-otp-slot[data-active="true"]]:ring-1;
+		@apply dark:bg-input/30 border-input has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/50 has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:ring-destructive/40 has-data-[matches-spartan-invalid=true]:border-destructive has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:border-destructive size-8 border-y border-e text-xs transition-all outline-none first:rounded-none first:border-s last:rounded-none has-[brn-input-otp-slot[data-active="true"]]:ring-1;
 	}
 
 	.spartan-input-otp-caret-line {

--- a/libs/registry/src/styles/style-maia.css
+++ b/libs/registry/src/styles/style-maia.css
@@ -625,11 +625,11 @@
 	}
 
 	.spartan-input-otp-group {
-		@apply data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive rounded-4xl data-[matches-spartan-invalid=true]:ring-[3px];
+		@apply has-data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-data-[matches-spartan-invalid=true]:ring-destructive/40 has-data-[matches-spartan-invalid=true]:border-destructive rounded-4xl has-data-[matches-spartan-invalid=true]:ring-[3px];
 	}
 
 	.spartan-input-otp-slot {
-		@apply bg-input/30 border-input has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/50 has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:border-destructive size-9 border-y border-e text-sm transition-all outline-none first:rounded-s-4xl first:border-s last:rounded-e-4xl has-[brn-input-otp-slot[data-active="true"]]:ring-[3px];
+		@apply bg-input/30 border-input has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/50 has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:ring-destructive/40 has-data-[matches-spartan-invalid=true]:border-destructive has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:border-destructive size-9 border-y border-e text-sm transition-all outline-none first:rounded-s-4xl first:border-s last:rounded-e-4xl has-[brn-input-otp-slot[data-active="true"]]:ring-[3px];
 	}
 
 	.spartan-input-otp-caret-line {

--- a/libs/registry/src/styles/style-mira.css
+++ b/libs/registry/src/styles/style-mira.css
@@ -625,11 +625,11 @@
 	}
 
 	.spartan-input-otp-group {
-		@apply data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive rounded-md data-[matches-spartan-invalid=true]:ring-2;
+		@apply has-data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-data-[matches-spartan-invalid=true]:ring-destructive/40 has-data-[matches-spartan-invalid=true]:border-destructive rounded-md has-data-[matches-spartan-invalid=true]:ring-2;
 	}
 
 	.spartan-input-otp-slot {
-		@apply bg-input/20 dark:bg-input/30 border-input has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/30 has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:border-destructive size-7 border-y border-e text-xs/relaxed transition-all outline-none first:rounded-s-md first:border-s last:rounded-e-md has-[brn-input-otp-slot[data-active="true"]]:ring-2;
+		@apply bg-input/20 dark:bg-input/30 border-input has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/30 has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:ring-destructive/40 has-data-[matches-spartan-invalid=true]:border-destructive has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:border-destructive size-7 border-y border-e text-xs/relaxed transition-all outline-none first:rounded-s-md first:border-s last:rounded-e-md has-[brn-input-otp-slot[data-active="true"]]:ring-2;
 	}
 
 	.spartan-input-otp-caret-line {

--- a/libs/registry/src/styles/style-nova.css
+++ b/libs/registry/src/styles/style-nova.css
@@ -655,11 +655,11 @@
 	}
 
 	.spartan-input-otp-group {
-		@apply data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive rounded-lg data-[matches-spartan-invalid=true]:ring-3;
+		@apply has-data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-data-[matches-spartan-invalid=true]:ring-destructive/40 has-data-[matches-spartan-invalid=true]:border-destructive rounded-lg has-data-[matches-spartan-invalid=true]:ring-3;
 	}
 
 	.spartan-input-otp-slot {
-		@apply dark:bg-input/30 border-input has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/50 has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:border-destructive size-8 border-y border-e text-sm transition-all outline-none first:rounded-s-lg first:border-s last:rounded-e-lg has-[brn-input-otp-slot[data-active="true"]]:ring-3;
+		@apply dark:bg-input/30 border-input has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/50 has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:ring-destructive/40 has-data-[matches-spartan-invalid=true]:border-destructive has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:border-destructive size-8 border-y border-e text-sm transition-all outline-none first:rounded-s-lg first:border-s last:rounded-e-lg has-[brn-input-otp-slot[data-active="true"]]:ring-3;
 	}
 
 	.spartan-input-otp-caret-line {

--- a/libs/registry/src/styles/style-vega.css
+++ b/libs/registry/src/styles/style-vega.css
@@ -683,11 +683,11 @@
 	}
 
 	.spartan-input-otp-group {
-		@apply data-[matches-spartan-invalid=true]:ring-destructive/20 dark:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive rounded-md data-[matches-spartan-invalid=true]:ring-3;
+		@apply has-data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-data-[matches-spartan-invalid=true]:ring-destructive/40 has-data-[matches-spartan-invalid=true]:border-destructive rounded-md has-data-[matches-spartan-invalid=true]:ring-3;
 	}
 
 	.spartan-input-otp-slot {
-		@apply dark:bg-input/30 border-input has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/50 has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:ring-destructive/40 data-[matches-spartan-invalid=true]:border-destructive has-[brn-input-otp-slot[data-active="true"]]:data-[matches-spartan-invalid=true]:border-destructive size-9 border-y border-e text-sm shadow-xs transition-all outline-none first:rounded-s-md first:border-s last:rounded-e-md has-[brn-input-otp-slot[data-active="true"]]:ring-3;
+		@apply dark:bg-input/30 border-input has-[brn-input-otp-slot[data-active="true"]]:border-ring has-[brn-input-otp-slot[data-active="true"]]:ring-ring/50 has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:ring-destructive/20 dark:has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:ring-destructive/40 has-data-[matches-spartan-invalid=true]:border-destructive has-[brn-input-otp-slot[data-active="true"]]:has-data-[matches-spartan-invalid=true]:border-destructive size-9 border-y border-e text-sm shadow-xs transition-all outline-none first:rounded-s-md first:border-s last:rounded-e-md has-[brn-input-otp-slot[data-active="true"]]:ring-3;
 	}
 
 	.spartan-input-otp-caret-line {

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -5288,6 +5288,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "required": true,
             "type": "number",
           },
+          {
+            "name": "forceInvalid",
+            "required": false,
+            "type": "boolean",
+          },
         ],
         "models": [],
         "outputs": [],
@@ -5325,6 +5330,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "name": "index",
             "required": true,
             "type": "number",
+          },
+          {
+            "name": "forceInvalid",
+            "required": false,
+            "type": "boolean",
           },
         ],
         "models": [],

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -5238,7 +5238,7 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "type": "boolean",
           },
           {
-            "name": "maxLength",
+            "name": "length",
             "required": true,
             "type": "number",
           },
@@ -5260,7 +5260,7 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
           {
             "name": "transformPaste",
             "required": false,
-            "type": "(pastedText: string, maxLength: number) => string",
+            "type": "(pastedText: string, length: number) => string",
           },
           {
             "name": "value",


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature
- [x] Documentation content changes

## Which package are you modifying?

### Primitives

- [x] input-otp

### Others

- [x] cli

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1633

BrnInputOtp exposes `maxLength` which conflict with `formField`. Also BrnInputOtp is missing `BrnFieldControl` to wire up form invalid states

## What is the new behavior?

Rename `maxLength` to `length` with a migration and health check.
Add `BrnFieldControl` and `provideBrnLabelable`, wire up invalid states in the `BrnInputOtpSlot`. Add missing `has-*` styles to show the error state. 

Add a new invalid example.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BrnInputOtp exposes `maxLength` input, this is renamed to `length`.

Migration and health check added to rename the input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added invalid-state support for OTP slots, including forced invalid styling.
  * Added an invalid OTP example and updated form integration with Signals Forms.
  * Improved validation-state styling across available themes.

* **Bug Fixes**
  * OTP fields now correctly report touched and validation states after losing focus.

* **Migration**
  * Renamed the OTP length setting from `maxLength` to `length`.
  * Added a CLI migration and health check to update existing usage automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->