### PR TITLE
fix: autocomplete, combobox and command a11y issues

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/autocomplete/autocomplete.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/autocomplete/autocomplete.cy.ts
@@ -58,6 +58,7 @@ describe('autocomplete', () => {
 			cy.get('hlm-autocomplete-item').should('have.length.gt', 0);
 			// Let the popup's fade-in/zoom-in animation settle; scanning mid-animation
 			// blends the text with the background and falsely fails color-contrast.
+			// eslint-disable-next-line cypress/no-unnecessary-waiting
 			cy.wait(600);
 			cy.checkA11y(undefined, {
 				rules: {

--- a/apps/ui-storybook-e2e/src/integration/autocomplete/autocomplete.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/autocomplete/autocomplete.cy.ts
@@ -40,6 +40,9 @@ describe('autocomplete', () => {
 		});
 
 		it('should pass accessibility checks', () => {
+			// Wait for the story to render before auditing; running axe immediately after
+			// cy.visit scans an empty root and falsely passes.
+			cy.get('input[hlmInputGroupInput]').should('be.visible');
 			cy.checkA11y(undefined, {
 				rules: {
 					'page-has-heading-one': { enabled: false },

--- a/apps/ui-storybook-e2e/src/integration/autocomplete/autocomplete.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/autocomplete/autocomplete.cy.ts
@@ -50,6 +50,19 @@ describe('autocomplete', () => {
 				},
 			});
 		});
+
+		it('should pass accessibility checks when opened', () => {
+			// Wait for the story to render before typing to open the popup and auditing.
+			cy.get('input[hlmInputGroupInput]').should('be.visible');
+			cy.get('input[hlmInputGroupInput]').type('Mar');
+			cy.get('hlm-autocomplete-item').should('have.length.gt', 0);
+			cy.checkA11y(undefined, {
+				rules: {
+					'page-has-heading-one': { enabled: false },
+					'landmark-one-main': { enabled: false },
+				},
+			});
+		});
 	});
 
 	describe('Form', () => {

--- a/apps/ui-storybook-e2e/src/integration/autocomplete/autocomplete.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/autocomplete/autocomplete.cy.ts
@@ -56,10 +56,17 @@ describe('autocomplete', () => {
 			cy.get('input[hlmInputGroupInput]').should('be.visible');
 			cy.get('input[hlmInputGroupInput]').type('Mar');
 			cy.get('hlm-autocomplete-item').should('have.length.gt', 0);
+			// Let the popup's fade-in/zoom-in animation settle; scanning mid-animation
+			// blends the text with the background and falsely fails color-contrast.
+			cy.wait(600);
 			cy.checkA11y(undefined, {
 				rules: {
 					'page-has-heading-one': { enabled: false },
 					'landmark-one-main': { enabled: false },
+					// The open popup is a CDK overlay appended to <body>, outside any landmark.
+					// This is a Storybook-host artifact (same root cause as landmark-one-main),
+					// not a WCAG rule (region is best-practice).
+					region: { enabled: false },
 				},
 			});
 		});

--- a/apps/ui-storybook-e2e/src/integration/combobox/combobox.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/combobox/combobox.cy.ts
@@ -6,6 +6,9 @@ describe('combobox--default', () => {
 		});
 
 		it('click on combobox should open, click on Angular option should closed', () => {
+			// Wait for the story to render before auditing; running axe immediately after
+			// cy.visit scans an empty root and falsely passes.
+			cy.get('input[placeholder="Select framework..."]').should('be.visible');
 			cy.checkA11y('#storybook-root', {
 				rules: {
 					'page-has-heading-one': { enabled: false },

--- a/apps/ui-storybook-e2e/src/integration/combobox/combobox.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/combobox/combobox.cy.ts
@@ -57,10 +57,17 @@ describe('combobox--default', () => {
 			cy.get('input[placeholder="Select framework..."]').should('be.visible');
 			cy.get('input[placeholder="Select framework..."]').realClick();
 			cy.findByText('Angular').should('be.visible');
+			// Let the popup's fade-in/zoom-in animation settle; scanning mid-animation
+			// blends the text with the background and falsely fails color-contrast.
+			cy.wait(600);
 			cy.checkA11y(undefined, {
 				rules: {
 					'page-has-heading-one': { enabled: false },
 					'landmark-one-main': { enabled: false },
+					// The open popup is a CDK overlay appended to <body>, outside any landmark.
+					// This is a Storybook-host artifact (same root cause as landmark-one-main),
+					// not a WCAG rule (region is best-practice).
+					region: { enabled: false },
 				},
 			});
 		});

--- a/apps/ui-storybook-e2e/src/integration/combobox/combobox.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/combobox/combobox.cy.ts
@@ -51,6 +51,19 @@ describe('combobox--default', () => {
 			cy.get('input[placeholder="Select framework..."]').realClick();
 			cy.findByText('Angular').should('be.visible');
 		});
+
+		it('should pass accessibility checks when opened', () => {
+			// Wait for the story to render before opening and auditing.
+			cy.get('input[placeholder="Select framework..."]').should('be.visible');
+			cy.get('input[placeholder="Select framework..."]').realClick();
+			cy.findByText('Angular').should('be.visible');
+			cy.checkA11y(undefined, {
+				rules: {
+					'page-has-heading-one': { enabled: false },
+					'landmark-one-main': { enabled: false },
+				},
+			});
+		});
 	});
 });
 

--- a/apps/ui-storybook-e2e/src/integration/combobox/combobox.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/combobox/combobox.cy.ts
@@ -59,6 +59,7 @@ describe('combobox--default', () => {
 			cy.findByText('Angular').should('be.visible');
 			// Let the popup's fade-in/zoom-in animation settle; scanning mid-animation
 			// blends the text with the background and falsely fails color-contrast.
+			// eslint-disable-next-line cypress/no-unnecessary-waiting
 			cy.wait(600);
 			cy.checkA11y(undefined, {
 				rules: {

--- a/apps/ui-storybook-e2e/src/integration/command/command--default.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/command/command--default.cy.ts
@@ -149,5 +149,24 @@ describe('command', () => {
 			cy.findByText(/search emoji/i).should('have.attr', 'aria-selected', 'false');
 			cy.findByText(/calendar/i).should('have.attr', 'aria-selected', 'true');
 		});
+		it(`
+	Input, list, and items should be accessible and have no WCAG A/AA violations.
+	  `, () => {
+			// Wait for the story to render before auditing; running axe immediately after
+			// cy.visit scans an empty root and falsely passes.
+			cy.get('input').should('be.visible');
+			cy.get('[role="listbox"]').should('be.visible');
+			cy.realPress('Tab');
+			cy.realPress('Tab');
+			cy.checkA11y('#storybook-root', {
+				rules: {
+					'page-has-heading-one': { enabled: false },
+					'landmark-one-main': { enabled: false },
+				},
+			});
+			cy.get('input').should('exist').and('be.visible');
+			cy.findByRole('listbox').should('be.visible');
+			cy.findByRole('option', { name: /calendar/i }).should('be.visible');
+		});
 	});
 });

--- a/libs/brain/autocomplete/src/lib/brn-autocomplete-input.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete-input.ts
@@ -17,6 +17,7 @@ import { injectBrnAutocompleteBase } from './brn-autocomplete.token';
 		'aria-autocomplete': 'list',
 		'aria-haspopup': 'listbox',
 		'[attr.aria-expanded]': '_isExpanded()',
+		'[attr.aria-controls]': '_autocompleteListId()',
 		'[attr.aria-invalid]': '_ariaInvalid() ? "true": null',
 		'[attr.data-invalid]': '_ariaInvalid() ? "true": null',
 		'[attr.data-matches-spartan-invalid]': '_spartanInvalid() ? "true": null',
@@ -31,6 +32,9 @@ export class BrnAutocompleteInput<T> {
 	private static _id = 0;
 	private readonly _el = inject(ElementRef);
 	private readonly _autocomplete = injectBrnAutocompleteBase<T>();
+
+	/** The id of the autocomplete list, used for aria-controls. */
+	protected readonly _autocompleteListId = this._autocomplete.listId;
 
 	/** The id of the autocomplete input */
 	public readonly id = input<string>(`brn-autocomplete-input-${++BrnAutocompleteInput._id}`);

--- a/libs/brain/autocomplete/src/lib/brn-autocomplete-list.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete-list.ts
@@ -21,4 +21,8 @@ export class BrnAutocompleteList {
 
 	/** The id of the autocomplete list */
 	public readonly id = input<string>(`brn-autocomplete-list-${++BrnAutocompleteList._id}`);
+
+	constructor() {
+		this._autocomplete.registerAutocompleteList(this);
+	}
 }

--- a/libs/brain/autocomplete/src/lib/brn-autocomplete-list.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete-list.ts
@@ -9,6 +9,7 @@ import { injectBrnAutocompleteBase } from './brn-autocomplete.token';
 		'aria-orientation': 'vertical',
 		'[id]': 'id()',
 		'[attr.data-empty]': '!_visibleItems() ? "" : null',
+		'[attr.aria-label]': 'ariaLabel()',
 	},
 })
 export class BrnAutocompleteList {
@@ -21,6 +22,9 @@ export class BrnAutocompleteList {
 
 	/** The id of the autocomplete list */
 	public readonly id = input<string>(`brn-autocomplete-list-${++BrnAutocompleteList._id}`);
+
+	/** Optional accessible name for the listbox. Usually not needed as the autocomplete names the widget. */
+	public readonly ariaLabel = input<string | undefined>(undefined, { alias: 'aria-label' });
 
 	constructor() {
 		this._autocomplete.registerAutocompleteList(this);

--- a/libs/brain/autocomplete/src/lib/brn-autocomplete-search.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete-search.ts
@@ -24,6 +24,7 @@ import { BrnPopover } from '@spartan-ng/brain/popover';
 import { BrnAutocompleteInput } from './brn-autocomplete-input';
 import { BrnAutocompleteItem } from './brn-autocomplete-item';
 import { BrnAutocompleteItemToken } from './brn-autocomplete-item.token';
+import type { BrnAutocompleteList } from './brn-autocomplete-list';
 import {
 	AutocompleteItemToString,
 	BrnAutocompleteBase,
@@ -103,6 +104,11 @@ export class BrnAutocompleteSearch<T> implements BrnAutocompleteBase<T>, Control
 
 	private readonly _autocompleteInput = signal<BrnAutocompleteInput<T> | undefined>(undefined);
 
+	private readonly _autocompleteList = signal<BrnAutocompleteList | undefined>(undefined);
+
+	/** @internal The id of the autocomplete list, registered by BrnAutocompleteList. Used by the input for aria-controls. */
+	public readonly listId = computed(() => this._autocompleteList()?.id());
+
 	protected _onChange?: ChangeFn<string | undefined | null>;
 	protected _onTouched?: TouchFn;
 
@@ -141,6 +147,11 @@ export class BrnAutocompleteSearch<T> implements BrnAutocompleteBase<T>, Control
 
 	public registerAutocompleteInput(input: BrnAutocompleteInput<T>): void {
 		return this._autocompleteInput.set(input);
+	}
+
+	/** @internal Register the autocomplete list. Called by BrnAutocompleteList in its constructor. */
+	public registerAutocompleteList(list: BrnAutocompleteList): void {
+		this._autocompleteList.set(list);
 	}
 
 	public updateInputWidth(width: number | null): void {

--- a/libs/brain/autocomplete/src/lib/brn-autocomplete.token.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete.token.ts
@@ -12,6 +12,7 @@ import {
 import type { ControlState } from '@spartan-ng/brain/forms';
 import type { BrnAutocompleteInput } from './brn-autocomplete-input';
 import type { BrnAutocompleteItem } from './brn-autocomplete-item';
+import type { BrnAutocompleteList } from './brn-autocomplete-list';
 
 export interface BrnAutocompleteBase<T> {
 	itemToString: InputSignal<AutocompleteItemToString<T> | undefined>;
@@ -24,6 +25,7 @@ export interface BrnAutocompleteBase<T> {
 	isExpanded: Signal<boolean>;
 	searchInputWrapperWidth: Signal<number | null>;
 	controlState: Signal<ControlState | null> | undefined;
+	listId: Signal<string | undefined>;
 
 	updateSearch: (value: string) => void;
 	isSelected: (itemValue: T) => boolean;
@@ -33,6 +35,7 @@ export interface BrnAutocompleteBase<T> {
 	/** Select the active item with Enter key. */
 	selectActiveItem: () => void;
 	registerAutocompleteInput: (input: BrnAutocompleteInput<T>) => void;
+	registerAutocompleteList: (list: BrnAutocompleteList) => void;
 	updateInputWidth: (width: number | null) => void;
 }
 

--- a/libs/brain/autocomplete/src/lib/brn-autocomplete.ts
+++ b/libs/brain/autocomplete/src/lib/brn-autocomplete.ts
@@ -23,6 +23,7 @@ import { BrnPopover } from '@spartan-ng/brain/popover';
 import { BrnAutocompleteInput } from './brn-autocomplete-input';
 import { BrnAutocompleteItem } from './brn-autocomplete-item';
 import { BrnAutocompleteItemToken } from './brn-autocomplete-item.token';
+import type { BrnAutocompleteList } from './brn-autocomplete-list';
 import {
 	AutocompleteItemEqualToValue,
 	AutocompleteItemToString,
@@ -103,6 +104,11 @@ export class BrnAutocomplete<T> implements BrnAutocompleteBase<T>, ControlValueA
 
 	private readonly _autocompleteInput = signal<BrnAutocompleteInput<T> | undefined>(undefined);
 
+	private readonly _autocompleteList = signal<BrnAutocompleteList | undefined>(undefined);
+
+	/** @internal The id of the autocomplete list, registered by BrnAutocompleteList. Used by the input for aria-controls. */
+	public readonly listId = computed(() => this._autocompleteList()?.id());
+
 	protected _onChange?: ChangeFn<T | undefined | null>;
 	protected _onTouched?: TouchFn;
 
@@ -143,6 +149,11 @@ export class BrnAutocomplete<T> implements BrnAutocompleteBase<T>, ControlValueA
 
 	public registerAutocompleteInput(input: BrnAutocompleteInput<T>): void {
 		return this._autocompleteInput.set(input);
+	}
+
+	/** @internal Register the autocomplete list. Called by BrnAutocompleteList in its constructor. */
+	public registerAutocompleteList(list: BrnAutocompleteList): void {
+		this._autocompleteList.set(list);
 	}
 
 	public updateInputWidth(width: number | null): void {

--- a/libs/brain/combobox/src/lib/brn-combobox-input.spec.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-input.spec.ts
@@ -22,6 +22,7 @@ function comboboxStub(initialValue: SimpleValue = null, state: PartialControlSta
 		disabledState: signal(false),
 		itemToString: signal(undefined),
 		mode: signal('combobox'),
+		listId: signal<string | undefined>(undefined),
 		hasValue: computed(() => value() !== undefined && value() !== null && value() !== ''),
 		controlState: signal(
 			state !== null

--- a/libs/brain/combobox/src/lib/brn-combobox-input.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-input.ts
@@ -18,6 +18,7 @@ import { ComboboxInputMode, injectBrnComboboxBase } from './brn-combobox.token';
 		'aria-autocomplete': 'list',
 		'aria-haspopup': 'listbox',
 		'[attr.aria-expanded]': '_isExpanded()',
+		'[attr.aria-controls]': '_comboboxListId()',
 		'[attr.aria-invalid]': '_isCombobox() && _ariaInvalid() ? "true": null',
 		'[attr.data-invalid]': '_isCombobox() && _ariaInvalid() ? "true": null',
 		'[attr.data-matches-spartan-invalid]': '_isCombobox() && _spartanInvalid() ? "true": null',
@@ -36,6 +37,9 @@ export class BrnComboboxInput<T> {
 	private readonly _content = inject(BrnComboboxContent, { optional: true });
 
 	public readonly mode = computed<ComboboxInputMode>(() => (this._content ? 'popup' : 'combobox'));
+
+	/** The id of the command list, used for aria-controls. */
+	protected readonly _comboboxListId = this._combobox.listId;
 
 	/** The id of the combobox input */
 	public readonly id = input<string>(`brn-combobox-input-${++BrnComboboxInput._id}`);

--- a/libs/brain/combobox/src/lib/brn-combobox-list.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-list.ts
@@ -21,4 +21,9 @@ export class BrnComboboxList {
 
 	/** The id of the combobox list */
 	public readonly id = input<string>(`brn-combobox-list-${++BrnComboboxList._id}`);
+
+	constructor() {
+		// Register the list with the combobox so the input can reference its id via aria-controls.
+		this._combobox.registerComboboxList?.(this);
+	}
 }

--- a/libs/brain/combobox/src/lib/brn-combobox-list.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-list.ts
@@ -9,6 +9,7 @@ import { injectBrnComboboxBase } from './brn-combobox.token';
 		'aria-orientation': 'vertical',
 		'[id]': 'id()',
 		'[attr.data-empty]': '!_visibleItems() ? "" : null',
+		'[attr.aria-label]': 'ariaLabel()',
 	},
 })
 export class BrnComboboxList {
@@ -22,8 +23,10 @@ export class BrnComboboxList {
 	/** The id of the combobox list */
 	public readonly id = input<string>(`brn-combobox-list-${++BrnComboboxList._id}`);
 
+	/** Optional accessible name for the listbox. Usually not needed as the combobox names the widget. */
+	public readonly ariaLabel = input<string | undefined>(undefined, { alias: 'aria-label' });
+
 	constructor() {
-		// Register the list with the combobox so the input can reference its id via aria-controls.
 		this._combobox.registerComboboxList?.(this);
 	}
 }

--- a/libs/brain/combobox/src/lib/brn-combobox-multiple.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-multiple.ts
@@ -25,6 +25,7 @@ import { BrnComboboxChipInput } from './brn-combobox-chip-input';
 import { BrnComboboxContent } from './brn-combobox-content';
 import { type BrnComboboxItem } from './brn-combobox-item';
 import { BrnComboboxItemToken } from './brn-combobox-item.token';
+import type { BrnComboboxList } from './brn-combobox-list';
 import {
 	type BrnComboboxBase,
 	type ComboboxFilter,
@@ -146,6 +147,11 @@ export class BrnComboboxMultiple<T> implements BrnComboboxBase<T>, ControlValueA
 
 	private readonly _comboboxChipInput = signal<BrnComboboxChipInput<T> | undefined>(undefined);
 
+	private readonly _comboboxList = signal<BrnComboboxList | undefined>(undefined);
+
+	/** @internal The id of the combobox list, registered by BrnComboboxList. Used by the input for aria-controls. */
+	public readonly listId = computed(() => this._comboboxList()?.id());
+
 	public readonly mode = signal<ComboboxInputMode>('combobox').asReadonly();
 
 	public readonly labelableId = computed(() => this._comboboxChipInput()?.id());
@@ -187,6 +193,11 @@ export class BrnComboboxMultiple<T> implements BrnComboboxBase<T>, ControlValueA
 
 	public registerComboboxChipInput(input: BrnComboboxChipInput<T>): void {
 		this._comboboxChipInput.set(input);
+	}
+
+	/** @internal Register the combobox list. Called by BrnComboboxList in its constructor. */
+	public registerComboboxList(list: BrnComboboxList): void {
+		this._comboboxList.set(list);
 	}
 
 	public updateInputWidth(width: number | null): void {

--- a/libs/brain/combobox/src/lib/brn-combobox.token.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox.token.ts
@@ -14,6 +14,7 @@ import type { BrnComboboxChipInput } from './brn-combobox-chip-input';
 import { comboboxContainsFilter } from './brn-combobox-filter';
 import type { BrnComboboxInput } from './brn-combobox-input';
 import type { BrnComboboxItem } from './brn-combobox-item';
+import type { BrnComboboxList } from './brn-combobox-list';
 
 export type ComboboxInputMode = 'combobox' | 'popup';
 
@@ -32,6 +33,7 @@ export interface BrnComboboxBase<T> {
 	mode: Signal<ComboboxInputMode>;
 	controlState?: Signal<ControlState | null>;
 	hasValue: Signal<boolean>;
+	listId: Signal<string | undefined>;
 
 	isSelected: (itemValue: T) => boolean;
 	select: (itemValue: T) => void;
@@ -49,6 +51,8 @@ export interface BrnComboboxBase<T> {
 	registerComboboxInput?: (input: BrnComboboxInput<T>) => void;
 	/** Register the combobox chip input component for multi selection mode */
 	registerComboboxChipInput?: (input: BrnComboboxChipInput<T>) => void;
+	/** Register the combobox list component so the input can reference its id via aria-controls */
+	registerComboboxList?: (list: BrnComboboxList) => void;
 	updateInputWidth: (width: number | null) => void;
 }
 

--- a/libs/brain/combobox/src/lib/brn-combobox.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox.ts
@@ -25,6 +25,7 @@ import { BrnComboboxContent } from './brn-combobox-content';
 import type { BrnComboboxInput } from './brn-combobox-input';
 import { type BrnComboboxItem } from './brn-combobox-item';
 import { BrnComboboxItemToken } from './brn-combobox-item.token';
+import type { BrnComboboxList } from './brn-combobox-list';
 import {
 	type BrnComboboxBase,
 	type ComboboxFilter,
@@ -139,6 +140,11 @@ export class BrnCombobox<T> implements BrnComboboxBase<T>, ControlValueAccessor 
 
 	private readonly _comboboxInput = signal<BrnComboboxInput<T> | undefined>(undefined);
 
+	private readonly _comboboxList = signal<BrnComboboxList | undefined>(undefined);
+
+	/** @internal The id of the combobox list, registered by BrnComboboxList. Used by the input for aria-controls. */
+	public readonly listId = computed(() => this._comboboxList()?.id());
+
 	public readonly mode = computed<ComboboxInputMode>(() => this._comboboxInput()?.mode() || 'combobox');
 
 	public readonly labelableId = computed(() => this._comboboxInput()?.id());
@@ -181,6 +187,11 @@ export class BrnCombobox<T> implements BrnComboboxBase<T>, ControlValueAccessor 
 
 	public registerComboboxInput(input: BrnComboboxInput<T>): void {
 		this._comboboxInput.set(input);
+	}
+
+	/** @internal Register the combobox list. Called by BrnComboboxList in its constructor. */
+	public registerComboboxList(list: BrnComboboxList): void {
+		this._comboboxList.set(list);
 	}
 
 	public updateInputWidth(width: number | null): void {

--- a/libs/brain/command/src/lib/brn-command-input.ts
+++ b/libs/brain/command/src/lib/brn-command-input.ts
@@ -13,7 +13,7 @@ import { injectBrnCommand } from './brn-command.token';
 		'aria-autocomplete': 'list',
 		'aria-haspopup': 'listbox',
 		'aria-expanded': 'true',
-		'[attr.aria-controls]': '_command.listId()',
+		'[attr.aria-controls]': '_commandListId()',
 		'[attr.aria-activedescendant]': '_activeDescendant()',
 		'[attr.disabled]': '_disabled() ? "" : null',
 		'(keydown)': 'onKeyDown($event)',
@@ -28,13 +28,15 @@ export class BrnCommandInput {
 	private static _id = 0;
 
 	private readonly _el = inject(ElementRef);
-	protected readonly _command = injectBrnCommand();
+	private readonly _command = injectBrnCommand();
 	private readonly _initialId = `brn-command-input-${++BrnCommandInput._id}`;
 
 	/** The id of the command input */
 	public readonly id = input<string, string | undefined>(this._initialId, {
 		transform: (value) => value || this._initialId,
 	});
+
+	protected readonly _commandListId = this._command.listId;
 
 	protected readonly _disabled = this._command.disabledState;
 

--- a/libs/brain/command/src/lib/brn-command-input.ts
+++ b/libs/brain/command/src/lib/brn-command-input.ts
@@ -11,6 +11,9 @@ import { injectBrnCommand } from './brn-command.token';
 		'[id]': 'id()',
 		role: 'combobox',
 		'aria-autocomplete': 'list',
+		'aria-haspopup': 'listbox',
+		'aria-expanded': 'true',
+		'[attr.aria-controls]': '_command.listId()',
 		'[attr.aria-activedescendant]': '_activeDescendant()',
 		'[attr.disabled]': '_disabled() ? "" : null',
 		'(keydown)': 'onKeyDown($event)',
@@ -25,8 +28,7 @@ export class BrnCommandInput {
 	private static _id = 0;
 
 	private readonly _el = inject(ElementRef);
-	private readonly _command = injectBrnCommand();
-
+	protected readonly _command = injectBrnCommand();
 	private readonly _initialId = `brn-command-input-${++BrnCommandInput._id}`;
 
 	/** The id of the command input */

--- a/libs/brain/command/src/lib/brn-command-list.ts
+++ b/libs/brain/command/src/lib/brn-command-list.ts
@@ -6,6 +6,7 @@ import { injectBrnCommand } from './brn-command.token';
 	host: {
 		role: 'listbox',
 		'[id]': 'id()',
+		'[attr.aria-label]': 'ariaLabel()',
 	},
 })
 export class BrnCommandList {
@@ -16,8 +17,10 @@ export class BrnCommandList {
 	/** The id of the command list */
 	public readonly id = input<string>(`brn-command-list-${++BrnCommandList._id}`);
 
+	/** Optional accessible name for the listbox. Usually not needed as the combobox names the widget. */
+	public readonly ariaLabel = input<string | undefined>(undefined, { alias: 'aria-label' });
+
 	constructor() {
-		// Register the list with the command so the input can reference its id via aria-controls.
 		this._command.registerCommandList(this);
 	}
 }

--- a/libs/brain/command/src/lib/brn-command-list.ts
+++ b/libs/brain/command/src/lib/brn-command-list.ts
@@ -1,4 +1,5 @@
 import { Directive, input } from '@angular/core';
+import { injectBrnCommand } from './brn-command.token';
 
 @Directive({
 	selector: '[brnCommandList]',
@@ -10,6 +11,13 @@ import { Directive, input } from '@angular/core';
 export class BrnCommandList {
 	private static _id = 0;
 
+	private readonly _command = injectBrnCommand();
+
 	/** The id of the command list */
 	public readonly id = input<string>(`brn-command-list-${++BrnCommandList._id}`);
+
+	constructor() {
+		// Register the list with the command so the input can reference its id via aria-controls.
+		this._command.registerCommandList(this);
+	}
 }

--- a/libs/brain/command/src/lib/brn-command-separator.ts
+++ b/libs/brain/command/src/lib/brn-command-separator.ts
@@ -4,7 +4,7 @@ import { injectBrnCommand } from './brn-command.token';
 @Directive({
 	selector: '[brnCommandSeparator]',
 	host: {
-		role: 'separator',
+		role: 'presentation',
 		'[attr.data-hidden]': '_hasSearchInput() ? true : null',
 	},
 })

--- a/libs/brain/command/src/lib/brn-command.ts
+++ b/libs/brain/command/src/lib/brn-command.ts
@@ -3,6 +3,7 @@ import { BooleanInput } from '@angular/cdk/coercion';
 import {
 	afterNextRender,
 	booleanAttribute,
+	computed,
 	contentChildren,
 	Directive,
 	effect,
@@ -13,12 +14,14 @@ import {
 	linkedSignal,
 	model,
 	output,
+	signal,
 	untracked,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ChangeFn, TouchFn } from '@spartan-ng/brain/forms';
 import { BrnCommandItemToken } from './brn-command-item.token';
+import type { BrnCommandList } from './brn-command-list';
 import { type CommandFilter, injectBrnCommandConfig, provideBrnCommand } from './brn-command.token';
 
 export const BRN_COMMAND_VALUE_ACCESSOR = {
@@ -69,6 +72,16 @@ export class BrnCommand implements ControlValueAccessor {
 
 	/** @internal The key manager for managing active descendant */
 	public readonly keyManager = new ActiveDescendantKeyManager(this.items, this._injector);
+
+	private readonly _commandList = signal<BrnCommandList | undefined>(undefined);
+
+	/** @internal The id of the command list, registered by BrnCommandList. Used by the input for aria-controls. */
+	public readonly listId = computed(() => this._commandList()?.id());
+
+	/** @internal Register the command list. Called by BrnCommandList in its constructor. */
+	public registerCommandList(list: BrnCommandList): void {
+		this._commandList.set(list);
+	}
 
 	protected _onChange?: ChangeFn<string | null>;
 	protected _onTouched?: TouchFn;

--- a/libs/cli/src/generators/ui/libs/combobox/files/lib/hlm-combobox-input.ts.template
+++ b/libs/cli/src/generators/ui/libs/combobox/files/lib/hlm-combobox-input.ts.template
@@ -32,6 +32,7 @@ import { classes } from '<%- importAlias %>/utils';
 					hlmInputGroupButton
 					data-slot="input-group-button"
 					[disabled]="comboboxInput.disabled()"
+					[attr.aria-label]="triggerAriaLabel()"
 					size="icon-xs"
 					variant="ghost"
 					class="group-has-data-[slot=combobox-clear]/input-group:hidden data-pressed:bg-transparent"
@@ -46,6 +47,7 @@ import { classes } from '<%- importAlias %>/utils';
 					hlmInputGroupButton
 					data-slot="combobox-clear"
 					[disabled]="comboboxInput.disabled()"
+					[attr.aria-label]="clearAriaLabel()"
 					size="icon-xs"
 					variant="ghost"
 				>
@@ -66,6 +68,12 @@ export class HlmComboboxInput {
 	public readonly showTrigger = input<boolean, BooleanInput>(true, { transform: booleanAttribute });
 	public readonly showClear = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 	public readonly forceInvalid = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
+
+	/** Accessible name for the icon-only popover trigger button. */
+	public readonly triggerAriaLabel = input<string>('Toggle options');
+
+	/** Accessible name for the icon-only clear button. */
+	public readonly clearAriaLabel = input<string>('Clear selection');
 
 	/** Manual override for aria-invalid. When not set, auto-detects from the parent combobox error state. */
 	public readonly ariaInvalidOverride = input<boolean | undefined, BooleanInput>(undefined, {

--- a/libs/helm/combobox/src/lib/hlm-combobox-input.ts
+++ b/libs/helm/combobox/src/lib/hlm-combobox-input.ts
@@ -32,6 +32,7 @@ import { classes } from '@spartan-ng/helm/utils';
 					hlmInputGroupButton
 					data-slot="input-group-button"
 					[disabled]="comboboxInput.disabled()"
+					[attr.aria-label]="triggerAriaLabel()"
 					size="icon-xs"
 					variant="ghost"
 					class="group-has-data-[slot=combobox-clear]/input-group:hidden data-pressed:bg-transparent"
@@ -46,6 +47,7 @@ import { classes } from '@spartan-ng/helm/utils';
 					hlmInputGroupButton
 					data-slot="combobox-clear"
 					[disabled]="comboboxInput.disabled()"
+					[attr.aria-label]="clearAriaLabel()"
 					size="icon-xs"
 					variant="ghost"
 				>
@@ -66,6 +68,12 @@ export class HlmComboboxInput {
 	public readonly showTrigger = input<boolean, BooleanInput>(true, { transform: booleanAttribute });
 	public readonly showClear = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 	public readonly forceInvalid = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
+
+	/** Accessible name for the icon-only popover trigger button. */
+	public readonly triggerAriaLabel = input<string>('Toggle options');
+
+	/** Accessible name for the icon-only clear button. */
+	public readonly clearAriaLabel = input<string>('Clear selection');
 
 	/** Manual override for aria-invalid. When not set, auto-detects from the parent combobox error state. */
 	public readonly ariaInvalidOverride = input<boolean | undefined, BooleanInput>(undefined, {

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -831,6 +831,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "required": false,
             "type": "string",
           },
+          {
+            "name": "aria-label",
+            "required": false,
+            "type": "string | undefined",
+          },
         ],
         "models": [],
         "outputs": [],
@@ -2596,6 +2601,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "name": "id",
             "required": false,
             "type": "string",
+          },
+          {
+            "name": "aria-label",
+            "required": false,
+            "type": "string | undefined",
           },
         ],
         "models": [],

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -2921,6 +2921,16 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "type": "boolean",
           },
           {
+            "name": "triggerAriaLabel",
+            "required": false,
+            "type": "string",
+          },
+          {
+            "name": "clearAriaLabel",
+            "required": false,
+            "type": "string",
+          },
+          {
             "name": "aria-invalid",
             "required": false,
             "type": "boolean | undefined",

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -3258,6 +3258,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "required": false,
             "type": "string",
           },
+          {
+            "name": "aria-label",
+            "required": false,
+            "type": "string | undefined",
+          },
         ],
         "models": [],
         "outputs": [],


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Which package are you modifying?

### Primitives

- [x] autocomplete
- [x] combobox
- [x] command

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #1660

## What is the new behavior?

Fix a11y tests for command, autocomplete and combobox to actually perform the validation with axe.

Command
- add `aria-expanded`, `aria-haspopup`, `aria-controls` to `brn-command-input`
- change separator role to `presentation`
- add `aria-label` input to brn-command-list

Combobox
- add `aria-label` for icon only buttons 
- add `aria-controls` to `brn-combobox-input`
- add `aria-label` input to `brn-combobox-list`

Autocomplete
- add `aria-controls` to `brn-autocomplete-input`
- add `aria-label` input to `brn-autocomplete-list`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved autocomplete, combobox, and command accessibility by linking inputs to their listboxes and exposing appropriate ARIA state.
  - Added configurable accessible labels for autocomplete, combobox, and command lists.
  - Improved command separator semantics for assistive technologies.
  - Added configurable labels for combobox toggle and clear-selection buttons.

- **Tests**
  - Expanded accessibility coverage for autocomplete, combobox, and command interactions, including opened and populated states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->