### PR TITLE
fix(tooltip): add Escape key functionality to dismiss tooltip

### DIFF
--- a/libs/brain/tooltip/src/lib/brn-tooltip.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip.ts
@@ -29,6 +29,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { Directionality } from '@angular/cdk/bidi';
+import { hasModifierKey } from '@angular/cdk/keycodes';
 import { waitForElementAnimations } from '@spartan-ng/brain/core';
 import { of, Subject, Subscription, timer } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
@@ -138,6 +139,9 @@ export class BrnTooltip {
 						if (!this._isHoverPointer(event)) return;
 						this._tooltipHovered = false;
 						this.delay(false, this.hideDelay());
+					}),
+					this._renderer.listen(this._document.defaultView, 'keydown', (event: KeyboardEvent) => {
+						if (event.key === 'Escape' && !hasModifierKey(event)) this._hide(true);
 					}),
 				];
 			});
@@ -376,8 +380,8 @@ export class BrnTooltip {
 		);
 	}
 
-	private _hide(): void {
-		if (!this._componentRef || this._tooltipHovered) return;
+	private _hide(force = false): void {
+		if (!this._componentRef || (!force && this._tooltipHovered)) return;
 		// Already closing (exit animation in flight): nothing to do.
 		if (this._componentRef.instance.state() === 'closed') return;
 		this._componentRef.instance.state.set('closed');

--- a/libs/brain/tooltip/src/lib/brn-tooltip.ts
+++ b/libs/brain/tooltip/src/lib/brn-tooltip.ts
@@ -141,7 +141,7 @@ export class BrnTooltip {
 						this.delay(false, this.hideDelay());
 					}),
 					this._renderer.listen(this._document.defaultView, 'keydown', (event: KeyboardEvent) => {
-						if (event.key === 'Escape' && !hasModifierKey(event)) this._hide(true);
+						if (event.key === 'Escape' && !hasModifierKey(event)) this._dismiss();
 					}),
 				];
 			});
@@ -153,6 +153,11 @@ export class BrnTooltip {
 			this._cleanupTriggerEvents();
 			this._overlayRef?.dispose();
 		});
+	}
+
+	private _dismiss(): void {
+		this._tooltipHovered = false;
+		this.delay(false, -1);
 	}
 
 	private _updatePosition(): void {
@@ -380,8 +385,8 @@ export class BrnTooltip {
 		);
 	}
 
-	private _hide(force = false): void {
-		if (!this._componentRef || (!force && this._tooltipHovered)) return;
+	private _hide(): void {
+		if (!this._componentRef || this._tooltipHovered) return;
 		// Already closing (exit animation in flight): nothing to do.
 		if (this._componentRef.instance.state() === 'closed') return;
 		this._componentRef.instance.state.set('closed');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] attachment
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] bubble
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] marker
- [ ] menubar
- [ ] message
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [x] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

Add [brnTooltip]="'hello'" to a button.
Focus or hover the button so the tooltip shows.
Press Escape.
Expected: the tooltip closes.
Actual: nothing happens — it stays open until blur/mouseleave.

Closes https://github.com/spartan-ng/spartan/issues/1661

## What is the new behavior?

Tootip closes when clicking escape

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pressing Escape now reliably hides tooltips, including while hovering.
  * Tooltip hover behavior remains unchanged for ordinary hide actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->