### PR TITLE
fix(combobox): dont reopen popover when item is selected via enter

### DIFF
--- a/libs/brain/combobox/src/lib/brn-combobox-input.spec.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-input.spec.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
-import { render, screen } from '@testing-library/angular';
+import { fireEvent, render, screen } from '@testing-library/angular';
 import { BrnComboboxContent } from './brn-combobox-content';
 import { BrnComboboxInput } from './brn-combobox-input';
 import { BrnComboboxBaseToken } from './brn-combobox.token';
@@ -55,6 +55,33 @@ const renderInputInPopup = async (combobox: ReturnType<typeof comboboxStub>) =>
 			{ provide: BrnComboboxContent, useValue: {} },
 		],
 	});
+
+function keyboardComboboxStub(options: { expanded?: boolean } = {}) {
+	const value = signal<SimpleValue>(null);
+	const isExpanded = signal(options.expanded ?? false);
+	const selectActiveItem = vi.fn(() => {
+		if (isExpanded()) {
+			isExpanded.set(false);
+		}
+	});
+	return {
+		value,
+		search: signal(''),
+		isExpanded,
+		disabledState: signal(false),
+		itemToString: signal(undefined),
+		mode: signal('combobox'),
+		listId: signal<string | undefined>(undefined),
+		hasValue: computed(() => value() !== undefined && value() !== null && value() !== ''),
+		controlState: signal(null),
+		keyManager: { onKeydown: vi.fn() },
+		selectActiveItem,
+		close: vi.fn(() => isExpanded.set(false)),
+		open: vi.fn(() => isExpanded.set(true)),
+		resetValue: vi.fn(),
+		registerComboboxInput: vi.fn(),
+	};
+}
 
 describe('BrnComboboxInput', () => {
 	describe('value display', () => {
@@ -171,6 +198,31 @@ describe('BrnComboboxInput', () => {
 		it('does not set data-dirty even when the control is dirty', async () => {
 			await renderInputInPopup(comboboxStub(null, { dirty: true }));
 			expect(screen.getByLabelText('Test')).not.toHaveAttribute('data-dirty');
+		});
+	});
+
+	describe('keyboard selection', () => {
+		it('does not re-open the popover on the Enter that selects and closes an item', async () => {
+			const combobox = keyboardComboboxStub({ expanded: true });
+			await renderInputInPopup(combobox);
+			const input = screen.getByLabelText('Test');
+
+			fireEvent.keyDown(input, { key: 'Enter' });
+
+			expect(combobox.selectActiveItem).toHaveBeenCalledTimes(1);
+			expect(combobox.open).not.toHaveBeenCalled();
+			expect(combobox.isExpanded()).toBe(false);
+		});
+
+		it('opens a collapsed combobox on Enter', async () => {
+			const combobox = keyboardComboboxStub({ expanded: false });
+			await renderInputInPopup(combobox);
+			const input = screen.getByLabelText('Test');
+
+			fireEvent.keyDown(input, { key: 'Enter' });
+
+			expect(combobox.open).toHaveBeenCalledTimes(1);
+			expect(combobox.isExpanded()).toBe(true);
 		});
 	});
 });

--- a/libs/brain/combobox/src/lib/brn-combobox-input.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-input.ts
@@ -104,6 +104,12 @@ export class BrnComboboxInput<T> {
 
 	/** Listen for keydown events */
 	protected onKeyDown(event: KeyboardEvent): void {
+		// Snapshot the expansion state BEFORE selecting, since `selectActiveItem()` may close the
+		// popover synchronously (closeOnSelect) and flip `_isExpanded()` to false mid-handler.
+		// Branching on this snapshot keeps "Enter opens a closed combobox" without re-opening the
+		// popover on the very Enter that just selected and closed it.
+		const wasExpanded = this._isExpanded();
+
 		if (event.key === 'Enter') {
 			// prevent form submission if inside a form
 			event.preventDefault();
@@ -111,7 +117,7 @@ export class BrnComboboxInput<T> {
 			this._combobox.selectActiveItem();
 		}
 
-		if (this._isExpanded()) {
+		if (wasExpanded) {
 			if (event.key === 'Tab') {
 				// In popup mode the input lives inside a CDK overlay which is appended to <body>.
 				// Without preventDefault the browser has nowhere to Tab to inside the overlay and

--- a/libs/brain/combobox/src/lib/brn-combobox-input.ts
+++ b/libs/brain/combobox/src/lib/brn-combobox-input.ts
@@ -104,10 +104,7 @@ export class BrnComboboxInput<T> {
 
 	/** Listen for keydown events */
 	protected onKeyDown(event: KeyboardEvent): void {
-		// Snapshot the expansion state BEFORE selecting, since `selectActiveItem()` may close the
-		// popover synchronously (closeOnSelect) and flip `_isExpanded()` to false mid-handler.
-		// Branching on this snapshot keeps "Enter opens a closed combobox" without re-opening the
-		// popover on the very Enter that just selected and closed it.
+		// Snapshot the expansion state before handling selection to avoid re-opening the popover if it is closed on select
 		const wasExpanded = this._isExpanded();
 
 		if (event.key === 'Enter') {

--- a/libs/helm/combobox/src/lib/hlm-combobox-multiple.ts
+++ b/libs/helm/combobox/src/lib/hlm-combobox-multiple.ts
@@ -17,6 +17,7 @@ import { classes } from '@spartan-ng/helm/utils';
 			directive: BrnComboboxMultiple,
 			inputs: [
 				'autoHighlight',
+				'closeOnSelect',
 				'disabled',
 				'filter',
 				'search',

--- a/libs/helm/combobox/src/lib/hlm-combobox.ts
+++ b/libs/helm/combobox/src/lib/hlm-combobox.ts
@@ -17,6 +17,7 @@ import { classes } from '@spartan-ng/helm/utils';
 			directive: BrnCombobox,
 			inputs: [
 				'autoHighlight',
+				'closeOnSelect',
 				'disabled',
 				'filter',
 				'search',

--- a/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
+++ b/libs/tools/src/executors/docs/generate-ui-docs/__snapshots__/executor.spec.ts.snap
@@ -2752,6 +2752,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
             "type": "boolean",
           },
           {
+            "name": "closeOnSelect",
+            "required": false,
+            "type": "boolean",
+          },
+          {
             "name": "disabled",
             "required": false,
             "type": "boolean",
@@ -3000,6 +3005,11 @@ exports[`generate-ui-docs executor > produces stable output 1`] = `
         "inputs": [
           {
             "name": "autoHighlight",
+            "required": false,
+            "type": "boolean",
+          },
+          {
+            "name": "closeOnSelect",
             "required": false,
             "type": "boolean",
           },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] attachment
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] bubble
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [x] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] marker
- [ ] menubar
- [ ] message
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

With a Combobox that has `closeOnSelect` true (the default), clicking an item correctly closes the popover. However, pressing Enter on keyboard does not close the popover, or rather closes and immediately reopens.

Closes #1685 

## What is the new behavior?

A combobox with `closeOnSelect` true correctly closes the popover on Enter, while still opening via Enter if it was closed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The solution snapshots the expanded state at the moment Enter was pressed, and doesnt reopen the popover if it was open.

The original shadcn combobox correctly has the "new" behaviour: https://ui.shadcn.com/docs/components/base/combobox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Fixed keyboard behavior in comboboxes so pressing Enter on an expanded popup selects the active item and closes it without reopening.
- Pressing Enter on a collapsed combobox now opens it as expected.

## New Features

- Added support for configuring comboboxes to close automatically after selecting an option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->