### PR TITLE
fix(calendar): make default year dropdown range relative for start an…

### DIFF
--- a/apps/app/src/app/pages/(components)/components/(calendar)/calendar.page.ts
+++ b/apps/app/src/app/pages/(components)/components/(calendar)/calendar.page.ts
@@ -151,6 +151,23 @@ export const routeMeta: RouteMeta = {
 
 			<h3 id="examples__month_and_year_selection" spartanH4>Month and Year Selector</h3>
 
+			<p class="${hlmP} mb-6">
+				Caption layouts with a year dropdown use the
+				<code class="${hlmCode}">years</code>
+				function from the calendar's i18n configuration. By default, the dropdown includes an inclusive range from 100
+				years in the past through 10 years in the future. Override
+				<code class="${hlmCode}">years</code>
+				with
+				<code class="${hlmCode}">provideBrnCalendarI18n</code>
+				if you need a different range.
+			</p>
+
+			<p class="${hlmP} mb-6">
+				See the
+				<a href="/components/calendar#i18n" class="${link}">Internationalization</a>
+				section for configuration examples.
+			</p>
+
 			<spartan-tabs firstTab="Preview" secondTab="Code">
 				<div spartanCodePreview firstTab>
 					<spartan-calendar-year-and-month-dropdown />

--- a/libs/brain/calendar/src/lib/i18n/calendar-i18n.spec.ts
+++ b/libs/brain/calendar/src/lib/i18n/calendar-i18n.spec.ts
@@ -1,0 +1,17 @@
+import { BrnCalendarI18nService } from './calendar-i18n';
+
+describe('BrnCalendarI18nService', () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	describe('defaultCalendarI18n', () => {
+		it('should set years to 100 years in the past and 10 years in the future relative to the current date', () => {
+			vi.spyOn(Date.prototype, 'getFullYear').mockReturnValueOnce(2025).mockReturnValueOnce(2026);
+
+			const years = new BrnCalendarI18nService().config().years();
+
+			expect(years).toHaveLength(111);
+			expect(years[0]).toBe(1925);
+			expect(years.at(-1)).toBe(2035);
+		});
+	});
+});

--- a/libs/brain/calendar/src/lib/i18n/calendar-i18n.ts
+++ b/libs/brain/calendar/src/lib/i18n/calendar-i18n.ts
@@ -52,8 +52,12 @@ const defaultCalendarI18n: BrnCalendarI18n = {
 		return weekdays[index];
 	},
 	months: () => ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-	years: (startYear = 1925, endYear = new Date().getFullYear() + 1) =>
-		Array.from({ length: endYear - startYear + 1 }, (_, i) => startYear + i),
+	years: (startYear?: number, endYear?: number) => {
+		const currentYear = new Date().getFullYear();
+		const firstYear = startYear ?? currentYear - 100;
+		const lastYear = endYear ?? currentYear + 10;
+		return Array.from({ length: lastYear - firstYear + 1 }, (_, i) => firstYear + i);
+	},
 	formatHeader: (month: number, year: number) => {
 		return new Date(year, month).toLocaleDateString(undefined, {
 			month: 'long',


### PR DESCRIPTION
This change is about th Calendars default year dropdown options.
It currently has a range of 100 years in the past and only one year in the future.

There are many usecases, where a the calendar might be used for future years.
I therefore suggest a default 10 year range in the future. This still ensures the current date is always visible even if the user scrolls to the bottom. 

Also both start end end dates for the range should be relative to the current date, eliminating the hardcoded 1926 start date.

I think ideally the calendars year range should not come from the i18n config and instead should be controlled via optional inputs with the current default values. It is not intuitive to cahnge these via i18n config.
But I do not yet have the confidence to make such a change... so this is a quickfix that should be a non breaking change. (Keep in mind that this range is not related to min/max dates necessarily, also the calendar allows to traverse years not in the range still by stepping through the months, so currently this range is only for the dropdown options)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

### Primitives

- [X] calendar


### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

The Calendar uses a I18n config to determine the year dropdown captios select options. It currentently set the first selectable date to a hardcoded "1926" value. The last selectable value is only one year in the future relative to the current date. 
This can potentially cause two problems:
1. The hardcoded start date will become outdated overtime. At some point it might need to be changed.
2. The Calendar can net (easily) be used to view or select dates futher in the future.
(a workaround is possible ass the calendar does not actually prevent these years from being selected. Once could still click through all the months etc.. but this is no good ux)

Closes #

## What is the new behavior?

The new i18n config now sets both start end end date relatively to the current date. It also changes the future range to a more generous 10 year span. This allows better default usage for any date picker fields or calendar views that are not the typical birthday in the past usecase. 

Also the calendars documentation page now has a little paragraph explaining this behavior and how to override it using the two i18n config override methods.

## Does this PR introduce a breaking change?

- [ ] Yes
- [C] No

## Other information
This my first ever contribution attempt to a open source project... I wanst sure if I should treat this as bug, feature or refactoring... let me know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The calendar year selector now includes a dynamic range from 100 years in the past through 10 years in the future.
  * The available year range can be customized through calendar internationalization settings.

* **Documentation**
  * Added guidance for configuring the year range.
  * Added a link to internationalization configuration examples.

* **Tests**
  * Added coverage for the default year range and its boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->