### PR TITLE
fix(popover): anchor to the opposite edge when content does not fit

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/popover/popover.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/popover/popover.cy.ts
@@ -95,3 +95,74 @@ describe('popover--default', () => {
 		});
 	});
 });
+
+describe('popover--near-viewport-edge', () => {
+	/** Reading geometry before the opening animation ends is off by a pixel. */
+	const settled = () =>
+		cy
+			.get('hlm-popover-content')
+			.should('be.visible')
+			.then(($content) => cy.wrap(Promise.all($content[0].getAnimations().map((a: Animation) => a.finished))));
+
+	const geometry = () =>
+		cy.get('#edge-trigger').then(($trigger) => {
+			const trigger = $trigger[0].getBoundingClientRect();
+			return cy.get('hlm-popover-content').then(($content) => {
+				const content = $content[0].getBoundingClientRect();
+				return { trigger, content, offsetY: Math.round(content.top - trigger.top) };
+			});
+		});
+
+	/**
+	 * Asserts on both boxes from a single retried query, so repositioning is awaited rather
+	 * than slept through.
+	 */
+	const expectGeometry = (assert: (boxes: { trigger: DOMRect; content: DOMRect }) => void) =>
+		cy.get('hlm-popover-content').should(($content) =>
+			assert({
+				trigger: Cypress.$('#edge-trigger')[0].getBoundingClientRect(),
+				content: $content[0].getBoundingClientRect(),
+			}),
+		);
+
+	/**
+	 * Cypress scrolls by assigning `scrollTop`, which never reaches the listener
+	 * `ScrollDispatcher` installs, so the reposition strategy would not run. Dispatching the
+	 * event explicitly is what makes this a scroll as far as the overlay is concerned.
+	 */
+	const scrollTo = (y: number) => {
+		cy.scrollTo(0, y);
+		cy.document().then((doc) => doc.dispatchEvent(new Event('scroll')));
+	};
+
+	beforeEach(() => {
+		cy.visit('/iframe.html?id=popover--near-viewport-edge');
+		cy.get('#edge-trigger').click();
+		settled();
+	});
+
+	it('keeps content at its own width rather than squeezing it into the space left', () => {
+		cy.window().then((win) => {
+			geometry().then(({ trigger, content }) => {
+				// Without push the overlay is confined to the gap between the trigger and the
+				// viewport edge, which collapses 288px of content down to about 68px.
+				expect(content.width).to.be.greaterThan(win.innerWidth - trigger.left);
+				expect(content.right).to.be.at.most(win.innerWidth);
+				expect(content.left).to.be.at.least(0);
+			});
+		});
+	});
+
+	it('follows a trigger that scrolls out of view instead of holding itself against the edge', () => {
+		scrollTo(400);
+		scrollTo(900);
+		scrollTo(1400);
+
+		expectGeometry(({ trigger, content }) => {
+			expect(trigger.top, 'the trigger should have scrolled above the viewport').to.be.lessThan(0);
+			// This is the drift #955 removed: an overlay pushed back on every reposition stays
+			// against the top edge while its trigger keeps travelling away from it.
+			expect(content.top).to.be.lessThan(0);
+		});
+	});
+});

--- a/apps/ui-storybook/stories/popover.stories.ts
+++ b/apps/ui-storybook/stories/popover.stories.ts
@@ -87,3 +87,28 @@ export const Default: Story = {
     `,
 	}),
 };
+
+/**
+ * Trigger pinned to the right edge with content wider than itself, inside a page tall
+ * enough to scroll. Covers both positioning cases: the overlay has to be shifted back
+ * into the viewport when it opens, and it has to keep following its trigger afterwards.
+ */
+export const NearViewportEdge: Story = {
+	args: {
+		align: 'start',
+		sideOffset: 4,
+	},
+	render: ({ ...args }) => ({
+		props: { ...args },
+		template: `
+    <hlm-popover ${argsToTemplate(args)}>
+      <div class='flex justify-end py-[900px]'>
+        <button id='edge-trigger' variant='outline' hlmPopoverTrigger hlmBtn>Edge</button>
+      </div>
+      <hlm-popover-content class='w-80' *hlmPopoverPortal='let ctx'>
+        <p id='edge-content' class='text-sm'>Content wider than its trigger.</p>
+      </hlm-popover-content>
+    </hlm-popover>
+    `,
+	}),
+};

--- a/libs/brain/popover/src/lib/brn-popover.ts
+++ b/libs/brain/popover/src/lib/brn-popover.ts
@@ -38,29 +38,39 @@ export class BrnPopover extends BrnOverlay {
 		const align = this.align();
 		const sideOffset = this.sideOffset();
 		const offsetX = this.offsetX();
-		return [
+
+		const positionsFor = (alignment: BrnPopoverAlign): ConnectedPosition[] => [
 			{
-				originX: align,
+				originX: alignment,
 				originY: 'bottom',
-				overlayX: align,
+				overlayX: alignment,
 				overlayY: 'top',
 				offsetX,
 				offsetY: sideOffset,
 			},
 			{
-				originX: align,
+				originX: alignment,
 				originY: 'top',
-				overlayX: align,
+				overlayX: alignment,
 				overlayY: 'bottom',
 				offsetX,
 				offsetY: -sideOffset,
 			},
 		];
+
+		// Anchoring to the opposite edge is what keeps content wider than its trigger inside
+		// the viewport. Without these, every candidate shares one align axis, the CDK finds
+		// none that fits, and it confines the overlay to the gap that is left — which reads as
+		// content squeezed to a fraction of its width rather than as content moved.
+		const opposite = align === 'start' ? 'end' : align === 'end' ? 'start' : null;
+		return opposite ? [...positionsFor(align), ...positionsFor(opposite)] : positionsFor(align);
 	}
 
 	protected override getPositionStrategy() {
 		const attachTo = this.getAttachTo();
 		if (!attachTo) return super.getPositionStrategy();
+		// Push stays off, as #955 established: recomputing it on every scroll is what pinned
+		// overlays to the viewport in #943. Falling back to another anchor needs no push.
 		return this._positionBuilder.flexibleConnectedTo(attachTo).withPositions(this.getAttachPositions()).withPush(false);
 	}
 }


### PR DESCRIPTION
`BrnPopover` builds both of its attach positions from the same `align` value, so `originX` and `overlayX` never vary. When the trigger sits close to a viewport edge, no candidate fits and the CDK falls back to confining the overlay to the gap that is left beside the trigger. Content declaring `w-72` then renders at roughly 68px. It is not clipped, it is squeezed, which is why it reads as unusable rather than cut off. Closes #1283.

Adding the mirrored pair of positions gives the CDK a candidate that does fit: the overlay anchors to the opposite edge of its trigger instead of being compressed into what is left. `align: 'center'` is unchanged, having no opposite edge to fall back to.

Push stays disabled. Re-enabling it is the obvious fix and it is the wrong one: #955 turned it off to resolve #943, where the push amount was recalculated on every reposition and held overlays against the viewport while their trigger scrolled away. Measured on the story below, a trigger scrolled 288px above the viewport leaves the overlay pinned at `y=4` with push on, against `y=-252` without it. A fallback anchor needs no push, so that behaviour is untouched.

The story pins a trigger to the right edge, with content wider than the space beside it, on a page tall enough to scroll past it. The first spec fails on `main` (68px against the 88px of room it should exceed). The second fails if push is enabled instead of this change, which is what keeps the reasoning above from being quietly undone later. The four existing popover specs pass in all three states.

One note on the specs: they dispatch the scroll event explicitly. Cypress scrolls by assigning `scrollTop`, which never reaches the listener `ScrollDispatcher` installs, so the reposition strategy would otherwise not run at all and both specs would pass without measuring anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Popovers near viewport edges now reposition more reliably to remain visible.
  - Popover content preserves its width instead of being unnecessarily squeezed.
  - Popovers continue following their trigger as it scrolls in and out of view.
- **Tests**
  - Added coverage for edge positioning, scrolling behavior, animations, and content sizing.
- **Documentation**
  - Added a Storybook example demonstrating popover behavior near a viewport edge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->