### PR TITLE
fix: forward the scroll strategy input through the helm overlay wrappers

### DIFF
--- a/apps/ui-storybook-e2e/src/integration/popover/popover.cy.ts
+++ b/apps/ui-storybook-e2e/src/integration/popover/popover.cy.ts
@@ -166,3 +166,20 @@ describe('popover--near-viewport-edge', () => {
 		});
 	});
 });
+
+describe('popover--close-on-scroll', () => {
+	beforeEach(() => {
+		cy.visit('/iframe.html?id=popover--close-on-scroll');
+		cy.get('#closing-trigger').click();
+		cy.get('hlm-popover-content').should('be.visible');
+	});
+
+	it('honours the scroll strategy the wrapper now forwards', () => {
+		// Cypress scrolls by assigning `scrollTop`, which never reaches the listener
+		// `ScrollDispatcher` installs, so the strategy has to be told explicitly.
+		cy.scrollTo(0, 400);
+		cy.document().then((doc) => doc.dispatchEvent(new Event('scroll')));
+
+		cy.get('hlm-popover-content').should('not.exist');
+	});
+});

--- a/apps/ui-storybook/stories/popover.stories.ts
+++ b/apps/ui-storybook/stories/popover.stories.ts
@@ -112,3 +112,25 @@ export const NearViewportEdge: Story = {
     `,
 	}),
 };
+
+/**
+ * `scrollStrategy` is declared by `BrnOverlay` but was not forwarded by the helm wrapper,
+ * so an app could not opt out of the default reposition behaviour. Overlays that follow a
+ * trigger scrolling under a sticky header end up drawn over it, and closing on scroll is
+ * the usual way out.
+ */
+export const CloseOnScroll: Story = {
+	render: ({ ...args }) => ({
+		props: { ...args },
+		template: `
+    <hlm-popover ${argsToTemplate(args)} scrollStrategy='close'>
+      <div class='flex justify-center py-[900px]'>
+        <button id='closing-trigger' variant='outline' hlmPopoverTrigger hlmBtn>Closes on scroll</button>
+      </div>
+      <hlm-popover-content class='w-80' *hlmPopoverPortal='let ctx'>
+        <p id='closing-content' class='text-sm'>Dismissed as soon as the page scrolls.</p>
+      </hlm-popover-content>
+    </hlm-popover>
+    `,
+	}),
+};

--- a/libs/helm/autocomplete/src/lib/hlm-autocomplete.ts
+++ b/libs/helm/autocomplete/src/lib/hlm-autocomplete.ts
@@ -20,7 +20,7 @@ import { classes } from '@spartan-ng/helm/utils';
 		},
 		{
 			directive: BrnPopover,
-			inputs: ['align', 'closeOnOutsidePointerEvents', 'sideOffset', 'state', 'offsetX'],
+			inputs: ['align', 'closeOnOutsidePointerEvents', 'sideOffset', 'state', 'offsetX', 'scrollStrategy'],
 			outputs: ['stateChanged', 'closed'],
 		},
 	],

--- a/libs/helm/combobox/src/lib/hlm-combobox.ts
+++ b/libs/helm/combobox/src/lib/hlm-combobox.ts
@@ -29,7 +29,7 @@ import { classes } from '@spartan-ng/helm/utils';
 		},
 		{
 			directive: BrnPopover,
-			inputs: ['align', 'closeOnOutsidePointerEvents', 'sideOffset', 'state', 'offsetX'],
+			inputs: ['align', 'closeOnOutsidePointerEvents', 'sideOffset', 'state', 'offsetX', 'scrollStrategy'],
 			outputs: ['stateChanged', 'closed'],
 		},
 	],

--- a/libs/helm/popover/src/lib/hlm-popover.ts
+++ b/libs/helm/popover/src/lib/hlm-popover.ts
@@ -6,7 +6,16 @@ import { BrnPopover } from '@spartan-ng/brain/popover';
 	hostDirectives: [
 		{
 			directive: BrnPopover,
-			inputs: ['align', 'attachTo', 'autoFocus', 'closeOnOutsidePointerEvents', 'offsetX', 'sideOffset', 'state'],
+			inputs: [
+				'align',
+				'attachTo',
+				'autoFocus',
+				'closeOnOutsidePointerEvents',
+				'offsetX',
+				'scrollStrategy',
+				'sideOffset',
+				'state',
+			],
 			outputs: ['stateChanged', 'closed'],
 		},
 	],

--- a/libs/helm/select/src/lib/hlm-select-multiple.ts
+++ b/libs/helm/select/src/lib/hlm-select-multiple.ts
@@ -20,7 +20,7 @@ import { classes } from '@spartan-ng/helm/utils';
 		},
 		{
 			directive: BrnPopover,
-			inputs: ['align', 'closeOnOutsidePointerEvents', 'sideOffset', 'state', 'offsetX'],
+			inputs: ['align', 'closeOnOutsidePointerEvents', 'sideOffset', 'state', 'offsetX', 'scrollStrategy'],
 			outputs: ['stateChanged', 'closed'],
 		},
 	],

--- a/libs/helm/select/src/lib/hlm-select.ts
+++ b/libs/helm/select/src/lib/hlm-select.ts
@@ -20,7 +20,7 @@ import { classes } from '@spartan-ng/helm/utils';
 		},
 		{
 			directive: BrnPopover,
-			inputs: ['align', 'closeOnOutsidePointerEvents', 'sideOffset', 'state', 'offsetX'],
+			inputs: ['align', 'closeOnOutsidePointerEvents', 'sideOffset', 'state', 'offsetX', 'scrollStrategy'],
 			outputs: ['stateChanged', 'closed'],
 		},
 	],

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -951,6 +951,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "required": false,
             "type": "number",
           },
+          {
+            "name": "scrollStrategy",
+            "required": false,
+            "type": "BrnOverlayOptions['scrollStrategy'] | 'close' | 'reposition' | null",
+          },
         ],
         "models": [],
         "outputs": [
@@ -2810,6 +2815,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "name": "offsetX",
             "required": false,
             "type": "number",
+          },
+          {
+            "name": "scrollStrategy",
+            "required": false,
+            "type": "BrnOverlayOptions['scrollStrategy'] | 'close' | 'reposition' | null",
           },
         ],
         "models": [],
@@ -6563,6 +6573,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "type": "number",
           },
           {
+            "name": "scrollStrategy",
+            "required": false,
+            "type": "BrnOverlayOptions['scrollStrategy'] | 'close' | 'reposition' | null",
+          },
+          {
             "name": "sideOffset",
             "required": false,
             "type": "number",
@@ -7324,6 +7339,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "required": false,
             "type": "number",
           },
+          {
+            "name": "scrollStrategy",
+            "required": false,
+            "type": "BrnOverlayOptions['scrollStrategy'] | 'close' | 'reposition' | null",
+          },
         ],
         "models": [],
         "outputs": [
@@ -7440,6 +7460,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "name": "offsetX",
             "required": false,
             "type": "number",
+          },
+          {
+            "name": "scrollStrategy",
+            "required": false,
+            "type": "BrnOverlayOptions['scrollStrategy'] | 'close' | 'reposition' | null",
           },
         ],
         "models": [],


### PR DESCRIPTION
`BrnOverlay` declares a `scrollStrategy` input, and `getScrollStrategy()` already accepts `'close'`, `'reposition'`, or a strategy object. None of that is reachable from an app. `hlm-select`, `hlm-select-multiple`, `hlm-combobox`, `hlm-autocomplete` and `hlm-popover` all leave it out of their host directive inputs, so the reposition default is the only behaviour available.

Where this bites is a trigger inside a scrollable container, under a sticky header. Once the container is registered with `cdkScrollable`, the overlay follows its trigger correctly, and then keeps following it under the header, drawn on top of it, because the CDK measures the whole viewport and knows nothing about app chrome. Measured against a 56px header, the overlay reached `y=-445` while still painting over it. Closing on scroll, or repositioning with `autoClose`, would both fix that, and neither was reachable.

This forwards the existing input on the five wrappers. Nothing changes by default: with no binding the input still falls back to the strategy the tokens provide, which is `reposition` for popover-based overlays.

The new story binds `scrollStrategy='close'`, and the spec scrolls the page while the overlay is open. Without the forwarding the binding is silently ignored (Storybook compiles templates JIT, so there is no build error), the overlay stays put, and the spec fails on the content still being in the DOM. Against `main` that is 6 passing and 1 failing; with the change, 7 passing.

One note on the spec: it dispatches the scroll event explicitly. Cypress scrolls by assigning `scrollTop`, which never reaches the listener `ScrollDispatcher` installs, so without that the strategy would never run and the spec would pass without measuring anything.
