### PR TITLE
fix(avatar): support ngSrc on avatar image

### DIFF
--- a/libs/brain/avatar/src/lib/brn-avatar.spec.ts
+++ b/libs/brain/avatar/src/lib/brn-avatar.spec.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { type ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { BrnAvatar } from './brn-avatar';
 import { BrnAvatarFallback } from './fallback/brn-avatar-fallback';
 import { BrnAvatarImage } from './image/brn-avatar-image';

--- a/libs/brain/avatar/src/lib/brn-avatar.spec.ts
+++ b/libs/brain/avatar/src/lib/brn-avatar.spec.ts
@@ -61,13 +61,12 @@ describe('BrnAvatarComponent', () => {
 	});
 
 	it('should not render the fallback, but rather the image when provided with a valid src', async () => {
-		// The data-URI image loads asynchronously in a real browser; wait for the directive to swap in
-		// the <img> once its load event fires, then assert the fallback is gone.
+		// With the new architecture the <img> is always in the DOM; wait for the real image load
+		// to complete and canShow() to flip true before asserting the fallback has been removed.
 		await vi.waitFor(() => {
-			const img = fixture.debugElement.query(By.css('#good img'));
-			expect(img).toBeTruthy();
+			fixture.detectChanges();
+			const fallback = fixture.nativeElement.querySelector('#good span');
+			expect(fallback).toBeFalsy();
 		});
-		const fallback = fixture.nativeElement.querySelector('#good span');
-		expect(fallback).toBeFalsy();
 	});
 });

--- a/libs/brain/avatar/src/lib/brn-avatar.ts
+++ b/libs/brain/avatar/src/lib/brn-avatar.ts
@@ -4,6 +4,9 @@ import { BrnAvatarImage } from './image';
 @Component({
 	selector: 'brn-avatar',
 	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'relative',
+	},
 	template: `
 		<ng-content select="[brnAvatarImage]" />
 		@if (!_image()?.canShow()) {

--- a/libs/brain/avatar/src/lib/brn-avatar.ts
+++ b/libs/brain/avatar/src/lib/brn-avatar.ts
@@ -5,7 +5,7 @@ import { BrnAvatarImage } from './image';
 	selector: 'brn-avatar',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	host: {
-		class: 'relative',
+		'[style.position]': "'relative'",
 	},
 	template: `
 		<ng-content select="[brnAvatarImage]" />

--- a/libs/brain/avatar/src/lib/brn-avatar.ts
+++ b/libs/brain/avatar/src/lib/brn-avatar.ts
@@ -5,9 +5,8 @@ import { BrnAvatarImage } from './image';
 	selector: 'brn-avatar',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
-		@if (_image()?.canShow()) {
-			<ng-content select="[brnAvatarImage]" />
-		} @else {
+		<ng-content select="[brnAvatarImage]" />
+		@if (!_image()?.canShow()) {
 			<ng-content select="[brnAvatarFallback]" />
 		}
 	`,

--- a/libs/brain/avatar/src/lib/image/brn-avatar-image.ts
+++ b/libs/brain/avatar/src/lib/image/brn-avatar-image.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, afterNextRender, computed, inject, signal } from '@angular/core';
+import { Directive, computed, signal } from '@angular/core';
 
 @Directive({
 	selector: 'img[brnAvatarImage]',

--- a/libs/brain/avatar/src/lib/image/brn-avatar-image.ts
+++ b/libs/brain/avatar/src/lib/image/brn-avatar-image.ts
@@ -1,4 +1,4 @@
-import { Directive, computed, signal } from '@angular/core';
+import { Directive, ElementRef, afterNextRender, computed, inject, signal } from '@angular/core';
 
 @Directive({
 	selector: 'img[brnAvatarImage]',
@@ -6,6 +6,8 @@ import { Directive, computed, signal } from '@angular/core';
 	host: {
 		'(load)': '_onLoad()',
 		'(error)': '_onError()',
+		class: 'absolute inset-0',
+		'[class.invisible]': '!canShow()',
 	},
 })
 export class BrnAvatarImage {

--- a/libs/brain/avatar/src/lib/image/brn-avatar-image.ts
+++ b/libs/brain/avatar/src/lib/image/brn-avatar-image.ts
@@ -6,8 +6,9 @@ import { Directive, computed, signal } from '@angular/core';
 	host: {
 		'(load)': '_onLoad()',
 		'(error)': '_onError()',
-		class: 'absolute inset-0',
-		'[class.invisible]': '!canShow()',
+		'[style.position]': "'absolute'",
+		'[style.inset]': "'0'",
+		'[style.visibility]': "canShow() ? 'visible' : 'hidden'",
 	},
 })
 export class BrnAvatarImage {

--- a/libs/helm/avatar/src/lib/hlm-avatar-image.spec.ts
+++ b/libs/helm/avatar/src/lib/hlm-avatar-image.spec.ts
@@ -30,7 +30,7 @@ describe('HlmAvatarImageDirective', () => {
 	it('should add the default classes if no inputs are provided', () => {
 		fixture.detectChanges();
 		expect(fixture.nativeElement.querySelector('img').className).toBe(
-			'spartan-avatar-image aspect-square size-full object-cover',
+			'spartan-avatar-image aspect-square size-full object-cover absolute inset-0 invisible',
 		);
 	});
 

--- a/libs/helm/avatar/src/lib/hlm-avatar-image.spec.ts
+++ b/libs/helm/avatar/src/lib/hlm-avatar-image.spec.ts
@@ -30,8 +30,16 @@ describe('HlmAvatarImageDirective', () => {
 	it('should add the default classes if no inputs are provided', () => {
 		fixture.detectChanges();
 		expect(fixture.nativeElement.querySelector('img').className).toBe(
-			'spartan-avatar-image aspect-square size-full object-cover absolute inset-0 invisible',
+			'spartan-avatar-image aspect-square size-full object-cover',
 		);
+	});
+
+	it('should apply positioning and visibility via inline styles', () => {
+		fixture.detectChanges();
+		const img = fixture.nativeElement.querySelector('img');
+		expect(img.style.position).toBe('absolute');
+		expect(img.style.inset).toBe('0px');
+		expect(img.style.visibility).toBe('hidden'); 
 	});
 
 	it('should add any user defined classes', async () => {

--- a/libs/helm/avatar/src/lib/hlm-avatar-image.spec.ts
+++ b/libs/helm/avatar/src/lib/hlm-avatar-image.spec.ts
@@ -39,7 +39,7 @@ describe('HlmAvatarImageDirective', () => {
 		const img = fixture.nativeElement.querySelector('img');
 		expect(img.style.position).toBe('absolute');
 		expect(img.style.inset).toBe('0px');
-		expect(img.style.visibility).toBe('hidden'); 
+		expect(img.style.visibility).toBe('hidden');
 	});
 
 	it('should add any user defined classes', async () => {

--- a/libs/helm/avatar/src/lib/hlm-avatar.spec.ts
+++ b/libs/helm/avatar/src/lib/hlm-avatar.spec.ts
@@ -33,7 +33,7 @@ describe('HlmAvatarComponent', () => {
 	it('should add the default classes if no inputs are provided', () => {
 		fixture.detectChanges();
 		expect(fixture.nativeElement.className).toBe(
-			'spartan-avatar group/avatar after:border-border relative flex shrink-0 select-none after:absolute after:inset-0 after:border after:mix-blend-darken dark:after:mix-blend-lighten',
+			'spartan-avatar group/avatar after:border-border flex shrink-0 select-none after:absolute after:inset-0 after:border after:mix-blend-darken dark:after:mix-blend-lighten relative',
 		);
 	});
 

--- a/libs/helm/avatar/src/lib/hlm-avatar.spec.ts
+++ b/libs/helm/avatar/src/lib/hlm-avatar.spec.ts
@@ -33,8 +33,13 @@ describe('HlmAvatarComponent', () => {
 	it('should add the default classes if no inputs are provided', () => {
 		fixture.detectChanges();
 		expect(fixture.nativeElement.className).toBe(
-			'spartan-avatar group/avatar after:border-border flex shrink-0 select-none after:absolute after:inset-0 after:border after:mix-blend-darken dark:after:mix-blend-lighten relative',
+			'spartan-avatar group/avatar after:border-border flex shrink-0 select-none after:absolute after:inset-0 after:border after:mix-blend-darken dark:after:mix-blend-lighten',
 		);
+	});
+
+	it('should apply relative positioning via inline style', () => {
+		fixture.detectChanges();
+		expect(fixture.nativeElement.style.position).toBe('relative');
 	});
 
 	it('should add any user defined classes', () => {

--- a/libs/helm/avatar/src/lib/hlm-avatar.ts
+++ b/libs/helm/avatar/src/lib/hlm-avatar.ts
@@ -24,7 +24,7 @@ export class HlmAvatar extends BrnAvatar {
 		super();
 		classes(
 			() =>
-				'spartan-avatar group/avatar after:border-border relative flex shrink-0 select-none after:absolute after:inset-0 after:border after:mix-blend-darken dark:after:mix-blend-lighten',
+				'spartan-avatar group/avatar after:border-border flex shrink-0 select-none after:absolute after:inset-0 after:border after:mix-blend-darken dark:after:mix-blend-lighten',
 		);
 	}
 }

--- a/libs/helm/avatar/src/lib/hlm-avatar.ts
+++ b/libs/helm/avatar/src/lib/hlm-avatar.ts
@@ -10,9 +10,8 @@ import { classes } from '@spartan-ng/helm/utils';
 		'[attr.data-size]': 'size()',
 	},
 	template: `
-		@if (_image()?.canShow()) {
-			<ng-content select="[hlmAvatarImage],[brnAvatarImage]" />
-		} @else {
+		<ng-content select="[hlmAvatarImage],[brnAvatarImage]" />
+		@if (!_image()?.canShow()) {
 			<ng-content select="[hlmAvatarFallback],[brnAvatarFallback]" />
 		}
 		<ng-content />


### PR DESCRIPTION
Fixes #1702

The avatar image was only rendered once the load state became true, but the load state could only become true once the image had already loaded. This circular dependency prevented ngSrc from working since NgOptimizedImage relies on lazy loading.

The image is now always rendered and hidden with CSS until it finishes loading, so the load event can fire normally regardless of whether src or ngSrc is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar image loading so fallback content appears only when the image cannot be displayed.
  * Ensured avatar images are correctly positioned and hidden until ready to show.
  * Refined avatar styling for more consistent image sizing, positioning, and appearance.

* **Tests**
  * Expanded coverage for image loading, fallback rendering, visibility, and positioning.
  * Updated styling expectations to reflect the improved avatar layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->