### PR TITLE
feat(app): add charts gallery page

### DIFF
--- a/apps/app/src/app/pages/(charts)/charts.examples.ts
+++ b/apps/app/src/app/pages/(charts)/charts.examples.ts
@@ -1,0 +1,691 @@
+import { HLM_CHART_THEME, hlmChartTooltip } from '@spartan-ng/helm/chart';
+import { areaY, barX, barY, colorLegend, defineChart, group, lineY } from '@tanstack/charts';
+import {
+	pie,
+	polar,
+	radialArc,
+	radialArea,
+	radialBarAngle,
+	radialBarRadius,
+	radialLine,
+	radialText,
+} from '@tanstack/charts/polar';
+import { scaleBand } from '@tanstack/charts/scales/band';
+import { scaleLinear } from '@tanstack/charts/scales/linear';
+import { scalePoint } from '@tanstack/charts/scales/point';
+
+const monthly = [
+	{ month: 'Jan', desktop: 186, mobile: 80, low: 148, high: 218 },
+	{ month: 'Feb', desktop: 305, mobile: 200, low: 260, high: 342 },
+	{ month: 'Mar', desktop: 237, mobile: 120, low: 198, high: 280 },
+	{ month: 'Apr', desktop: 273, mobile: 190, low: 226, high: 310 },
+	{ month: 'May', desktop: 209, mobile: 130, low: 178, high: 252 },
+	{ month: 'Jun', desktop: 314, mobile: 240, low: 270, high: 356 },
+];
+
+const monthlySeries = monthly.flatMap(({ month, desktop, mobile }) => [
+	{ month, series: 'Desktop', value: desktop },
+	{ month, series: 'Mobile', value: mobile },
+]);
+
+const products = [
+	{ product: 'Search', value: 275 },
+	{ product: 'Social', value: 220 },
+	{ product: 'Email', value: 188 },
+	{ product: 'Direct', value: 142 },
+];
+
+const changes = [
+	{ month: 'Jan', value: 42 },
+	{ month: 'Feb', value: -18 },
+	{ month: 'Mar', value: 31 },
+	{ month: 'Apr', value: -12 },
+	{ month: 'May', value: 48 },
+	{ month: 'Jun', value: 24 },
+];
+
+const devices = [
+	{ device: 'Desktop', visitors: 560 },
+	{ device: 'Mobile', visitors: 420 },
+	{ device: 'Tablet', visitors: 180 },
+	{ device: 'Other', visitors: 90 },
+];
+
+const radialMetrics = [
+	{ metric: 'Speed', value: 82 },
+	{ metric: 'Power', value: 68 },
+	{ metric: 'Control', value: 91 },
+	{ metric: 'Range', value: 74 },
+	{ metric: 'Comfort', value: 63 },
+];
+
+const deviceNames = devices.map(({ device }) => device);
+const radialNames = radialMetrics.map(({ metric }) => metric);
+const devicePie = pie(devices, { value: 'visitors' });
+const deviceDonut = pie(devices, { value: 'visitors', gapAngle: 0.04 });
+const roundedDonut = pie(devices, { value: 'visitors', gapAngle: 0.07 });
+const halfDonut = pie(devices, {
+	value: 'visitors',
+	startAngle: -Math.PI * 0.75,
+	endAngle: Math.PI * 0.75,
+	gapAngle: 0.04,
+});
+const completion = [
+	{ status: 'Complete', value: 72 },
+	{ status: 'Remaining', value: 28 },
+];
+const completionSlices = pie(completion, {
+	value: 'value',
+	startAngle: -Math.PI * 0.75,
+	endAngle: Math.PI * 0.75,
+	gapAngle: 0.04,
+});
+
+const chartOptions = <const TDefinition>(definition: TDefinition, ariaLabel: string, ariaDescription: string) => ({
+	definition,
+	ariaLabel,
+	ariaDescription,
+	aspectRatio: 16 / 9,
+});
+
+export const chartSections = [
+	{
+		id: 'area-charts',
+		label: 'Area',
+		description: 'Show totals, ranges, and composition changing over time.',
+		examples: [
+			{
+				title: 'Default area',
+				description: 'A single series with a semantic fill and outline.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								areaY(monthly, {
+									x: 'month',
+									y: 'desktop',
+									fill: 'var(--chart-1)',
+									fillOpacity: 0.22,
+									stroke: 'var(--chart-1)',
+									strokeWidth: 2,
+								}),
+							],
+							x: { scale: () => scalePoint<string>().padding(0.2) },
+							y: { scale: scaleLinear, nice: true, grid: true },
+							theme: HLM_CHART_THEME,
+						},
+						{ focus: 'nearest-x', tooltip: hlmChartTooltip() },
+					),
+					'Monthly desktop visitors',
+					'Area chart showing desktop visitors from January through June.',
+				),
+			},
+			{
+				title: 'Range area',
+				description: 'An interval between a lower and upper estimate.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								areaY(monthly, {
+									x: 'month',
+									y1: 'low',
+									y2: 'high',
+									fill: 'var(--chart-2)',
+									fillOpacity: 0.3,
+									stroke: 'var(--chart-2)',
+									strokeWidth: 2,
+								}),
+							],
+							x: { scale: () => scalePoint<string>().padding(0.2) },
+							y: { scale: scaleLinear, nice: true, grid: true },
+							theme: HLM_CHART_THEME,
+						},
+						{ focus: 'nearest-x', tooltip: hlmChartTooltip() },
+					),
+					'Monthly visitor forecast range',
+					'Range area chart showing lower and upper visitor estimates.',
+				),
+			},
+			{
+				title: 'Stacked area',
+				description: 'Desktop and mobile contributions to the total.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								areaY(monthlySeries, {
+									x: 'month',
+									y: 'value',
+									color: 'series',
+									fillOpacity: 0.7,
+								}),
+							],
+							x: { scale: () => scalePoint<string>().padding(0.2) },
+							y: { scale: scaleLinear, nice: true, grid: true },
+							color: {
+								domain: ['Desktop', 'Mobile'],
+								legend: colorLegend({ label: 'Device' }),
+							},
+							theme: HLM_CHART_THEME,
+						},
+						{ focus: 'group-x', tooltip: hlmChartTooltip() },
+					),
+					'Visitors by device',
+					'Stacked area chart comparing desktop and mobile visitors.',
+				),
+			},
+			{
+				title: 'Layered area',
+				description: 'Two translucent series sharing one baseline.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								areaY(monthly, {
+									x: 'month',
+									y: 'desktop',
+									fill: 'var(--chart-1)',
+									fillOpacity: 0.18,
+									stroke: 'var(--chart-1)',
+								}),
+								areaY(monthly, {
+									x: 'month',
+									y: 'mobile',
+									fill: 'var(--chart-2)',
+									fillOpacity: 0.18,
+									stroke: 'var(--chart-2)',
+								}),
+							],
+							x: { scale: () => scalePoint<string>().padding(0.2) },
+							y: { scale: scaleLinear, nice: true, grid: true },
+							theme: HLM_CHART_THEME,
+						},
+						{ focus: 'nearest-x', tooltip: hlmChartTooltip() },
+					),
+					'Layered visitors by device',
+					'Layered area chart comparing desktop and mobile visitors.',
+				),
+			},
+		],
+	},
+	{
+		id: 'bar-charts',
+		label: 'Bar',
+		description: 'Compare magnitudes across categories and series.',
+		examples: [
+			{
+				title: 'Default bar',
+				description: 'A compact vertical comparison by month.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [barY(monthly, { x: 'month', y: 'desktop', inset: 4, fill: 'var(--chart-1)', radius: 4 })],
+							x: { scale: () => scaleBand<string>().padding(0.16) },
+							y: { scale: scaleLinear, nice: true, grid: true },
+							theme: HLM_CHART_THEME,
+						},
+						{ focus: 'nearest-x', tooltip: hlmChartTooltip() },
+					),
+					'Monthly desktop visitors',
+					'Bar chart showing desktop visitors from January through June.',
+				),
+			},
+			{
+				title: 'Horizontal bar',
+				description: 'Ranked acquisition channels with long labels.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [barX(products, { x: 'value', y: 'product', inset: 4, fill: 'var(--chart-2)', radius: 4 })],
+							x: { scale: scaleLinear, nice: true, grid: true },
+							y: { scale: () => scaleBand<string>().padding(0.16) },
+							theme: HLM_CHART_THEME,
+						},
+						{ focus: 'nearest-y', tooltip: hlmChartTooltip() },
+					),
+					'Visitors by acquisition channel',
+					'Horizontal bar chart ranking acquisition channels by visitors.',
+				),
+			},
+			{
+				title: 'Grouped bar',
+				description: 'Desktop and mobile values side by side.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								barY(monthlySeries, {
+									x: 'month',
+									y: 'value',
+									color: 'series',
+									layout: group({ padding: 0.18 }),
+									inset: 2,
+									radius: 3,
+								}),
+							],
+							x: { scale: () => scaleBand<string>().padding(0.16) },
+							y: { scale: scaleLinear, nice: true, grid: true },
+							color: {
+								domain: ['Desktop', 'Mobile'],
+								legend: colorLegend({ label: 'Device' }),
+							},
+							theme: HLM_CHART_THEME,
+						},
+						{ focus: 'group-x', tooltip: hlmChartTooltip() },
+					),
+					'Grouped visitors by device',
+					'Grouped bar chart comparing desktop and mobile visitors.',
+				),
+			},
+			{
+				title: 'Diverging bar',
+				description: 'Positive and negative monthly change around zero.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								barY(changes, {
+									x: 'month',
+									y: 'value',
+									inset: 4,
+									fill: ({ value }) => (value >= 0 ? 'var(--chart-2)' : 'var(--chart-5)'),
+									radius: 3,
+								}),
+							],
+							x: { scale: () => scaleBand<string>().padding(0.16) },
+							y: { scale: scaleLinear, nice: true, grid: true },
+							theme: HLM_CHART_THEME,
+						},
+						{ focus: 'nearest-x', tooltip: hlmChartTooltip() },
+					),
+					'Monthly visitor change',
+					'Diverging bar chart showing positive and negative monthly changes.',
+				),
+			},
+		],
+	},
+	{
+		id: 'line-charts',
+		label: 'Line',
+		description: 'Follow trends and compare trajectories over ordered values.',
+		examples: [
+			{
+				title: 'Default line',
+				description: 'A focused trend with visible data points.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								lineY(monthly, {
+									x: 'month',
+									y: 'desktop',
+									points: true,
+									stroke: 'var(--chart-1)',
+									strokeWidth: 2.5,
+								}),
+							],
+							x: { scale: () => scalePoint<string>().padding(0.2) },
+							y: { scale: scaleLinear, nice: true, grid: true },
+							theme: HLM_CHART_THEME,
+						},
+						{ focus: 'nearest-x', tooltip: hlmChartTooltip() },
+					),
+					'Monthly desktop trend',
+					'Line chart showing desktop visitors from January through June.',
+				),
+			},
+			{
+				title: 'Multiple lines',
+				description: 'Two device series with a shared legend.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								lineY(monthlySeries, {
+									x: 'month',
+									y: 'value',
+									z: 'series',
+									color: 'series',
+									points: true,
+									strokeWidth: 2.5,
+								}),
+							],
+							x: { scale: () => scalePoint<string>().padding(0.2) },
+							y: { scale: scaleLinear, nice: true, grid: true },
+							color: {
+								domain: ['Desktop', 'Mobile'],
+								legend: colorLegend({ label: 'Device' }),
+							},
+							theme: HLM_CHART_THEME,
+						},
+						{ focus: 'group-x', tooltip: hlmChartTooltip() },
+					),
+					'Visitor trends by device',
+					'Multiple line chart comparing desktop and mobile visitors.',
+				),
+			},
+			{
+				title: 'Dashed line',
+				description: 'A forecast-style series with a dashed stroke.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								lineY(monthly, {
+									x: 'month',
+									y: 'mobile',
+									points: true,
+									stroke: 'var(--chart-4)',
+									strokeWidth: 2.5,
+									strokeDasharray: '7 5',
+								}),
+							],
+							x: { scale: () => scalePoint<string>().padding(0.2) },
+							y: { scale: scaleLinear, nice: true, grid: true },
+							theme: HLM_CHART_THEME,
+						},
+						{ focus: 'nearest-x', tooltip: hlmChartTooltip() },
+					),
+					'Monthly mobile forecast',
+					'Dashed line chart showing a monthly mobile visitor forecast.',
+				),
+			},
+			{
+				title: 'Actual and target',
+				description: 'A measured series against a constant target.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								lineY(monthly, {
+									x: 'month',
+									y: 'desktop',
+									points: true,
+									stroke: 'var(--chart-1)',
+									strokeWidth: 2.5,
+								}),
+								lineY(monthly, {
+									x: 'month',
+									y: () => 250,
+									stroke: 'var(--muted-foreground)',
+									strokeDasharray: '5 5',
+								}),
+							],
+							x: { scale: () => scalePoint<string>().padding(0.2) },
+							y: { scale: scaleLinear, nice: true, grid: true },
+							theme: HLM_CHART_THEME,
+						},
+						{ focus: 'nearest-x', tooltip: hlmChartTooltip() },
+					),
+					'Visitors compared with target',
+					'Line chart comparing actual desktop visitors with a target of 250.',
+				),
+			},
+		],
+	},
+	{
+		id: 'pie-charts',
+		label: 'Pie',
+		description: 'Show a small number of parts within a whole.',
+		examples: [
+			{
+				title: 'Default pie',
+				description: 'A direct part-to-whole comparison.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								polar({
+									inset: 8,
+									radiusRatio: 0.78,
+									marks: [radialArc(devicePie, { color: 'device', key: 'device' })],
+								}),
+							],
+							color: { domain: deviceNames, legend: colorLegend({ label: 'Device' }) },
+							theme: HLM_CHART_THEME,
+						},
+						{ tooltip: hlmChartTooltip() },
+					),
+					'Visitors by device',
+					'Pie chart showing visitor share across four device types.',
+				),
+			},
+			{
+				title: 'Donut',
+				description: 'A ring layout with clear spacing between slices.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								polar({
+									inset: 8,
+									radiusRatio: 0.78,
+									marks: [
+										radialArc(deviceDonut, {
+											innerRadius: ({ radius }) => radius * 0.56,
+											color: 'device',
+											key: 'device',
+										}),
+									],
+								}),
+							],
+							color: { domain: deviceNames, legend: colorLegend({ label: 'Device' }) },
+							theme: HLM_CHART_THEME,
+						},
+						{ tooltip: hlmChartTooltip() },
+					),
+					'Visitors by device',
+					'Donut chart showing visitor share across four device types.',
+				),
+			},
+			{
+				title: 'Rounded donut',
+				description: 'A narrow ring with rounded slice corners.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								polar({
+									inset: 8,
+									radiusRatio: 0.78,
+									marks: [
+										radialArc(roundedDonut, {
+											innerRadius: ({ radius }) => radius * 0.7,
+											cornerRadius: 8,
+											color: 'device',
+											key: 'device',
+										}),
+									],
+								}),
+							],
+							color: { domain: deviceNames, legend: colorLegend({ label: 'Device' }) },
+							theme: HLM_CHART_THEME,
+						},
+						{ tooltip: hlmChartTooltip() },
+					),
+					'Visitors by device',
+					'Rounded donut chart showing visitor share across four device types.',
+				),
+			},
+			{
+				title: 'Half donut',
+				description: 'A compact semicircular part-to-whole layout.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								polar({
+									inset: 8,
+									radiusRatio: 0.78,
+									marks: [
+										radialArc(halfDonut, {
+											innerRadius: ({ radius }) => radius * 0.62,
+											cornerRadius: 5,
+											color: 'device',
+											key: 'device',
+										}),
+									],
+								}),
+							],
+							color: { domain: deviceNames, legend: colorLegend({ label: 'Device' }) },
+							theme: HLM_CHART_THEME,
+						},
+						{ tooltip: hlmChartTooltip() },
+					),
+					'Visitors by device',
+					'Half donut chart showing visitor share across four device types.',
+				),
+			},
+		],
+	},
+	{
+		id: 'radial-charts',
+		label: 'Radial',
+		description: 'Use angle and radius for compact cyclic comparisons.',
+		examples: [
+			{
+				title: 'Radial bars',
+				description: 'Values extend through radius around an angle band.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								polar({
+									radiusRatio: 0.78,
+									angle: { scale: () => scaleBand<string>().domain(radialNames).padding(0.12) },
+									radius: {
+										scale: scaleLinear().domain([0, 100]),
+										range: [({ radius }) => radius * 0.24, ({ radius }) => radius],
+									},
+									marks: [
+										radialBarRadius(radialMetrics, {
+											angle: 'metric',
+											radius: 'value',
+											color: 'metric',
+											key: 'metric',
+										}),
+									],
+								}),
+							],
+							color: { domain: radialNames },
+							theme: HLM_CHART_THEME,
+						},
+						{ tooltip: hlmChartTooltip() },
+					),
+					'Product metrics as radial bars',
+					'Radial bar chart comparing five product metrics.',
+				),
+			},
+			{
+				title: 'Concentric bars',
+				description: 'Values extend through angle on concentric bands.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								polar({
+									radiusRatio: 0.78,
+									angle: { scale: scaleLinear().domain([0, 100]) },
+									radius: { scale: () => scaleBand<string>().domain(radialNames).padding(0.2) },
+									marks: [
+										radialBarAngle(radialMetrics, {
+											angle: 'value',
+											radius: 'metric',
+											color: 'metric',
+											key: 'metric',
+											cornerRadius: 'full',
+										}),
+									],
+								}),
+							],
+							color: { domain: radialNames },
+							theme: HLM_CHART_THEME,
+						},
+						{ tooltip: hlmChartTooltip() },
+					),
+					'Product metrics as concentric bars',
+					'Concentric radial bar chart comparing five product metrics.',
+				),
+			},
+			{
+				title: 'Polar profile',
+				description: 'An area and line profile across cyclic dimensions.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								polar({
+									radiusRatio: 0.72,
+									angle: { scale: scalePoint<string>().domain(radialNames), wrap: true },
+									radius: { scale: scaleLinear().domain([0, 100]) },
+									marks: [
+										radialArea(radialMetrics, {
+											angle: 'metric',
+											radius: 'value',
+											fill: 'var(--chart-2)',
+											fillOpacity: 0.22,
+										}),
+										radialLine(radialMetrics, {
+											angle: 'metric',
+											radius: 'value',
+											stroke: 'var(--chart-2)',
+											strokeWidth: 2.5,
+											points: true,
+										}),
+									],
+								}),
+							],
+							theme: HLM_CHART_THEME,
+						},
+						{ tooltip: hlmChartTooltip() },
+					),
+					'Product metric profile',
+					'Polar area and line chart comparing five product metrics.',
+				),
+			},
+			{
+				title: 'Radial gauge',
+				description: 'A compact completion metric with center text.',
+				options: chartOptions(
+					defineChart(
+						{
+							marks: [
+								polar({
+									radiusRatio: 0.76,
+									angle: { scale: scaleLinear().domain([0, 1]) },
+									radius: { scale: scaleLinear().domain([0, 1]) },
+									marks: [
+										radialArc(completionSlices, {
+											innerRadius: ({ radius }) => radius * 0.72,
+											cornerRadius: 999,
+											color: 'status',
+											key: 'status',
+										}),
+										radialText([completion[0]], {
+											angle: 0,
+											radius: 0,
+											text: () => '72%',
+											key: 'status',
+											fill: 'currentColor',
+											fontSize: 22,
+											fontWeight: 700,
+										}),
+									],
+								}),
+							],
+							color: {
+								domain: ['Complete', 'Remaining'],
+								range: ['var(--chart-1)', 'var(--muted)'],
+							},
+							theme: HLM_CHART_THEME,
+						},
+						{ tooltip: hlmChartTooltip() },
+					),
+					'Project completion',
+					'Radial gauge showing 72 percent completion.',
+				),
+			},
+		],
+	},
+] as const;

--- a/apps/app/src/app/pages/(charts)/charts.page.spec.ts
+++ b/apps/app/src/app/pages/(charts)/charts.page.spec.ts
@@ -1,0 +1,78 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { createChartScene } from '@tanstack/charts';
+import { vitest } from 'vitest';
+import { chartSections } from './charts.examples';
+import ChartsPage from './charts.page';
+
+describe('ChartsPage', () => {
+	beforeEach(async () => {
+		vitest.stubGlobal(
+			'IntersectionObserver',
+			class {
+				public readonly observe = vitest.fn();
+				public readonly unobserve = vitest.fn();
+				public readonly disconnect = vitest.fn();
+			},
+		);
+
+		await TestBed.configureTestingModule({
+			imports: [ChartsPage],
+			providers: [provideRouter([{ path: 'charts', component: ChartsPage }])],
+		}).compileComponents();
+	});
+
+	afterEach(() => vitest.unstubAllGlobals());
+
+	it('links to the Chart documentation and source on GitHub', () => {
+		const fixture = TestBed.createComponent(ChartsPage);
+		fixture.detectChanges();
+
+		const documentationLink = fixture.nativeElement.querySelector('a[href="/components/chart"]') as HTMLAnchorElement;
+		const githubLink = fixture.nativeElement.querySelector(
+			'a[href="https://github.com/spartan-ng/spartan/blob/main/apps/app/src/app/pages/(charts)/charts.examples.ts"]',
+		) as HTMLAnchorElement;
+
+		expect(documentationLink.textContent?.trim()).toBe('Chart documentation');
+		expect(githubLink.textContent?.trim()).toBe('Open in');
+		expect(githubLink.target).toBe('_blank');
+	});
+
+	it('renders only the four examples for the selected chart type', async () => {
+		const fixture = TestBed.createComponent(ChartsPage);
+		fixture.detectChanges();
+
+		const chartTypeLinks = fixture.nativeElement.querySelectorAll(
+			'[aria-label="Chart types"] a',
+		) as NodeListOf<HTMLAnchorElement>;
+
+		expect(chartSections.every(({ examples }) => examples.length === 4)).toBe(true);
+		expect(fixture.nativeElement.querySelector('[data-chart-section] h2').textContent.trim()).toBe('Area Charts');
+		expect(fixture.nativeElement.querySelectorAll('[data-chart-section] article')).toHaveLength(4);
+		expect(Array.from(chartTypeLinks, (link) => link.getAttribute('href'))).toEqual([
+			'/charts#area-charts',
+			'/charts#bar-charts',
+			'/charts#line-charts',
+			'/charts#pie-charts',
+			'/charts#radial-charts',
+		]);
+		expect(chartTypeLinks[0].dataset['state']).toBe('active');
+
+		await TestBed.inject(Router).navigateByUrl('/charts#bar-charts');
+		fixture.detectChanges();
+
+		expect(fixture.nativeElement.querySelector('[data-chart-section] h2').textContent.trim()).toBe('Bar Charts');
+		expect(fixture.nativeElement.querySelectorAll('[data-chart-section] article')).toHaveLength(4);
+		expect(fixture.nativeElement.querySelector('[data-chart-section]').id).toBe('bar-charts');
+	});
+
+	it('builds a renderable scene for all twenty chart definitions', () => {
+		for (const section of chartSections) {
+			for (const example of section.examples) {
+				const scene = createChartScene(example.options.definition, { width: 640, height: 360 });
+
+				expect(scene.nodes.length, example.title).toBeGreaterThan(0);
+			}
+		}
+	});
+});

--- a/apps/app/src/app/pages/(charts)/charts.page.ts
+++ b/apps/app/src/app/pages/(charts)/charts.page.ts
@@ -1,0 +1,105 @@
+import type { RouteMeta } from '@analogjs/router';
+import { Component, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideGithub } from '@ng-icons/lucide';
+import { HlmButton } from '@spartan-ng/helm/button';
+import { HlmChartImports } from '@spartan-ng/helm/chart';
+import { HlmTabsImports } from '@spartan-ng/helm/tabs';
+import { metaWith } from '../../shared/meta/meta.util';
+import { chartSections } from './charts.examples';
+
+const chartCard =
+	'bg-card text-card-foreground scroll-mt-24 overflow-hidden rounded-xl border shadow-sm [&_tanstack-chart]:mx-auto';
+
+export const routeMeta: RouteMeta = {
+	meta: metaWith(
+		'spartan/ui - Charts',
+		'A collection of accessible Angular charts built with TanStack Charts and themed with spartan/ui.',
+	),
+	data: { breadcrumb: 'Charts' },
+	title: 'spartan/ui - Charts',
+};
+
+@Component({
+	selector: 'spartan-charts',
+	imports: [RouterLink, HlmButton, HlmTabsImports, HlmChartImports, NgIcon],
+	providers: [provideIcons({ lucideGithub })],
+	template: `
+		<section class="container flex flex-col items-center gap-4 py-12 text-center md:py-20">
+			<h1
+				class="text-primary leading-tighter max-w-4xl text-4xl font-semibold tracking-tight text-balance lg:leading-[1.1] xl:text-5xl xl:tracking-tighter"
+			>
+				Beautiful Charts for Angular
+			</h1>
+			<p class="text-foreground max-w-2xl text-base text-balance sm:text-lg">
+				Ready-to-use chart patterns powered by TanStack Charts and styled with spartan/ui theme tokens.
+			</p>
+			<div class="flex flex-wrap justify-center gap-2 pt-2">
+				<a hlmBtn size="sm" routerLink="/components/chart">Chart documentation</a>
+				<a hlmBtn size="sm" variant="outline" routerLink="/charts" fragment="chart-gallery">Browse charts</a>
+			</div>
+		</section>
+
+		<section id="chart-gallery" class="container-wrapper scroll-mt-20 px-6 pb-16">
+			<hlm-tabs [tab]="_activeChart()" class="mb-6 w-full">
+				<hlm-tabs-list
+					aria-label="Chart types"
+					class="bg-background dark:[&>a]:bg-background [&>a]:text-muted-foreground [&>a]:data-[state=active]:text-primary [&>a]:hover:text-primary dark:[&>a]:data-[state=active]:bg-background [&>a]:cursor-pointer [&>a]:data-[state=active]:shadow-none dark:[&>a]:data-[state=active]:border-none"
+				>
+					<a hlmTabsTrigger="area-charts" routerLink="/charts" fragment="area-charts">Area</a>
+					<a hlmTabsTrigger="bar-charts" routerLink="/charts" fragment="bar-charts">Bar</a>
+					<a hlmTabsTrigger="line-charts" routerLink="/charts" fragment="line-charts">Line</a>
+					<a hlmTabsTrigger="pie-charts" routerLink="/charts" fragment="pie-charts">Pie</a>
+					<a hlmTabsTrigger="radial-charts" routerLink="/charts" fragment="radial-charts">Radial</a>
+				</hlm-tabs-list>
+			</hlm-tabs>
+
+			@let section = _activeSection();
+			<section [id]="section.id" data-chart-section class="scroll-mt-24 space-y-5">
+				<div class="flex items-start justify-between gap-4">
+					<div>
+						<h2 class="text-2xl font-semibold tracking-tight">{{ section.label }} Charts</h2>
+						<p class="text-muted-foreground mt-1 text-sm">{{ section.description }}</p>
+					</div>
+					<a
+						hlmBtn
+						size="sm"
+						href="https://github.com/spartan-ng/spartan/blob/main/apps/app/src/app/pages/(charts)/charts.examples.ts"
+						target="_blank"
+						rel="noreferrer"
+					>
+						Open in
+						<ng-icon name="lucideGithub" />
+					</a>
+				</div>
+
+				<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+					@for (example of section.examples; track example.title) {
+						<article class="${chartCard}">
+							<header class="border-b p-4">
+								<h3 class="text-sm font-semibold">{{ example.title }}</h3>
+								<p class="text-muted-foreground mt-1 text-xs">{{ example.description }}</p>
+							</header>
+							<div class="p-2">
+								@defer (on viewport) {
+									<tanstack-chart hlmChart [options]="$any(example.options)" />
+								} @placeholder {
+									<div class="aspect-video w-full" aria-hidden="true"></div>
+								}
+							</div>
+						</article>
+					}
+				</div>
+			</section>
+		</section>
+	`,
+})
+export default class ChartsPage {
+	private readonly _fragment = toSignal(inject(ActivatedRoute).fragment);
+	protected readonly _activeSection = computed(
+		() => chartSections.find(({ id }) => id === this._fragment()) ?? chartSections[0],
+	);
+	protected readonly _activeChart = computed(() => this._activeSection().id);
+}

--- a/apps/app/src/app/shared/components/navigation-items.ts
+++ b/apps/app/src/app/shared/components/navigation-items.ts
@@ -17,6 +17,7 @@ export const pageNavs: Link[] = [
 	{ label: 'Components', url: '/components' },
 	{ label: 'Blocks', url: '/blocks' },
 	{ label: 'Colors', url: '/colors' },
+	{ label: 'Charts', url: '/charts', new: true },
 	{ label: 'Stack', url: '/stack' },
 ];
 

--- a/apps/app/src/app/shared/header/header.ts
+++ b/apps/app/src/app/shared/header/header.ts
@@ -73,6 +73,7 @@ import { HeaderMobileNav } from './header-mobile-nav';
 					<a spartanNavLink="/components">Components</a>
 					<a spartanNavLink="/blocks">Blocks</a>
 					<a spartanNavLink="/colors">Colors</a>
+					<a spartanNavLink="/charts">Charts</a>
 					<a spartanNavLink="/stack">Stack</a>
 				</div>
 

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -95,6 +95,7 @@ export default defineConfig(({ command, mode }) => {
 						const staticRoutes = [
 							'/',
 							'/colors',
+							'/charts',
 
 							'/documentation/introduction',
 							'/documentation/changelog',


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #1697. This PR intentionally contains only the gallery changes and remains a draft until the Chart primitive is merged.

## PR Checklist

- [x] The commit message follows the contribution guidelines
- [x] Tests for the feature have been added
- [x] Docs/examples have been added

## PR Type

- [x] Feature
- [x] Documentation content changes

## Which package are you modifying?

- [x] repo/docs app

## What is the current behavior?

The docs site has component-level Chart documentation but no dedicated gallery for comparing common chart patterns.

## What is the new behavior?

- Adds `/charts` with 20 examples: four each for area, bar, line, pie, and radial charts.
- Renders only the selected chart category and keeps it linkable through the URL fragment.
- Uses a responsive four-card desktop grid and deferred viewport rendering.
- Adds the Charts entry to desktop/mobile navigation and static prerendering.
- Adds an `Open in GitHub` action matching the Blocks gallery pattern.

## Validation

Validated together with prerequisite #1697:

- `pnpm nx test app --run` — 16 tests passed, including the gallery tests
- `NODE_OPTIONS='--no-experimental-webstorage --max-old-space-size=8192' pnpm nx build app` — passed, including `/charts` prerendering

## Does this PR introduce a breaking change?

- [x] No
