### PR TITLE
fix: quantize scroll-fade reveal to stop per-frame mask repaints

### DIFF
--- a/apps/app/src/app/pages/(documentation)/documentation/(ui)/(utilities)/scroll-fade.page.ts
+++ b/apps/app/src/app/pages/(documentation)/documentation/(ui)/(utilities)/scroll-fade.page.ts
@@ -227,6 +227,22 @@ export const routeMeta: RouteMeta = {
 				<spartan-code secondTab [code]="_sizeCode" />
 			</spartan-tabs>
 
+			<spartan-section-sub-heading id="reveal-steps">Reveal Granularity</spartan-section-sub-heading>
+			<p class="${hlmP}">
+				The fade depth is driven by a scroll-linked mask, and a mask has no compositor path — every distinct depth costs
+				a repaint of the scroll container. The reveal is therefore quantised into a fixed number of steps rather than
+				tracking the scroll continuously, which keeps scrolling to a single presented frame per tick. Without it, a
+				<code class="${hlmCode}">backdrop-filter</code>
+				drawn over the same area can drop its blur for a frame.
+			</p>
+			<p class="${hlmP}">
+				Set
+				<code class="${hlmCode}">--scroll-fade-steps</code>
+				to trade fidelity against paint cost — for example
+				<code class="${hlmCode}">[--scroll-fade-steps:4]</code>
+				for half the repaints, or a higher value for a finer reveal.
+			</p>
+
 			<spartan-section-sub-heading id="disabling">Disabling the Fade</spartan-section-sub-heading>
 			<p class="${hlmP}">
 				Use

--- a/libs/brain/hlm-tailwind-preset.css
+++ b/libs/brain/hlm-tailwind-preset.css
@@ -146,7 +146,19 @@
 	}
 }
 
-/* scroll-fade */
+/*
+ * scroll-fade
+ *
+ * The reveal animates a registered custom property that feeds the mask gradient. There is no
+ * compositor path for an animated mask, so every frame inside the reveal range regenerates the
+ * mask image and repaints the scroll container on the main thread — roughly one extra presented
+ * frame per scroll tick. That is enough to make a backdrop-filter drawn over the same area drop
+ * its blur for a frame.
+ *
+ * --scroll-fade-steps quantises the reveal, so the mask is regenerated a fixed number of times
+ * across the range rather than once per frame. The default is fine enough to read as smooth;
+ * lower it to trade fidelity for paint cost, raise it for the reverse.
+ */
 @property --scroll-fade-t {
 	syntax: '<length-percentage>';
 	inherits: false;
@@ -226,8 +238,8 @@
 
 	@supports (animation-timeline: scroll()) {
 		animation:
-			scroll-fade-reveal-t 1ms ease-in-out,
-			scroll-fade-reveal-b 1ms ease-in-out;
+			scroll-fade-reveal-t 1ms steps(var(--scroll-fade-steps, 8)),
+			scroll-fade-reveal-b 1ms steps(var(--scroll-fade-steps, 8));
 		animation-timeline: scroll(self y), scroll(self y);
 		animation-range:
 			0 var(--scroll-fade-reveal, calc(var(--spacing) * 24)),
@@ -273,8 +285,8 @@
 
 	@supports (animation-timeline: scroll()) {
 		animation:
-			scroll-fade-reveal-s 1ms ease-in-out,
-			scroll-fade-reveal-e 1ms ease-in-out;
+			scroll-fade-reveal-s 1ms steps(var(--scroll-fade-steps, 8)),
+			scroll-fade-reveal-e 1ms steps(var(--scroll-fade-steps, 8));
 		animation-timeline: scroll(self inline), scroll(self inline);
 		animation-range:
 			0 var(--scroll-fade-reveal, calc(var(--spacing) * 24)),
@@ -299,7 +311,7 @@
 	mask-repeat: no-repeat;
 
 	@supports (animation-timeline: scroll()) {
-		animation: scroll-fade-reveal-t 1ms ease-in-out;
+		animation: scroll-fade-reveal-t 1ms steps(var(--scroll-fade-steps, 8));
 		animation-timeline: scroll(self y);
 		animation-range: 0 var(--scroll-fade-reveal, calc(var(--spacing) * 24));
 		animation-fill-mode: both;
@@ -321,7 +333,7 @@
 	mask-repeat: no-repeat;
 
 	@supports (animation-timeline: scroll()) {
-		animation: scroll-fade-reveal-b 1ms ease-in-out;
+		animation: scroll-fade-reveal-b 1ms steps(var(--scroll-fade-steps, 8));
 		animation-timeline: scroll(self y);
 		animation-range: calc(100% - var(--scroll-fade-reveal, calc(var(--spacing) * 24))) 100%;
 		animation-fill-mode: both;
@@ -343,7 +355,7 @@
 	mask-repeat: no-repeat;
 
 	@supports (animation-timeline: scroll()) {
-		animation: scroll-fade-reveal-s 1ms ease-in-out;
+		animation: scroll-fade-reveal-s 1ms steps(var(--scroll-fade-steps, 8));
 		animation-timeline: scroll(self x);
 		animation-range: 0 var(--scroll-fade-reveal, calc(var(--spacing) * 24));
 		animation-fill-mode: both;
@@ -365,7 +377,7 @@
 	mask-repeat: no-repeat;
 
 	@supports (animation-timeline: scroll()) {
-		animation: scroll-fade-reveal-e 1ms ease-in-out;
+		animation: scroll-fade-reveal-e 1ms steps(var(--scroll-fade-steps, 8));
 		animation-timeline: scroll(self x);
 		animation-range: calc(100% - var(--scroll-fade-reveal, calc(var(--spacing) * 24))) 100%;
 		animation-fill-mode: both;
@@ -390,7 +402,7 @@
 	mask-repeat: no-repeat;
 
 	@supports (animation-timeline: scroll()) {
-		animation: scroll-fade-reveal-s 1ms ease-in-out;
+		animation: scroll-fade-reveal-s 1ms steps(var(--scroll-fade-steps, 8));
 		animation-timeline: scroll(self inline);
 		animation-range: 0 var(--scroll-fade-reveal, calc(var(--spacing) * 24));
 		animation-fill-mode: both;
@@ -415,7 +427,7 @@
 	mask-repeat: no-repeat;
 
 	@supports (animation-timeline: scroll()) {
-		animation: scroll-fade-reveal-e 1ms ease-in-out;
+		animation: scroll-fade-reveal-e 1ms steps(var(--scroll-fade-steps, 8));
 		animation-timeline: scroll(self inline);
 		animation-range: calc(100% - var(--scroll-fade-reveal, calc(var(--spacing) * 24))) 100%;
 		animation-fill-mode: both;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our
      guidelines: https://github.com/spartan-ng/spartan/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

> The Tailwind preset ships as a raw CSS asset and has no test harness, so this is backed by the
> measurements in "Other information" rather than an automated test. Happy to add one if there is a
> pattern for it I have missed.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Which package are you modifying?

> `libs/brain/hlm-tailwind-preset.css` (the shared Tailwind preset) plus the Scroll Fade docs page.
> `helm/attachment` is an in-repo consumer via `scroll-fade-x`, but is not itself modified.

### Primitives

- [ ] accordion
- [ ] alert
- [ ] alert-dialog
- [ ] aspect-ratio
- [ ] attachment
- [ ] autocomplete
- [ ] avatar
- [ ] badge
- [ ] breadcrumb
- [ ] bubble
- [ ] button
- [ ] button-group
- [ ] calendar
- [ ] card
- [ ] carousel
- [ ] chart
- [ ] checkbox
- [ ] collapsible
- [ ] combobox
- [ ] command
- [ ] context-menu
- [ ] data-table
- [ ] date-picker
- [ ] dialog
- [ ] empty
- [ ] dropdown-menu
- [ ] field
- [ ] hover-card
- [ ] icon
- [ ] input
- [ ] input-group
- [ ] input-otp
- [ ] item
- [ ] kbd
- [ ] label
- [ ] marker
- [ ] menubar
- [ ] message
- [ ] native-select
- [ ] navigation-menu
- [ ] pagination
- [ ] popover
- [ ] progress
- [ ] questionnaire
- [ ] radio-group
- [ ] resizable
- [ ] scroll-area
- [ ] select
- [ ] separator
- [ ] sheet
- [ ] sidebar
- [ ] skeleton
- [ ] slider
- [ ] sonner
- [ ] spinner
- [ ] switch
- [ ] table
- [ ] tabs
- [ ] textarea
- [ ] toggle
- [ ] toggle-group
- [ ] tooltip
- [ ] typography

### Others

- [ ] trpc
- [ ] nx
- [ ] repo
- [ ] cli
- [ ] mcp

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

> I can reproduce it by putting `scroll-fade` in a `<ng-scrollbar>` container or a `<div>` container with `overflow-y-auto` when it is **in a dialog or sheet**, to activate the background blur mask. It happens when the `scroll-fade` is animating in it's initial stages (the first `~96px` and the last `~96px` when it fades out) However, recording this is difficult as the issue flashes for 1 frame, which is too fast to capture. 

https://console.blotch.app/

<img width="1220" height="655" alt="Screenshot 2026-09-08 at 10 55 11" src="https://github.com/user-attachments/assets/2dcaacb4-73d3-49ab-849d-1ca11ca22b14" />


`scroll-fade`, and every `scroll-fade-*` edge variant, reveals the fade by interpolating
`--scroll-fade-t` / `--scroll-fade-b`. Those are registered `@property` values of type
`<length-percentage>` that feed the `mask-image` gradient stops:

```css
animation:
	scroll-fade-reveal-t 1ms ease-in-out,
	scroll-fade-reveal-b 1ms ease-in-out;
animation-timeline: scroll(self y), scroll(self y);
```

Because they interpolate continuously, the mask image is regenerated on every frame while the
scroll position sits inside the reveal range. There is no compositor path for an animated mask, so
each of those frames is a main-thread repaint of the scroll container. Measured in Chromium, a
scroll inside the reveal range presents roughly **1.8 frames per scroll tick instead of 1.0**.

The visible symptom is that a `backdrop-filter` drawn over the same area drops its blur for a
frame. That is not a hypothetical pairing — all four shipped styles apply
`supports-backdrop-filter:backdrop-blur-xs` to `.spartan-alert-dialog-overlay`,
`.spartan-dialog-overlay`, `.spartan-drawer-overlay` and `.spartan-sheet-overlay`. Slowly scrolling
a `scroll-fade` container inside a sheet or dialog makes the overlay behind it flash unblurred,
showing the page underneath sharp for a single frame.

It only happens near the ends of the scroll range, since that is where the reveal animates, which
is why it reads as intermittent and hard to pin down.

Layer-promotion escape hatches on the scroll container do not help — the repaint is inherent to
animating a mask, not a missing compositing hint:

| applied to the scroll container     | frames presented per scroll tick |
| ----------------------------------- | -------------------------------- |
| baseline                            | 1.80                             |
| `will-change: mask-image`           | 1.80                             |
| `will-change: transform`            | 1.80                             |
| `contain: paint`                    | 1.80                             |
| `transform: translateZ(0)`          | 1.80                             |
| `isolation: isolate`                | 1.81                             |
| `backface-visibility: hidden`       | 1.80                             |
| mask kept, reveal animation removed | **1.01**                         |

## What is the new behavior?

The reveal is quantised with `steps()` rather than interpolated continuously, so the mask is
regenerated a fixed number of times across the reveal range instead of once per frame. The step
count is exposed as `--scroll-fade-steps` with a default of 8, applied to all eight animated
utilities: `scroll-fade`, `scroll-fade-x`, `scroll-fade-t`, `scroll-fade-b`, `scroll-fade-l`,
`scroll-fade-r`, `scroll-fade-s`, `scroll-fade-e`.

```css
animation:
	scroll-fade-reveal-t 1ms steps(var(--scroll-fade-steps, 8)),
	scroll-fade-reveal-b 1ms steps(var(--scroll-fade-steps, 8));
```

Consumers can trade fidelity against paint cost per container, e.g. `[--scroll-fade-steps:4]`.

Measured after the change, compiling the patched preset with Tailwind 4.1.17 and driving the
compiled output in a headed Chromium:

|                                 | frames presented per scroll tick |
| ------------------------------- | -------------------------------- |
| before                          | 1.81                             |
| after, default `steps(8)`       | **1.14**                         |
| after, `--scroll-fade-steps: 4` | 1.07                             |
| after, `--scroll-fade-steps: 1` | 1.02                             |

The fade still tracks the scroll position. Sampling fade depth at scrollTop 0 / 24 / 48 / 72 / 96
with the default gives 0 → 0.125 → 0.375 → 0.625 → 1.0 of full depth.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

No API or class-name changes, and `--scroll-fade-steps` is additive and optional.

One visual note, since this touches the shipped look rather than being a purely internal
optimisation: the reveal curve moves from `ease-in-out` to linear-quantised. At 25% through the
reveal range the old curve gave 0.129 of full fade depth against 0.125 now — effectively identical
— but at 75% it is 0.871 against 0.625, about 10px of gradient softness at the default fade depth.
On a soft mask edge, mid-scroll, I could not tell the two apart. If you would rather keep the exact
easing curve, the alternative is to bake `ease-in-out` into the keyframes as explicit stops and use
`steps(1)` per interval: same paint saving, identical curve, larger diff. Happy to switch if you
prefer that.


## Other information

**How the numbers were produced.** Headed Chromium on macOS with GPU compositing, frames counted
via CDP `Page.startScreencast` with `everyNthFrame: 1`. Each run scrolls 60 wheel ticks of 2px down
and 60 back up, staying inside the reveal range throughout, then divides frames presented by the
120 ticks. Both tables use the same harness. The second table drives the real preset compiled
through Tailwind rather than a hand-written approximation of it.

**Why quantising works.** `animation-timing-function` applies per keyframe interval. The reveal
keyframes are a single `from`/`to` interval, so `steps(n)` subdivides that one interval into n
discrete values. Chromium skips the repaint when the computed custom-property value is unchanged,
so the mask is rebuilt n times across the range instead of once per presented frame.

**In-repo consumer.** `hlm-attachment-group` uses `scroll-fade-x no-scrollbar`, so an attachment
group inside a dialog is subject to this interaction today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documentation for configuring Scroll Fade reveal granularity with the `--scroll-fade-steps` custom property.
  - Added guidance on balancing reveal smoothness and rendering performance.

- **Performance**
  - Scroll Fade animations now use configurable stepped reveals to reduce per-frame painting while preserving backdrop blur during scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->