### PR TITLE
fix(dialog): update closeOnOutsidePointerEvents behavior for alert dialog

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(dialog)/dialog--dismiss-options.preview.ts
+++ b/apps/app/src/app/pages/(components)/components/(dialog)/dialog--dismiss-options.preview.ts
@@ -1,0 +1,60 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { HlmButtonImports } from '@spartan-ng/helm/button';
+import { HlmDialogImports } from '@spartan-ng/helm/dialog';
+import { HlmLabelImports } from '@spartan-ng/helm/label';
+import { HlmSwitchImports } from '@spartan-ng/helm/switch';
+import { HlmTooltipImports } from '@spartan-ng/helm/tooltip';
+
+@Component({
+	selector: 'spartan-dialog-dismiss-options',
+	imports: [HlmDialogImports, HlmButtonImports, HlmLabelImports, HlmSwitchImports, HlmTooltipImports],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<div class="flex flex-col gap-4">
+			<label hlmLabel class="flex w-fit items-center" [hlmTooltip]="disableCloseTip">
+				<hlm-switch class="mr-2" [checked]="_disableClose()" (checkedChange)="_disableClose.set($event)" />
+				disableClose
+			</label>
+			<ng-template #disableCloseTip>
+				<div class="max-w-56 py-1 text-sm">
+					<p class="font-semibold">disableClose</p>
+					<p>Ignores Escape and outside clicks. Only a close button can close the dialog.</p>
+				</div>
+			</ng-template>
+
+			<label hlmLabel class="flex w-fit items-center" [hlmTooltip]="outsideClickTip">
+				<hlm-switch
+					class="mr-2"
+					[checked]="_closeOnOutsidePointerEvents()"
+					(checkedChange)="_closeOnOutsidePointerEvents.set($event)"
+				/>
+				closeOnOutsidePointerEvents
+			</label>
+			<ng-template #outsideClickTip>
+				<div class="max-w-56 py-1 text-sm">
+					<p class="font-semibold">closeOnOutsidePointerEvents</p>
+					<p>When off, outside clicks no longer close the dialog. Escape still works.</p>
+				</div>
+			</ng-template>
+
+			<hlm-dialog [disableClose]="_disableClose()" [closeOnOutsidePointerEvents]="_closeOnOutsidePointerEvents()">
+				<button hlmDialogTrigger hlmBtn variant="outline" class="w-fit">Open Dialog</button>
+				<hlm-dialog-content *hlmDialogPortal="let ctx" class="sm:max-w-md">
+					<hlm-dialog-header>
+						<h3 hlmDialogTitle>Dismiss options</h3>
+						<p hlmDialogDescription>
+							Press Escape or click the backdrop to see how the dialog reacts to the selected options.
+						</p>
+					</hlm-dialog-header>
+					<hlm-dialog-footer>
+						<button hlmBtn hlmDialogClose>Close</button>
+					</hlm-dialog-footer>
+				</hlm-dialog-content>
+			</hlm-dialog>
+		</div>
+	`,
+})
+export class DialogDismissOptions {
+	protected readonly _disableClose = signal(false);
+	protected readonly _closeOnOutsidePointerEvents = signal(true);
+}

--- a/apps/app/src/app/pages/(components)/components/(dialog)/dialog.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(dialog)/dialog.page.ts
@@ -110,8 +110,8 @@ export const routeMeta: RouteMeta = {
 				<code class="${hlmCode}">disableClose</code>
 				to block every user-initiated dismissal (Escape, backdrop clicks, and outside pointer events), or
 				<code class="${hlmCode}">closeOnOutsidePointerEvents</code>
-				to only control whether clicks outside the dialog close it. Hover the toggle labels in the example for a
-				summary of each option, then open the dialog and try Escape or a backdrop click.
+				to only control whether clicks outside the dialog close it. Hover the toggle labels in the example for a summary
+				of each option, then open the dialog and try Escape or a backdrop click.
 			</p>
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>

--- a/apps/app/src/app/pages/(components)/components/(dialog)/dialog.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(dialog)/dialog.page.ts
@@ -21,6 +21,7 @@ import { SectionSubHeading } from '../../../../shared/layout/section-sub-heading
 import { Tabs } from '../../../../shared/layout/tabs';
 import { UIApiDocs } from '../../../../shared/layout/ui-docs-section/ui-docs-section';
 import { metaWith } from '../../../../shared/meta/meta.util';
+import { DialogDismissOptions } from './dialog--dismiss-options.preview';
 import { DialogNoCloseButton } from './dialog--no-close-button.preview';
 import { DialogRtl } from './dialog--rtl.preview';
 import { DialogScrollableContent } from './dialog--scrollable-content.preview';
@@ -65,6 +66,7 @@ export const routeMeta: RouteMeta = {
 		DialogDeclarativePreview,
 		DialogClosePreview,
 		DialogNoCloseButton,
+		DialogDismissOptions,
 		DialogStickyFooter,
 		DialogScrollableContent,
 		DialogRtl,
@@ -100,6 +102,22 @@ export const routeMeta: RouteMeta = {
 					<spartan-dialog-no-close-button />
 				</div>
 				<spartan-code secondTab [code]="_noCloseButtonCode()" />
+			</spartan-tabs>
+
+			<h3 id="dismiss-options" spartanH4>Dismiss Options</h3>
+			<p class="${hlmP} mb-6">
+				Use
+				<code class="${hlmCode}">disableClose</code>
+				to block every user-initiated dismissal (Escape, backdrop clicks, and outside pointer events), or
+				<code class="${hlmCode}">closeOnOutsidePointerEvents</code>
+				to only control whether clicks outside the dialog close it. Hover the toggle labels in the example for a
+				summary of each option, then open the dialog and try Escape or a backdrop click.
+			</p>
+			<spartan-tabs firstTab="Preview" secondTab="Code">
+				<div spartanCodePreview firstTab>
+					<spartan-dialog-dismiss-options />
+				</div>
+				<spartan-code secondTab [code]="_dismissOptionsCode()" />
 			</spartan-tabs>
 
 			<h3 id="sticky-footer" spartanH4>Sticky Footer</h3>
@@ -219,6 +237,7 @@ export default class DialogPage {
 	private readonly _snippets = inject(PrimitiveSnippetsService).getSnippets('dialog');
 	protected readonly _defaultCode = computed(() => this._snippets()['default']);
 	protected readonly _noCloseButtonCode = computed(() => this._snippets()['noCloseButton']);
+	protected readonly _dismissOptionsCode = computed(() => this._snippets()['dismissOptions']);
 	protected readonly _stickyFooterCode = computed(() => this._snippets()['stickyFooter']);
 	protected readonly _scrollableContentCode = computed(() => this._snippets()['scrollableContent']);
 	protected readonly _contextMenuCode = computed(() => this._snippets()['contextMenu']);

--- a/libs/brain/alert-dialog/src/lib/brn-alert-dialog.ts
+++ b/libs/brain/alert-dialog/src/lib/brn-alert-dialog.ts
@@ -2,7 +2,7 @@ import { Directive, forwardRef } from '@angular/core';
 import { BrnDialog, type BrnDialogDefaultOptions, provideBrnDialogDefaultOptions } from '@spartan-ng/brain/dialog';
 
 export const BRN_ALERT_DIALOG_DEFAULT_OPTIONS: Partial<BrnDialogDefaultOptions> = {
-	disableClose: true,
+	closeOnOutsidePointerEvents: false,
 	role: 'alertdialog',
 };
 

--- a/libs/brain/dialog/src/lib/brn-dialog-ref.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog-ref.ts
@@ -73,8 +73,10 @@ export class BrnDialogRef<DialogResult = unknown> {
 
 	public dismiss(reason: BrnDialogDismissReason): boolean {
 		const options = this.initialOptions;
+		const isOutsideInteraction = reason === 'outside' || reason === 'backdrop';
+		const outsideCloseAllowed = options.closeOnOutsidePointerEvents;
 		if (!this.open || options.disableClose) return false;
-		if ((reason === 'outside' || reason === 'backdrop') && !options.closeOnOutsidePointerEvents) return false;
+		if (isOutsideInteraction && !outsideCloseAllowed) return false;
 
 		this.close();
 		return true;

--- a/libs/brain/dialog/src/lib/brn-dialog-ref.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog-ref.ts
@@ -74,7 +74,7 @@ export class BrnDialogRef<DialogResult = unknown> {
 	public dismiss(reason: BrnDialogDismissReason): boolean {
 		const options = this.initialOptions;
 		if (!this.open || options.disableClose) return false;
-		if (reason === 'outside' && !options.closeOnOutsidePointerEvents) return false;
+		if ((reason === 'outside' || reason === 'backdrop') && !options.closeOnOutsidePointerEvents) return false;
 
 		this.close();
 		return true;

--- a/libs/brain/dialog/src/lib/brn-dialog-token.ts
+++ b/libs/brain/dialog/src/lib/brn-dialog-token.ts
@@ -12,7 +12,7 @@ export const defaultOptions: BrnDialogDefaultOptions = {
 	attachTo: null,
 	autoFocus: 'first-tabbable',
 	backdropClass: '',
-	closeOnOutsidePointerEvents: false,
+	closeOnOutsidePointerEvents: true,
 	disableClose: false,
 	hasBackdrop: true,
 	panelClass: '',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [x] alert-dialog
- [ ] aspect-ratio
- [ ] attachment
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] bubble
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [x] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] marker
- [ ] menubar
- [ ] message
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

Opening an alert dialog and pressing `Escape` does not close it. This diverges from the shadcn/ui / Radix / Base UI `AlertDialog` behavior

Closes https://github.com/spartan-ng/spartan/issues/1688

## What is the new behavior?
Pressing escape closes the alert dialog, dialog behaviour is retained 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive example demonstrating dialog dismissal options, including controls for disabling dismissal and closing on outside clicks.

* **Bug Fixes**
  * Dialogs now consistently respect the setting that controls whether clicking outside the dialog closes them.
  * Alert dialogs remain open when users click outside them by default.
  * Standard dialogs now close when users click outside them by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->