### PR TITLE
fix(combobox): skip scrollIntoView when activated by pointer event, c…

### DIFF
--- a/libs/brain/combobox/src/lib/brn-combobox-item.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-item.ts
@@ -54,6 +54,8 @@ export class BrnComboboxItem<T> implements Highlightable {
 
 	protected readonly _highlighted = signal(false);
 
+	private _activatedByPointer = false;
+
 	/** @internal Determine if this item is visible based on the current search query */
 	public readonly visible = computed(() => {
 		return this._combobox.filter()(
@@ -68,7 +70,7 @@ export class BrnComboboxItem<T> implements Highlightable {
 		this._highlighted.set(true);
 
 		// ensure the item is in view
-		if (isPlatformBrowser(this._platform)) {
+		if (!this._activatedByPointer && isPlatformBrowser(this._platform)) {
 			this._elementRef.nativeElement.scrollIntoView({ block: 'nearest' });
 		}
 	}
@@ -95,6 +97,8 @@ export class BrnComboboxItem<T> implements Highlightable {
 			return;
 		}
 
+		this._activatedByPointer = true;
 		this._combobox.keyManager.setActiveItem(this);
+		this._activatedByPointer = false;
 	}
 }


### PR DESCRIPTION
…loses #1658

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [x] combobox

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1658, which can be reproduced with the [Groups](https://spartan.ng/components/combobox#group) example  by moving the mouse to `London` and it moves into view.

## What is the new behavior?

Mouse pointer doesn't scroll items into view, only when activated by keyboard. Try again to move the mouse to `London` and the item doesn't move into view on mouse pointer, but when using the keyboard

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved combobox pointer interactions by preventing unnecessary scrolling when selecting an item with the mouse or other pointer input.
  * Preserved automatic scrolling for keyboard-based navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->