### PR TITLE
ci: replace wagoid action with inline commitlint, stagger format-and-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,25 +26,35 @@ jobs:
     permissions:
       actions: read
       contents: read
-      # Required by wagoid/commitlint-github-action
       pull-requests: read
     steps:
       - uses: actions/checkout@v6
         with:
-          # Required by wagoid/commitlint-github-action
           fetch-depth: 0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
       - name: Install Node
         uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      # Run commitlint locally instead of via wagoid/commitlint-github-action to avoid
+      # downloading an external action archive, which was a source of 429/503 CI failures.
       - name: Lint commit messages
-        uses: wagoid/commitlint-github-action@v5
-        with:
-          failOnWarnings: true
-          helpURL: https://github.com/goetzrobin/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pnpm commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+          else
+            pnpm commitlint --from ${{ github.event.before }} --to ${{ github.event.after }} --verbose
+          fi
 
   format-and-lint:
     if: ${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    # Staggered after commitlint so the nrwl/nx-set-shas archive download in this job does not
+    # hit GitHub's codeload endpoint at the exact same moment as the build/unit/e2e jobs.
+    needs: [commitlint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem
CI was failing repeatedly on push with 429 (Too Many Requests) and 503 errors when GitHub Actions tried to download external action archives at job startup:
- `nrwl/nx-set-shas` — hit by all 4 jobs simultaneously at `t=0`
- `wagoid/commitlint-github-action` — 503 on codeload CDN

## Changes
1. **Replaced `wagoid/commitlint-github-action`** with an inline `pnpm commitlint` run. `@commitlint/cli` is already a dev dependency so no new packages needed. Eliminates one external archive download entirely.

2. **Added `needs: [commitlint]` to `format-and-lint`** to stagger the start of `nrwl/nx-set-shas` downloads. Previously all 4 jobs hit the codeload endpoint simultaneously; now they start in two waves (build/unit/e2e together, then format-and-lint ~1-2 min later), reducing the concurrent burst from 4 to 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated commit message validation in the CI workflow.
  * Added dependency installation and caching to support consistent checks.
  * Updated job sequencing so formatting and lint checks run after commit validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->