### PR TITLE
fix(sidebar): add defaultOpen option into sidebar config

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(sidebar)/sidebar.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(sidebar)/sidebar.page.ts
@@ -358,6 +358,11 @@ export const routeMeta: RouteMeta = {
 			<h3 spartanH4 id="defaults">Defaults</h3>
 			<ul class="list-inside list-disc pl-4 text-sm">
 				<li class="mt-2">
+					<span hlmCode>defaultOpen</span>
+					–
+					<span hlmCode>true</span>
+				</li>
+				<li class="mt-2">
 					<span hlmCode>sidebarWidth</span>
 					–
 					<span hlmCode>16rem</span>

--- a/apps/app/src/app/pages/(components)/components/(sidebar)/sidebar.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(sidebar)/sidebar.preview.ts
@@ -282,6 +282,7 @@ export const appConfig: ApplicationConfig = {
     providers: [
         provideHlmSidebarConfig({
             ...
+            defaultOpen: true,
             sidebarWidth: '16rem',
             sidebarWidthMobile: '18rem',
             sidebarWidthIcon: '3rem',

--- a/libs/helm/sidebar/src/lib/hlm-sidebar.service.ts
+++ b/libs/helm/sidebar/src/lib/hlm-sidebar.service.ts
@@ -22,7 +22,7 @@ export class HlmSidebarService {
 	private readonly _config = injectHlmSidebarConfig();
 	private readonly _document = inject(DOCUMENT);
 	private readonly _window = this._document.defaultView;
-	private readonly _open = signal<boolean>(true);
+	private readonly _open = signal<boolean>(this._config.defaultOpen);
 	private readonly _openMobile = signal<boolean>(false);
 	private readonly _isMobile = signal<boolean>(false);
 	private readonly _variant = signal<SidebarVariant>('sidebar');

--- a/libs/helm/sidebar/src/lib/hlm-sidebar.token.ts
+++ b/libs/helm/sidebar/src/lib/hlm-sidebar.token.ts
@@ -1,6 +1,7 @@
 import { inject, InjectionToken, type ValueProvider } from '@angular/core';
 
 export interface HlmSidebarConfig {
+	defaultOpen: boolean;
 	sidebarWidth: string;
 	sidebarWidthMobile: string;
 	sidebarWidthIcon: string;
@@ -12,6 +13,7 @@ export interface HlmSidebarConfig {
 }
 
 const defaultConfig: HlmSidebarConfig = {
+	defaultOpen: true,
 	sidebarWidth: '16rem',
 	sidebarWidthMobile: '18rem',
 	sidebarWidthIcon: '3rem',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] attachment
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] bubble
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] marker
- [ ] menubar
- [ ] message
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [x] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

Currently, sidebar `open` state is always open and we can't change it

## What is the new behavior?

Add new config option `defaultOpen` to allow us set the initial state of sidebar. 
Default value is `true`

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable initial open state for the sidebar.
  * The sidebar now defaults to open, while allowing applications to start it closed.
  * Updated documentation and examples to demonstrate the new setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->