### PR TITLE
fix(combobox): prevent Tab in popup input from focusing browser addre…

### DIFF
--- a/libs/brain/combobox/src/lib/brn-combobox-input.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-input.ts
@@ -108,7 +108,18 @@ export class BrnComboboxInput<T> {
 
 		if (this._isExpanded()) {
 			if (event.key === 'Tab') {
-				this._combobox.selectActiveItem();
+				// In popup mode the input lives inside a CDK overlay which is appended to <body>.
+				// Without preventDefault the browser has nowhere to Tab to inside the overlay and
+				// jumps straight to the browser's address bar.  We intercept the key, select any
+				// active item, close the popup, and let BrnOverlay._restoreFocus restore focus to
+				// the trigger so the user can continue tabbing through the page normally.
+				if (this.mode() === 'popup') {
+					event.preventDefault();
+					this._combobox.selectActiveItem();
+					this._combobox.close();
+				} else {
+					this._combobox.selectActiveItem();
+				}
 			}
 		} else {
 			if (event.key === 'Enter' || event.key === 'ArrowDown' || event.key === 'ArrowUp') {

--- a/libs/brain/combobox/src/lib/brn-combobox-multiple.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-multiple.ts
@@ -270,7 +270,7 @@ export class BrnComboboxMultiple<T> implements BrnComboboxBase<T>, ControlValueA
 		}
 	}
 
-	private close(): void {
+	public close(): void {
 		if (this._disabled() || !this.isExpanded()) return;
 
 		this._brnPopover?.close();

--- a/libs/brain/combobox/src/lib/brn-combobox.token.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox.token.ts
@@ -40,6 +40,8 @@ export interface BrnComboboxBase<T> {
 	resetSearch: () => void;
 	/** Select the active item with Enter key. */
 	selectActiveItem: () => void;
+	/** Close the combobox popup. */
+	close: () => void;
 	/** Remove last selected item with Backspace key. Only works with multiple selection comboboxes. */
 	removeLastSelectedItem: () => void;
 	removeValue: (value: T) => void;

--- a/libs/brain/combobox/src/lib/brn-combobox.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox.ts
@@ -264,7 +264,7 @@ export class BrnCombobox<T> implements BrnComboboxBase<T>, ControlValueAccessor 
 		}
 	}
 
-	private close(): void {
+	public close(): void {
 		if (this._disabled() || !this.isExpanded()) return;
 
 		this._brnPopover?.close();


### PR DESCRIPTION
…ss bar #1671

When hlm-combobox-input is rendered inside a CDK overlay via *hlmComboboxPortal, the input lives outside the normal DOM tree. Pressing Tab found no further tabbable elements in the overlay and cycled focus to the browser's address bar.

Fix by intercepting Tab in popup mode: preventDefault stops the browser from handling the key, selectActiveItem + close collapse the popup, and BrnOverlay._restoreFocus then returns focus to the trigger so the user can continue tabbing through the page normally.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] attachment
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] bubble
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [x] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] marker
- [ ] menubar
- [ ] message
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1671 

## What is the new behavior?

Tab focus the next element

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added programmatic controls to close combobox popups.
  - Updated Tab-key behavior in popup mode to select the active option and close the popup.

- **Bug Fixes**
  - Improved keyboard navigation by preventing unintended browser focus movement when leaving an open popup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->