### PR TITLE
feat(cli): support adding all components non-interactively

### DIFF
--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/cli.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/cli.page.ts
@@ -65,9 +65,13 @@ export const routeMeta: RouteMeta = {
 			<spartan-cli-tabs class="mt-4" nxCode="npx nx g @spartan-ng/cli:ui" ngCode="ng g @spartan-ng/cli:ui" />
 
 			<p class="${hlmP}">
-				You'll be prompted to select components to add - choose individual components or all of them. The CLI takes care
-				of the rest.
+				You'll be prompted to select components to add - choose individual components or all of them. To add every
+				component non-interactively, pass
+				<code class="${hlmCode}">all</code>
+				:
 			</p>
+
+			<spartan-cli-tabs class="mt-4" nxCode="npx nx g @spartan-ng/cli:ui all" ngCode="ng g @spartan-ng/cli:ui all" />
 
 			<spartan-section-sub-heading id="inspect-project">Inspect Your Project</spartan-section-sub-heading>
 			<p class="${hlmP}">

--- a/apps/cli-smoke/src/utils/workspace.ts
+++ b/apps/cli-smoke/src/utils/workspace.ts
@@ -238,7 +238,7 @@ function writeComponentsJson(dir: string, cell: SetupCell, componentsPath: strin
 	writeFileSync(join(dir, 'components.json'), `${JSON.stringify(config, null, 2)}\n`);
 }
 
-/** Run `init` then `ui` for each component under test, non-interactively. */
+/** Run `init` then add the requested components non-interactively. */
 export function runGenerators(ws: CellWorkspace): void {
 	const gen = ws.cell.workspace === 'nx' ? 'npx nx g' : 'npx ng generate';
 	// Tag spartan libs (nx only) so buildWorkspace can build just them, ignoring the template's sample.
@@ -246,7 +246,7 @@ export function runGenerators(ws: CellWorkspace): void {
 
 	run(`${gen} @spartan-ng/cli:init --project=${ws.app} --theme=zinc`, ws.dir);
 
-	const components = ws.cell.allComponents ? readAllPrimitives() : [...componentsUnderTest];
+	const components = ws.cell.allComponents ? ['all'] : componentsUnderTest;
 	for (const component of components) {
 		run(`${gen} @spartan-ng/cli:ui ${component} --directory=${ws.componentsPath}${tags}`, ws.dir);
 	}
@@ -267,13 +267,6 @@ export function assertMigrateHelmLibrariesLoads(ws: CellWorkspace): void {
 	if (!out.includes('No libraries to migrate')) {
 		throw new Error(`Expected migrate-helm-libraries to no-op on a workspace with no spartan libraries, got:\n${out}`);
 	}
-}
-
-/** Every supported primitive name, read from the CLI source so the list stays current as primitives are
- * added (the harness lives in the same repo as the CLI). */
-function readAllPrimitives(): string[] {
-	const file = join(workspaceRootDir(), 'libs', 'cli', 'src', 'generators', 'ui', 'supported-ui-libraries.json');
-	return Object.keys(JSON.parse(readFileSync(file, 'utf-8')));
 }
 
 /**

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -39,6 +39,7 @@ ng g @spartan-ng/cli:ui button
 
 # Or add every component non-interactively
 ng g @spartan-ng/cli:ui all
+# Nx: npx nx g @spartan-ng/cli:ui all
 ```
 
 The CLI installs the relevant `@spartan-ng/brain` entry points as npm dependencies and copies the helm component code straight into your project so you can edit every style.

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -36,6 +36,9 @@ ng g @spartan-ng/cli:ui
 
 # 3. Add a single component by name
 ng g @spartan-ng/cli:ui button
+
+# Or add every component non-interactively
+ng g @spartan-ng/cli:ui all
 ```
 
 The CLI installs the relevant `@spartan-ng/brain` entry points as npm dependencies and copies the helm component code straight into your project so you can edit every style.

--- a/libs/cli/src/generators/ui/generator.ts
+++ b/libs/cli/src/generators/ui/generator.ts
@@ -27,7 +27,9 @@ export default async function hlmUIGenerator(tree: Tree, options: HlmUIGenerator
 	const availablePrimitiveNames: Primitive[] = Object.keys(availablePrimitives) as Primitive[];
 
 	let response: { primitives: PrimitiveResponse[] } = { primitives: [] };
-	if (options.name && availablePrimitiveNames.includes(options.name)) {
+	if (options.name === 'all') {
+		response.primitives.push('all');
+	} else if (options.name && availablePrimitiveNames.includes(options.name)) {
 		response.primitives.push(options.name);
 	} else {
 		if (options.name) {

--- a/libs/cli/src/generators/ui/schema.d.ts
+++ b/libs/cli/src/generators/ui/schema.d.ts
@@ -1,7 +1,7 @@
 import { type Primitive } from './primitives';
 
 export interface HlmUIGeneratorSchema {
-	name?: Primitive;
+	name?: Primitive | 'all';
 	directory?: string;
 	rootProject?: boolean;
 	tags?: string;

--- a/libs/cli/src/generators/ui/schema.json
+++ b/libs/cli/src/generators/ui/schema.json
@@ -6,7 +6,7 @@
 	"properties": {
 		"name": {
 			"type": "string",
-			"description": "Primitive name",
+			"description": "Primitive name, or 'all' to add every primitive",
 			"$default": {
 				"$source": "argv",
 				"index": 0

--- a/skills/spartan/cli.md
+++ b/skills/spartan/cli.md
@@ -32,6 +32,7 @@ Adds components. Installs the Brain dependency from npm and copies the Helm code
 ```bash
 npx nx g @spartan-ng/cli:ui                 # interactive multiselect (choose 'all' or specific)
 npx nx g @spartan-ng/cli:ui --name=dialog   # add a single component
+npx nx g @spartan-ng/cli:ui all             # add every component non-interactively
 ng g @spartan-ng/cli:ui --name=button
 ```
 

--- a/skills/spartan/cli.md
+++ b/skills/spartan/cli.md
@@ -34,6 +34,7 @@ npx nx g @spartan-ng/cli:ui                 # interactive multiselect (choose 'a
 npx nx g @spartan-ng/cli:ui --name=dialog   # add a single component
 npx nx g @spartan-ng/cli:ui all             # add every component non-interactively
 ng g @spartan-ng/cli:ui --name=button
+ng g @spartan-ng/cli:ui all
 ```
 
 Dependent components are pulled in automatically.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] attachment
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] bubble
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] marker
- [ ] menubar
- [ ] message
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [x] cli
- [ ] mcp

## What is the current behavior?

The interactive component picker supports selecting `all`, but passing `all` to the `ui` generator is
treated as an invalid primitive and opens the picker. This prevents non-interactive installs of every
component.

## What is the new behavior?

`npx nx g @spartan-ng/cli:ui all` and `ng g @spartan-ng/cli:ui all` now add every supported component
without opening the interactive picker. The CLI reference, package README, agent skill, and smoke coverage
document and exercise the new command.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Verified with:

- `pnpm nx run cli:test --skip-nx-cache` (223 tests)
- `pnpm nx run cli:build --skip-nx-cache`
- `pnpm nx run cli:lint --skip-nx-cache`
- `pnpm nx run cli-smoke:lint --skip-nx-cache`
- `pnpm exec tsc --noEmit -p apps/cli-smoke/tsconfig.json`
- `pnpm nx run app:lint --skip-nx-cache`
- `pnpm nx run app:build --skip-nx-cache`
- `pnpm nx format:check --files=<changed files>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the non-interactive `all` option to add every UI component at once.
  * CLI users can now choose individual components or install the complete component set without an interactive prompt.

* **Documentation**
  * Updated CLI guides, quick-start instructions, and component documentation with examples for adding all components using Angular and Nx.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->