### PR TITLE
fix(cli): pass false for angularCli when its missing

### DIFF
--- a/libs/cli/src/generators/ui/generator.spec.ts
+++ b/libs/cli/src/generators/ui/generator.spec.ts
@@ -1,0 +1,56 @@
+import type { Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { prompt } from 'enquirer';
+import { loadOrInitConfig } from '../../utils/config';
+import hlmUIGenerator from './generator';
+
+vi.mock('enquirer', () => ({
+	prompt: vi.fn(),
+}));
+vi.mock('../../utils/config', async (importOriginal) => {
+	const original = await importOriginal<typeof import('../../utils/config')>();
+	return {
+		...original,
+		backfillStyleInComponentsJson: vi.fn().mockResolvedValue(undefined),
+		loadOrInitConfig: vi.fn().mockResolvedValue({
+			componentsPath: 'libs/ui',
+			buildable: true,
+			generateAs: 'library',
+			importAlias: '@spartan-ng/helm',
+			style: 'vega',
+		}),
+	};
+});
+vi.mock('./add-dependent-primitive', () => ({
+	addDependentPrimitives: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./libs/button/generator', () => ({
+	generator: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('ui generator', () => {
+	let tree: Tree;
+
+	beforeEach(() => {
+		tree = createTreeWithEmptyWorkspace();
+		vi.mocked(prompt).mockResolvedValue({ primitives: ['button'] } as never);
+	});
+
+	it('loads config as an Nx workspace when not run via the Angular CLI', async () => {
+		await hlmUIGenerator(tree, {});
+
+		expect(loadOrInitConfig).toHaveBeenCalledWith(tree, {
+			componentsPath: undefined,
+			angularCli: false,
+		});
+	});
+
+	it('loads config as an Angular CLI workspace when the compat wrapper passes angularCli', async () => {
+		await hlmUIGenerator(tree, { angularCli: true });
+
+		expect(loadOrInitConfig).toHaveBeenCalledWith(tree, {
+			componentsPath: undefined,
+			angularCli: true,
+		});
+	});
+});

--- a/libs/cli/src/generators/ui/generator.ts
+++ b/libs/cli/src/generators/ui/generator.ts
@@ -18,7 +18,7 @@ export default async function hlmUIGenerator(tree: Tree, options: HlmUIGenerator
 	await backfillStyleInComponentsJson(tree);
 	const config = await loadOrInitConfig(tree, {
 		componentsPath: options.directory,
-		angularCli: options.angularCli ?? true,
+		angularCli: options.angularCli ?? false,
 	});
 
 	const availablePrimitives: PrimitiveDefinitions = await import('./supported-ui-libraries.json').then(


### PR DESCRIPTION
* nx passes angularCli as undefined but was set to true - always skipping nx related flags

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] attachment
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] bubble
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] marker
- [ ] menubar
- [ ] message
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [x] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Bug introduced with https://github.com/spartan-ng/spartan/commit/b22abbef8 which treats Cli calls in an NX workspace for the ui command as an Angular project. Closes #1708

## What is the new behavior?

Set `angularCli` flag to `false`, when its undefined. This is the case for NX. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI generator configuration handling for standard Nx workspaces.
  * Preserved Angular CLI compatibility mode when explicitly enabled.

* **Tests**
  * Added coverage to verify configuration behavior across standard Nx and Angular CLI-compatible workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->